### PR TITLE
Feature/filter training data

### DIFF
--- a/wcpredictor/__init__.py
+++ b/wcpredictor/__init__.py
@@ -3,7 +3,8 @@ from .src.data_loader import (
     get_teams_data,
     get_fixture_data,
     get_results_data,
-    get_fifa_rankings_data
+    get_fifa_rankings_data,
+    get_wcresults_data
 )
 from .src.tournament import Tournament, Group
 from .src.utils import (
@@ -11,5 +12,6 @@ from .src.utils import (
     get_and_train_model,
     predict_group_match,
     predict_knockout_match,
-    sort_teams_by
+    sort_teams_by,
+    get_difference_in_stages
 )

--- a/wcpredictor/data/results.csv
+++ b/wcpredictor/data/results.csv
@@ -40,14 +40,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1885-03-21,England,Scotland,1,1,British Championship,London,England,FALSE
 1885-03-23,Wales,Scotland,1,8,British Championship,Wrexham,Wales,FALSE
 1885-04-11,Northern Ireland,Wales,2,8,British Championship,Belfast,Ireland,FALSE
-1885-11-28,USA,Canada,0,1,Friendly,Newark,USA,FALSE
+1885-11-28,United States,Canada,0,1,Friendly,Newark,United States,FALSE
 1886-02-27,Wales,Northern Ireland,5,0,British Championship,Wrexham,Wales,FALSE
 1886-03-13,Northern Ireland,England,1,6,British Championship,Belfast,Ireland,FALSE
 1886-03-20,Northern Ireland,Scotland,2,7,British Championship,Belfast,Ireland,FALSE
 1886-03-27,Scotland,England,1,1,British Championship,Glasgow,Scotland,FALSE
 1886-03-29,Wales,England,1,3,British Championship,Wrexham,Wales,FALSE
 1886-04-10,Scotland,Wales,4,1,British Championship,Glasgow,Scotland,FALSE
-1886-11-25,USA,Canada,3,2,Friendly,Newark,USA,FALSE
+1886-11-25,United States,Canada,3,2,Friendly,Newark,United States,FALSE
 1887-02-05,England,Northern Ireland,7,0,British Championship,Sheffield,England,FALSE
 1887-02-19,Scotland,Northern Ireland,4,1,British Championship,Glasgow,Scotland,FALSE
 1887-02-26,England,Wales,4,0,British Championship,London,England,FALSE
@@ -449,8 +449,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1916-07-18,Uruguay,Brazil,0,1,Friendly,Montevideo,Uruguay,FALSE
 1916-08-15,Argentina,Uruguay,3,1,Copa Newton,Avellaneda,Argentina,FALSE
 1916-08-15,Uruguay,Argentina,1,2,Copa Lipton,Montevideo,Uruguay,FALSE
-1916-08-20,Sweden,USA,2,3,Friendly,Stockholm,Sweden,FALSE
-1916-09-03,Norway,USA,1,1,Friendly,Kristiania,Norway,FALSE
+1916-08-20,Sweden,United States,2,3,Friendly,Stockholm,Sweden,FALSE
+1916-09-03,Norway,United States,1,1,Friendly,Kristiania,Norway,FALSE
 1916-10-01,Argentina,Uruguay,7,2,Friendly,Avellaneda,Argentina,FALSE
 1916-10-01,Hungary,Austria,2,3,Friendly,Budapest,Hungary,FALSE
 1916-10-01,Norway,Sweden,0,0,Friendly,Kristiania,Norway,FALSE
@@ -808,7 +808,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1924-05-27,Egypt,Lithuania,10,0,Friendly,Vincennes,France,TRUE
 1924-06-04,France,Hungary,0,1,Friendly,Le Havre,France,FALSE
 1924-06-07,Australia,Canada,3,2,Friendly,Brisbane,Australia,FALSE
-1924-06-10,Poland,USA,2,3,Friendly,Warsaw,Poland,FALSE
+1924-06-10,Poland,United States,2,3,Friendly,Warsaw,Poland,FALSE
 1924-06-14,Australia,Canada,0,1,Friendly,Sydney,Australia,FALSE
 1924-06-15,Denmark,Sweden,2,3,Nordic Championship,Copenhagen,Denmark,FALSE
 1924-06-15,Norway,Germany,0,2,Friendly,Kristiania,Norway,FALSE
@@ -896,7 +896,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1925-06-21,Denmark,Norway,5,1,Nordic Championship,Copenhagen,Denmark,FALSE
 1925-06-21,Sweden,Germany,1,0,Friendly,Stockholm,Sweden,FALSE
 1925-06-26,Finland,Germany,3,5,Friendly,Helsinki,Finland,FALSE
-1925-06-27,Canada,USA,1,0,Friendly,Montréal,Canada,FALSE
+1925-06-27,Canada,United States,1,0,Friendly,Montréal,Canada,FALSE
 1925-06-28,Lithuania,Estonia,0,1,Friendly,Kaunas,Lithuania,FALSE
 1925-07-05,Estonia,Finland,2,0,Friendly,Tallinn,Estonia,FALSE
 1925-07-05,Sweden,Austria,2,4,Friendly,Stockholm,Sweden,FALSE
@@ -931,7 +931,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1925-11-04,Italy,Yugoslavia,2,1,Friendly,Padua,Italy,FALSE
 1925-11-08,Hungary,Italy,1,1,Friendly,Budapest,Hungary,FALSE
 1925-11-08,Switzerland,Austria,2,0,Friendly,Berne,Switzerland,FALSE
-1925-11-08,USA,Canada,6,1,Friendly,New York,USA,FALSE
+1925-11-08,United States,Canada,6,1,Friendly,New York,United States,FALSE
 1925-11-29,Argentina,Paraguay,2,0,Copa América,Buenos Aires,Argentina,FALSE
 1925-12-06,Brazil,Paraguay,5,2,Copa América,Buenos Aires,Argentina,TRUE
 1925-12-13,Argentina,Brazil,4,1,Copa América,Buenos Aires,Argentina,FALSE
@@ -1018,7 +1018,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1926-10-31,Netherlands,Germany,2,3,Friendly,Amsterdam,Netherlands,FALSE
 1926-11-01,Paraguay,Uruguay,1,6,Copa América,Santiago,Chile,TRUE
 1926-11-03,Chile,Paraguay,5,1,Copa América,Santiago,Chile,FALSE
-1926-11-06,USA,Canada,6,2,Friendly,New York,USA,FALSE
+1926-11-06,United States,Canada,6,2,Friendly,New York,United States,FALSE
 1926-11-07,Austria,Sweden,3,1,Friendly,Vienna,Austria,FALSE
 1926-11-14,Hungary,Sweden,3,1,Friendly,Budapest,Hungary,FALSE
 1926-11-20,Jamaica,Haiti,6,0,Friendly,Kingston,Jamaica,FALSE
@@ -1139,7 +1139,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1928-05-19,Belgium,England,1,3,Friendly,Antwerp,Belgium,FALSE
 1928-06-03,Finland,Norway,0,6,Friendly,Helsinki,Finland,FALSE
 1928-06-07,Sweden,Norway,6,1,Nordic Championship,Stockholm,Sweden,FALSE
-1928-06-10,Poland,USA,3,3,Friendly,Warsaw,Poland,FALSE
+1928-06-10,Poland,United States,3,3,Friendly,Warsaw,Poland,FALSE
 1928-06-14,Netherlands,Egypt,1,2,Friendly,Rotterdam,Netherlands,FALSE
 1928-06-17,Norway,Denmark,2,3,Nordic Championship,Oslo,Norway,FALSE
 1928-06-28,Luxembourg,Egypt,1,1,Friendly,Esch-sur-Alzette,Luxembourg,FALSE
@@ -1310,14 +1310,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1930-06-22,Italy,Spain,2,3,Friendly,Bologna,Italy,FALSE
 1930-06-27,Estonia,Latvia,1,1,Friendly,Tallinn,Estonia,FALSE
 1930-07-06,Sweden,Norway,6,3,Nordic Championship,Stockholm,Sweden,FALSE
-1930-07-13,Belgium,USA,0,3,FIFA World Cup,Montevideo,Uruguay,TRUE
+1930-07-13,Belgium,United States,0,3,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-13,France,Mexico,4,1,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-14,Brazil,Yugoslavia,1,2,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-14,Peru,Romania,1,3,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-15,Argentina,France,1,0,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-16,Chile,Mexico,3,0,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-17,Bolivia,Yugoslavia,0,4,FIFA World Cup,Montevideo,Uruguay,TRUE
-1930-07-17,Paraguay,USA,0,3,FIFA World Cup,Montevideo,Uruguay,TRUE
+1930-07-17,Paraguay,United States,0,3,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-18,Estonia,Sweden,1,5,Friendly,Tallinn,Estonia,FALSE
 1930-07-18,Uruguay,Peru,1,0,FIFA World Cup,Montevideo,Uruguay,FALSE
 1930-07-19,Argentina,Mexico,6,3,FIFA World Cup,Montevideo,Uruguay,TRUE
@@ -1327,7 +1327,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1930-07-21,Uruguay,Romania,4,0,FIFA World Cup,Montevideo,Uruguay,FALSE
 1930-07-22,Argentina,Chile,3,1,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-22,Latvia,Sweden,0,5,Friendly,Riga,Latvia,FALSE
-1930-07-26,Argentina,USA,6,1,FIFA World Cup,Montevideo,Uruguay,TRUE
+1930-07-26,Argentina,United States,6,1,FIFA World Cup,Montevideo,Uruguay,TRUE
 1930-07-27,Uruguay,Yugoslavia,6,1,FIFA World Cup,Montevideo,Uruguay,FALSE
 1930-07-30,Uruguay,Argentina,4,2,FIFA World Cup,Montevideo,Uruguay,FALSE
 1930-08-01,Brazil,France,3,2,Friendly,Rio de Janeiro,Brazil,FALSE
@@ -1337,7 +1337,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1930-08-10,Brazil,Yugoslavia,4,1,Friendly,Rio de Janeiro,Brazil,FALSE
 1930-08-15,Lithuania,Estonia,2,1,Baltic Cup,Kaunas,Lithuania,FALSE
 1930-08-16,Estonia,Latvia,2,3,Baltic Cup,Kaunas,Lithuania,TRUE
-1930-08-17,Brazil,USA,4,3,Friendly,Rio de Janeiro,Brazil,FALSE
+1930-08-17,Brazil,United States,4,3,Friendly,Rio de Janeiro,Brazil,FALSE
 1930-08-17,Lithuania,Latvia,3,3,Baltic Cup,Kaunas,Lithuania,FALSE
 1930-09-07,Denmark,Germany,6,3,Friendly,Copenhagen,Denmark,FALSE
 1930-09-13,Lithuania,Estonia,4,0,Friendly,Klaipėda,Lithuania,FALSE
@@ -1686,14 +1686,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1934-05-20,China PR,Japan,4,3,Friendly,Manila,Philippines,TRUE
 1934-05-21,Denmark,Poland,4,2,Friendly,Copenhagen,Denmark,FALSE
 1934-05-23,Sweden,Poland,4,2,Friendly,Stockholm,Sweden,FALSE
-1934-05-24,Mexico,USA,2,4,FIFA World Cup qualification,Rome,Italy,TRUE
+1934-05-24,Mexico,United States,2,4,FIFA World Cup qualification,Rome,Italy,TRUE
 1934-05-27,Argentina,Sweden,2,3,FIFA World Cup,Bologna,Italy,TRUE
 1934-05-27,Austria,France,3,2,FIFA World Cup,Turin,Italy,TRUE
 1934-05-27,Belgium,Germany,2,5,FIFA World Cup,Florence,Italy,TRUE
 1934-05-27,Brazil,Spain,1,3,FIFA World Cup,Genoa,Italy,TRUE
 1934-05-27,Czechoslovakia,Romania,2,1,FIFA World Cup,Trieste,Italy,TRUE
 1934-05-27,Egypt,Hungary,2,4,FIFA World Cup,Naples,Italy,TRUE
-1934-05-27,Italy,USA,7,1,FIFA World Cup,Rome,Italy,FALSE
+1934-05-27,Italy,United States,7,1,FIFA World Cup,Rome,Italy,FALSE
 1934-05-27,Netherlands,Switzerland,2,3,FIFA World Cup,Milan,Italy,TRUE
 1934-05-31,Austria,Hungary,2,1,FIFA World Cup,Bologna,Italy,TRUE
 1934-05-31,Czechoslovakia,Switzerland,3,2,FIFA World Cup,Turin,Italy,TRUE
@@ -1786,14 +1786,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1935-05-12,Hungary,Austria,6,3,Friendly,Budapest,Hungary,FALSE
 1935-05-18,Netherlands,England,0,1,Friendly,Amsterdam,Netherlands,FALSE
 1935-05-19,France,Hungary,2,0,Friendly,Colombes,France,FALSE
-1935-05-19,USA,Scotland,1,5,Friendly,New York,USA,FALSE
+1935-05-19,United States,Scotland,1,5,Friendly,New York,United States,FALSE
 1935-05-20,Suriname,Curaçao,0,1,Friendly,Paramaribo,Netherlands Guyana,FALSE
 1935-05-22,Suriname,Curaçao,4,1,Friendly,Paramaribo,Netherlands Guyana,FALSE
 1935-05-24,Suriname,Curaçao,2,1,Friendly,Paramaribo,Netherlands Guyana,FALSE
 1935-05-26,Germany,Czechoslovakia,2,1,Friendly,Dresden,Germany,FALSE
 1935-05-30,Belgium,Switzerland,2,2,Friendly,Brussels,Belgium,FALSE
 1935-05-30,Latvia,Lithuania,6,1,Friendly,Riga,Latvia,FALSE
-1935-06-09,USA,Scotland,1,4,Friendly,Newark,USA,FALSE
+1935-06-09,United States,Scotland,1,4,Friendly,Newark,United States,FALSE
 1935-06-12,Latvia,Estonia,1,1,Friendly,Riga,Latvia,FALSE
 1935-06-12,Sweden,Finland,2,2,Nordic Championship,Stockholm,Sweden,FALSE
 1935-06-16,Bulgaria,Greece,5,2,Balkan Cup,Sofia,Bulgaria,FALSE
@@ -2013,12 +2013,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1937-09-05,Lithuania,Estonia,0,4,Baltic Cup,Kaunas,Lithuania,FALSE
 1937-09-07,Estonia,Latvia,0,2,Baltic Cup,Kaunas,Lithuania,TRUE
 1937-09-12,Bulgaria,Poland,3,3,Friendly,Sofia,Bulgaria,FALSE
-1937-09-12,Mexico,USA,7,2,Friendly,Mexico City,Mexico,FALSE
+1937-09-12,Mexico,United States,7,2,Friendly,Mexico City,Mexico,FALSE
 1937-09-12,Poland,Denmark,3,1,Friendly,Warsaw,Poland,FALSE
 1937-09-19,Austria,Switzerland,4,3,International Cup,Vienna,Austria,FALSE
 1937-09-19,Hungary,Czechoslovakia,8,3,International Cup,Budapest,Hungary,FALSE
 1937-09-19,Latvia,Estonia,3,1,Friendly,Riga,Latvia,FALSE
-1937-09-19,Mexico,USA,7,3,Friendly,Mexico City,Mexico,FALSE
+1937-09-19,Mexico,United States,7,3,Friendly,Mexico City,Mexico,FALSE
 1937-09-19,Norway,Sweden,3,2,Nordic Championship,Oslo,Norway,FALSE
 1937-10-03,Czechoslovakia,Yugoslavia,5,4,Friendly,Prague,Czechoslovakia,FALSE
 1937-10-03,Sweden,Denmark,1,2,Nordic Championship,Solna,Sweden,FALSE
@@ -2716,11 +2716,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1947-07-05,New Zealand,South Africa,0,6,Friendly,Dunedin,New Zealand,FALSE
 1947-07-06,Bulgaria,Romania,2,3,Balkan Cup,Sofia,Bulgaria,FALSE
 1947-07-12,New Zealand,South Africa,3,8,Friendly,Wellington,New Zealand,FALSE
-1947-07-13,Mexico,USA,5,0,"NAFU Championship",Havana,Cuba,TRUE
+1947-07-13,Mexico,United States,5,0,"NAFU Championship",Havana,Cuba,TRUE
 1947-07-17,Cuba,Mexico,1,3,"NAFU Championship",Havana,Cuba,FALSE
 1947-07-19,New Zealand,South Africa,1,4,Friendly,Auckland,New Zealand,FALSE
 1947-07-19,Poland,Romania,1,2,Friendly,Warsaw,Poland,FALSE
-1947-07-20,Cuba,USA,5,2,"NAFU Championship",Havana,Cuba,FALSE
+1947-07-20,Cuba,United States,5,2,"NAFU Championship",Havana,Cuba,FALSE
 1947-07-24,Iceland,Norway,2,4,Friendly,Reykjavík,Iceland,FALSE
 1947-08-17,Hungary,Bulgaria,9,0,Balkan Cup,Budapest,Hungary,FALSE
 1947-08-20,Hungary,Albania,3,0,Balkan Cup,Budapest,Hungary,FALSE
@@ -2869,8 +2869,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1948-07-17,Mauritius,Madagascar,4,1,Friendly,Curepipe,Mauritius,FALSE
 1948-07-19,Mauritius,Réunion,5,1,Friendly,Curepipe,Mauritius,FALSE
 1948-08-02,Sweden,Austria,3,0,Friendly,London,England,TRUE
-1948-08-06,Norway,USA,11,0,Friendly,Oslo,Norway,FALSE
-1948-08-11,Northern Ireland,USA,5,0,Friendly,Belfast,Northern Ireland,FALSE
+1948-08-06,Norway,United States,11,0,Friendly,Oslo,Norway,FALSE
+1948-08-11,Northern Ireland,United States,5,0,Friendly,Belfast,Northern Ireland,FALSE
 1948-08-14,New Zealand,Australia,0,6,Friendly,Wellington,New Zealand,FALSE
 1948-08-25,Poland,Yugoslavia,0,1,Balkan Cup,Warsaw,Poland,FALSE
 1948-08-27,Zimbabwe,Zambia,4,0,Friendly,Salisbury,Southern Rhodesia,FALSE
@@ -2889,7 +2889,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1948-09-26,Denmark,England,0,0,Friendly,Copenhagen,Denmark,FALSE
 1948-09-26,French Guiana,Suriname,2,4,Friendly,Cayenne,French Guiana,FALSE
 1948-09-26,Latvia,Lithuania,0,1,Baltic Cup,Riga,Soviet Union,FALSE
-1948-09-26,USA,Israel,3,1,Friendly,East Rutherford,USA,FALSE
+1948-09-26,United States,Israel,3,1,Friendly,East Rutherford,United States,FALSE
 1948-09-27,Estonia,Lithuania,1,2,Baltic Cup,Riga,Soviet Union,TRUE
 1948-09-27,Latvia,Estonia,1,1,Baltic Cup,Riga,Soviet Union,FALSE
 1948-10-01,Suriname,Guyana,3,0,Friendly,Cayenne,French Guiana,TRUE
@@ -3008,7 +3008,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1949-06-19,Norway,Yugoslavia,1,3,Friendly,Oslo,Norway,FALSE
 1949-06-19,Poland,Denmark,1,2,Friendly,Warsaw,Poland,FALSE
 1949-06-19,Sweden,Hungary,2,2,Friendly,Solna,Sweden,FALSE
-1949-06-19,USA,Scotland,0,4,Friendly,New York,USA,FALSE
+1949-06-19,United States,Scotland,0,4,Friendly,New York,United States,FALSE
 1949-06-26,Switzerland,Luxembourg,5,2,FIFA World Cup qualification,Zürich,Switzerland,FALSE
 1949-07-01,Martinique,Trinidad and Tobago,2,0,Friendly,Fort-de-France,Martinique,FALSE
 1949-07-08,Finland,Norway,1,1,Nordic Championship,Helsinki,Finland,FALSE
@@ -3022,17 +3022,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1949-08-19,Suriname,French Guiana,2,1,Friendly,Paramaribo,Suriname,FALSE
 1949-08-21,Yugoslavia,Israel,6,0,FIFA World Cup qualification,Belgrade,Yugoslavia,FALSE
 1949-09-04,Czechoslovakia,Bulgaria,1,3,Friendly,Prague,Czechoslovakia,FALSE
-1949-09-04,Mexico,USA,6,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+1949-09-04,Mexico,United States,6,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1949-09-08,Republic of Ireland,Finland,3,0,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
 1949-09-11,Denmark,Finland,0,2,Nordic Championship,Copenhagen,Denmark,FALSE
 1949-09-11,Mexico,Cuba,2,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1949-09-11,Norway,Denmark,0,2,Nordic Championship,Oslo,Norway,FALSE
-1949-09-14,Cuba,USA,1,1,FIFA World Cup qualification,Mexico City,Mexico,TRUE
+1949-09-14,Cuba,United States,1,1,FIFA World Cup qualification,Mexico City,Mexico,TRUE
 1949-09-18,Israel,Yugoslavia,2,5,FIFA World Cup qualification,Tel Aviv,Israel,FALSE
 1949-09-18,Luxembourg,Switzerland,2,3,FIFA World Cup qualification,Luxembourg,Luxembourg,FALSE
-1949-09-18,Mexico,USA,6,2,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+1949-09-18,Mexico,United States,6,2,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1949-09-21,England,Republic of Ireland,0,2,Friendly,Liverpool,England,FALSE
-1949-09-21,USA,Cuba,5,2,FIFA World Cup qualification,Mexico City,Mexico,TRUE
+1949-09-21,United States,Cuba,5,2,FIFA World Cup qualification,Mexico City,Mexico,TRUE
 1949-09-25,Austria,Czechoslovakia,3,1,International Cup,Vienna,Austria,FALSE
 1949-09-25,Mexico,Cuba,3,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1949-10-01,Northern Ireland,Scotland,2,8,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
@@ -3132,17 +3132,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1950-06-25,Chile,England,0,2,FIFA World Cup,Rio de Janeiro,Brazil,TRUE
 1950-06-25,Denmark,Norway,1,4,Friendly,Aarhus,Denmark,FALSE
 1950-06-25,Italy,Sweden,2,3,FIFA World Cup,São Paulo,Brazil,TRUE
-1950-06-25,Spain,USA,3,1,FIFA World Cup,Curitiba,Brazil,TRUE
+1950-06-25,Spain,United States,3,1,FIFA World Cup,Curitiba,Brazil,TRUE
 1950-06-25,Switzerland,Yugoslavia,0,3,FIFA World Cup,Belo Horizonte,Brazil,TRUE
 1950-06-28,Brazil,Switzerland,2,2,FIFA World Cup,São Paulo,Brazil,FALSE
 1950-06-28,Mexico,Yugoslavia,1,4,FIFA World Cup,Porto Alegre,Brazil,TRUE
 1950-06-29,Chile,Spain,0,2,FIFA World Cup,Rio de Janeiro,Brazil,TRUE
-1950-06-29,England,USA,0,1,FIFA World Cup,Belo Horizonte,Brazil,TRUE
+1950-06-29,England,United States,0,1,FIFA World Cup,Belo Horizonte,Brazil,TRUE
 1950-06-29,Paraguay,Sweden,2,2,FIFA World Cup,Curitiba,Brazil,TRUE
 1950-07-01,Brazil,Yugoslavia,2,0,FIFA World Cup,Rio de Janeiro,Brazil,FALSE
 1950-07-01,South Africa,Australia,2,1,Friendly,Johannesburg,South Africa,FALSE
 1950-07-02,Bolivia,Uruguay,0,8,FIFA World Cup,Belo Horizonte,Brazil,TRUE
-1950-07-02,Chile,USA,5,2,FIFA World Cup,Recife,Brazil,TRUE
+1950-07-02,Chile,United States,5,2,FIFA World Cup,Recife,Brazil,TRUE
 1950-07-02,England,Spain,0,1,FIFA World Cup,Rio de Janeiro,Brazil,TRUE
 1950-07-02,Italy,Paraguay,2,0,FIFA World Cup,São Paulo,Brazil,TRUE
 1950-07-02,Mexico,Switzerland,1,2,FIFA World Cup,Porto Alegre,Brazil,TRUE
@@ -3340,7 +3340,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1952-04-20,France,Portugal,3,0,Friendly,Colombes,France,FALSE
 1952-04-20,Luxembourg,Germany,0,3,Friendly,Luxembourg,Luxembourg,FALSE
 1952-04-20,Mexico,Peru,0,3,Pan American Championship,Santiago,Chile,TRUE
-1952-04-30,Scotland,USA,6,0,Friendly,Glasgow,Scotland,FALSE
+1952-04-30,Scotland,United States,6,0,Friendly,Glasgow,Scotland,FALSE
 1952-05-04,Germany,Republic of Ireland,3,0,Friendly,Cologne,Germany,FALSE
 1952-05-07,Austria,Republic of Ireland,6,0,Friendly,Vienna,Austria,FALSE
 1952-05-11,Romania,Czechoslovakia,3,1,Friendly,Bucharest,Romania,FALSE
@@ -3505,7 +3505,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1953-06-02,Gambia,Guinea-Bissau,1,3,Friendly,Bathurst,Gambia,FALSE
 1953-06-05,Turkey,Yugoslavia,2,2,Friendly,Istanbul,Turkey,FALSE
 1953-06-08,Guinea-Bissau,Gambia,1,0,Friendly,Bissau,Portuguese Guinea,FALSE
-1953-06-08,USA,England,3,6,Friendly,New York,USA,FALSE
+1953-06-08,United States,England,3,6,Friendly,New York,United States,FALSE
 1953-06-11,Sweden,France,1,0,Friendly,Solna,Sweden,FALSE
 1953-06-14,German DR,Bulgaria,0,0,Friendly,Dresden,German DR,FALSE
 1953-06-20,Singapore,Philippines,3,1,Friendly,Kallang,Singapore,FALSE
@@ -3599,8 +3599,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1953-12-17,France,Luxembourg,8,0,FIFA World Cup qualification,Paris,France,FALSE
 1953-12-27,Haiti,Mexico,0,4,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
 1954-01-06,Spain,Turkey,4,1,FIFA World Cup qualification,Madrid,Spain,FALSE
-1954-01-10,Mexico,USA,4,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
-1954-01-14,Mexico,USA,3,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+1954-01-10,Mexico,United States,4,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+1954-01-14,Mexico,United States,3,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1954-01-24,Italy,Egypt,5,1,FIFA World Cup qualification,Milan,Italy,FALSE
 1954-02-12,Egypt,Hungary,0,3,Friendly,Cairo,Egypt,FALSE
 1954-02-14,Paraguay,Chile,4,0,FIFA World Cup qualification,Asunción,Paraguay,FALSE
@@ -3621,10 +3621,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1954-03-28,Greece,Yugoslavia,0,1,FIFA World Cup qualification,Athens,Greece,FALSE
 1954-03-28,Saarland,Germany,1,3,FIFA World Cup qualification,Saarbrücken,Saarland,FALSE
 1954-03-31,Wales,Northern Ireland,1,2,FIFA World Cup qualification,Wrexham,Wales,FALSE
-1954-04-03,Haiti,USA,2,3,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
+1954-04-03,Haiti,United States,2,3,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
 1954-04-03,Scotland,England,2,4,FIFA World Cup qualification,Glasgow,Scotland,FALSE
 1954-04-04,Belgium,Netherlands,4,0,Friendly,Antwerp,Belgium,FALSE
-1954-04-04,Haiti,USA,0,3,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
+1954-04-04,Haiti,United States,0,3,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
 1954-04-10,Uruguay,Paraguay,1,4,Friendly,Montevideo,Uruguay,FALSE
 1954-04-11,Austria,Hungary,0,1,Friendly,Vienna,Austria,FALSE
 1954-04-11,France,Italy,1,3,Friendly,Colombes,France,FALSE
@@ -3832,7 +3832,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1955-08-22,Honduras,Aruba,1,1,CCCF Championship,Tegucigalpa,Honduras,FALSE
 1955-08-24,Costa Rica,Curaçao,2,1,CCCF Championship,Tegucigalpa,Honduras,TRUE
 1955-08-24,El Salvador,Aruba,2,0,CCCF Championship,Tegucigalpa,Honduras,TRUE
-1955-08-25,Iceland,USA,3,2,Friendly,Reykjavík,Iceland,FALSE
+1955-08-25,Iceland,United States,3,2,Friendly,Reykjavík,Iceland,FALSE
 1955-08-26,Curaçao,El Salvador,3,0,CCCF Championship,Tegucigalpa,Honduras,TRUE
 1955-08-28,Curaçao,Cuba,2,0,CCCF Championship,Tegucigalpa,Honduras,TRUE
 1955-08-28,Honduras,Costa Rica,1,2,CCCF Championship,Tegucigalpa,Honduras,FALSE
@@ -4061,18 +4061,18 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1956-10-22,Vietnam Republic,Thailand,3,1,Friendly,Saigon,Vietnam Republic,FALSE
 1956-10-27,Nigeria,Ghana,3,0,Friendly,Lagos,Nigeria,FALSE
 1956-10-28,Poland,Norway,5,3,Friendly,Warsaw,Poland,FALSE
-1956-10-31,South Korea,USA,1,0,Friendly,Seoul,South Korea,FALSE
+1956-10-31,South Korea,United States,1,0,Friendly,Seoul,South Korea,FALSE
 1956-11-04,Denmark,Netherlands,2,2,Friendly,Copenhagen,Denmark,FALSE
 1956-11-04,Poland,Finland,5,0,Friendly,Kraków,Poland,FALSE
 1956-11-07,Scotland,Northern Ireland,1,0,British Championship,Glasgow,Scotland,FALSE
-1956-11-10,Philippines,USA,0,4,Friendly,Manila,Philippines,FALSE
+1956-11-10,Philippines,United States,0,4,Friendly,Manila,Philippines,FALSE
 1956-11-10,Sierra Leone,Gambia,1,0,Friendly,Freetown,Sierra Leone,FALSE
 1956-11-11,France,Belgium,6,3,FIFA World Cup qualification,Colombes,France,FALSE
 1956-11-11,Switzerland,Italy,1,1,International Cup,Berne,Switzerland,FALSE
 1956-11-14,Argentina,Uruguay,2,2,Friendly,Buenos Aires,Argentina,FALSE
 1956-11-14,England,Wales,3,1,British Championship,London,England,FALSE
 1956-11-16,Ethiopia,Sudan,2,1,Friendly,Addis Ababa,Ethiopia,FALSE
-1956-11-16,Indonesia,USA,7,5,Friendly,Jakarta,Indonesia,FALSE
+1956-11-16,Indonesia,United States,7,5,Friendly,Jakarta,Indonesia,FALSE
 1956-11-16,Turkey,Poland,1,1,Friendly,Istanbul,Turkey,FALSE
 1956-11-21,Germany,Switzerland,1,3,Friendly,Frankfurt am Main,Germany,FALSE
 1956-11-21,Scotland,Yugoslavia,2,0,Friendly,Glasgow,Scotland,FALSE
@@ -4135,7 +4135,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1957-04-03,Netherlands,Germany,1,2,Friendly,Amsterdam,Netherlands,FALSE
 1957-04-06,England,Scotland,2,1,British Championship,London,England,FALSE
 1957-04-06,Peru,Argentina,2,1,Copa América,Lima,Peru,FALSE
-1957-04-07,Mexico,USA,6,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+1957-04-07,Mexico,United States,6,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1957-04-09,Peru,Argentina,1,4,Friendly,Lima,Peru,FALSE
 1957-04-10,Northern Ireland,Wales,0,0,British Championship,Belfast,Northern Ireland,FALSE
 1957-04-13,Peru,Brazil,1,1,FIFA World Cup qualification,Lima,Peru,FALSE
@@ -4145,7 +4145,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1957-04-21,Brazil,Peru,1,0,FIFA World Cup qualification,Rio de Janeiro,Brazil,FALSE
 1957-04-25,Italy,Northern Ireland,1,0,FIFA World Cup qualification,Rome,Italy,FALSE
 1957-04-28,Netherlands,Belgium,1,1,Friendly,Amsterdam,Netherlands,FALSE
-1957-04-28,USA,Mexico,2,7,FIFA World Cup qualification,Long Beach,USA,FALSE
+1957-04-28,United States,Mexico,2,7,FIFA World Cup qualification,Long Beach,United States,FALSE
 1957-05-01,Northern Ireland,Portugal,3,0,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
 1957-05-01,Wales,Czechoslovakia,1,0,FIFA World Cup qualification,Cardiff,Wales,FALSE
 1957-05-05,Austria,Sweden,1,0,Friendly,Vienna,Austria,FALSE
@@ -4191,7 +4191,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1957-06-19,Denmark,Norway,2,0,Friendly,Tampere,Finland,TRUE
 1957-06-19,Finland,Sweden,1,5,Friendly,Helsinki,Finland,FALSE
 1957-06-20,Colombia,Paraguay,2,3,FIFA World Cup qualification,Bogotá,Colombia,FALSE
-1957-06-22,Canada,USA,5,1,FIFA World Cup qualification,Toronto,Canada,FALSE
+1957-06-22,Canada,United States,5,1,FIFA World Cup qualification,Toronto,Canada,FALSE
 1957-06-23,China PR,Indonesia,0,0,FIFA World Cup qualification,Yangon,Burma,TRUE
 1957-06-23,Colombia,Paraguay,1,2,Friendly,Medellín,Colombia,FALSE
 1957-06-23,Hungary,Bulgaria,4,1,FIFA World Cup qualification,Budapest,Hungary,FALSE
@@ -4202,7 +4202,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1957-06-30,Uruguay,Colombia,1,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 1957-07-03,Mexico,Canada,2,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1957-07-05,Finland,Poland,1,3,FIFA World Cup qualification,Helsinki,Finland,FALSE
-1957-07-06,USA,Canada,2,3,FIFA World Cup qualification,St. Louis,USA,FALSE
+1957-07-06,United States,Canada,2,3,FIFA World Cup qualification,St. Louis,United States,FALSE
 1957-07-07,Brazil,Argentina,1,2,Copa Roca,Rio de Janeiro,Brazil,FALSE
 1957-07-07,Paraguay,Colombia,3,0,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 1957-07-08,Iceland,Norway,0,3,Friendly,Reykjavík,Iceland,FALSE
@@ -4543,7 +4543,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1959-05-24,Mexico,England,2,1,Friendly,Mexico City,Mexico,FALSE
 1959-05-25,Ethiopia,Sudan,0,1,African Cup of Nations,Cairo,United Arab Republic,TRUE
 1959-05-27,Netherlands,Scotland,1,2,Friendly,Amsterdam,Netherlands,FALSE
-1959-05-28,USA,England,1,8,Friendly,Los Angeles,USA,FALSE
+1959-05-28,United States,England,1,8,Friendly,Los Angeles,United States,FALSE
 1959-05-29,Egypt,Sudan,2,1,African Cup of Nations,Cairo,United Arab Republic,TRUE
 1959-05-30,Martinique,Suriname,3,1,Friendly,Fort-de-France,Martinique,FALSE
 1959-05-31,Martinique,Suriname,3,0,Friendly,Fort-de-France,Martinique,FALSE
@@ -4842,11 +4842,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1960-10-30,Sweden,France,1,0,Friendly,Solna,Sweden,FALSE
 1960-11-06,Republic of Ireland,Norway,3,1,Friendly,Dublin,Republic of Ireland,FALSE
 1960-11-06,South Korea,Japan,2,1,FIFA World Cup qualification,Seoul,South Korea,FALSE
-1960-11-06,USA,Mexico,3,3,FIFA World Cup qualification,Los Angeles,USA,FALSE
+1960-11-06,United States,Mexico,3,3,FIFA World Cup qualification,Los Angeles,United States,FALSE
 1960-11-09,Scotland,Northern Ireland,5,2,British Championship,Glasgow,Scotland,FALSE
 1960-11-13,Cyprus,Israel,1,1,FIFA World Cup qualification,Nicosia,Cyprus,FALSE
 1960-11-13,Hungary,Poland,4,1,Friendly,Budapest,Hungary,FALSE
-1960-11-13,Mexico,USA,3,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+1960-11-13,Mexico,United States,3,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1960-11-13,Tunisia,Morocco,2,1,FIFA World Cup qualification,Tunis,Tunisia,FALSE
 1960-11-20,Belgium,Switzerland,2,4,FIFA World Cup qualification,Brussels,Belgium,FALSE
 1960-11-20,Greece,Germany,0,3,FIFA World Cup qualification,Athens,Greece,FALSE
@@ -4873,7 +4873,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1961-01-18,Dominica,Saint Vincent and the Grenadines,1,1,Windward Islands Tournament,Castries,Saint Lucia,TRUE
 1961-01-19,Dominica,Grenada,1,8,Windward Islands Tournament,Castries,Saint Lucia,TRUE
 1961-01-20,Saint Lucia,Saint Vincent and the Grenadines,2,2,Windward Islands Tournament,Castries,Saint Lucia,FALSE
-1961-02-05,Colombia,USA,2,0,Friendly,Bogotá,Colombia,FALSE
+1961-02-05,Colombia,United States,2,0,Friendly,Bogotá,Colombia,FALSE
 1961-02-17,Egypt,Hungary,0,2,Friendly,Cairo,Egypt,FALSE
 1961-02-22,Morocco,Tunisia,1,1,FIFA World Cup qualification,Palermo,Italy,TRUE
 1961-03-05,Costa Rica,Cuba,4,1,CCCF Championship,San José,Costa Rica,FALSE
@@ -5644,7 +5644,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1964-05-26,Israel,Hong Kong,1,0,AFC Asian Cup,Ramat-Gan,Israel,FALSE
 1964-05-27,India,South Korea,2,0,AFC Asian Cup,Haifa,Israel,TRUE
 1964-05-27,Russia,Sweden,3,1,UEFA Euro qualification,Moscow,Soviet Union,FALSE
-1964-05-27,USA,England,0,10,Friendly,New York,USA,FALSE
+1964-05-27,United States,England,0,10,Friendly,New York,United States,FALSE
 1964-05-29,Israel,India,2,0,AFC Asian Cup,Jaffa,Israel,FALSE
 1964-05-30,Brazil,England,5,1,Friendly,Rio de Janeiro,Brazil,FALSE
 1964-05-31,Argentina,Portugal,2,0,Friendly,Rio de Janeiro,Brazil,TRUE
@@ -5796,14 +5796,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1965-02-28,Tunisia,Morocco,0,0,Friendly,Tunis,Tunisia,FALSE
 1965-03-04,Mexico,Honduras,3,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1965-03-07,Trinidad and Tobago,Costa Rica,0,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
-1965-03-07,USA,Mexico,2,2,FIFA World Cup qualification,Los Angeles,USA,FALSE
+1965-03-07,United States,Mexico,2,2,FIFA World Cup qualification,Los Angeles,United States,FALSE
 1965-03-09,Curaçao,Costa Rica,1,2,Friendly,Willemstad,Netherlands Antilles,FALSE
 1965-03-10,El Salvador,Nicaragua,4,0,CONCACAF Championship qualification,San Salvador,El Salvador,FALSE
 1965-03-10,Guatemala,Paraguay,1,4,Friendly,Guatemala,Guatemala,FALSE
 1965-03-11,Hong Kong,Japan,1,4,Friendly,So Kon Po,Hong Kong,FALSE
 1965-03-12,Honduras,Nicaragua,0,2,CONCACAF Championship qualification,San Salvador,El Salvador,TRUE
 1965-03-12,Kuwait,Morocco,0,2,Friendly,Tripoli,Libya,TRUE
-1965-03-12,Mexico,USA,2,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+1965-03-12,Mexico,United States,2,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1965-03-13,Germany,Italy,1,1,Friendly,Hamburg,Germany,FALSE
 1965-03-14,El Salvador,Honduras,3,1,CONCACAF Championship qualification,San Salvador,El Salvador,FALSE
 1965-03-14,Guatemala,Paraguay,0,3,Friendly,Guatemala,Guatemala,FALSE
@@ -5811,14 +5811,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1965-03-14,Suriname,Trinidad and Tobago,6,1,FIFA World Cup qualification,Paramaribo,Suriname,FALSE
 1965-03-15,Hong Kong,Japan,1,2,Friendly,So Kon Po,Hong Kong,FALSE
 1965-03-17,Costa Rica,Paraguay,1,0,Friendly,San José,Costa Rica,FALSE
-1965-03-17,Honduras,USA,0,1,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
+1965-03-17,Honduras,United States,0,1,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 1965-03-17,Israel,Switzerland,0,0,Friendly,Jaffa,Israel,FALSE
 1965-03-17,Northern Ireland,Netherlands,2,1,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
 1965-03-17,Wales,Greece,4,1,FIFA World Cup qualification,Cardiff,Wales,FALSE
 1965-03-19,Costa Rica,Paraguay,0,0,Friendly,San José,Costa Rica,FALSE
 1965-03-19,Libya,Morocco,1,0,Friendly,Tripoli,Libya,FALSE
 1965-03-20,Cyprus,Lebanon,2,0,Friendly,Nicosia,Cyprus,FALSE
-1965-03-21,Honduras,USA,1,1,FIFA World Cup qualification,Tegucigalpa,Honduras,FALSE
+1965-03-21,Honduras,United States,1,1,FIFA World Cup qualification,Tegucigalpa,Honduras,FALSE
 1965-03-22,Myanmar,Japan,1,1,Friendly,Yangon,Burma,FALSE
 1965-03-24,France,Austria,1,2,Friendly,Paris,France,FALSE
 1965-03-24,Republic of Ireland,Belgium,0,2,Friendly,Dublin,Republic of Ireland,FALSE
@@ -6959,14 +6959,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1968-09-11,El Salvador,Costa Rica,1,1,Friendly,San Salvador,El Salvador,FALSE
 1968-09-11,Finland,Sweden,0,3,Nordic Championship,Helsinki,Finland,FALSE
 1968-09-15,Norway,Sweden,1,1,Nordic Championship,Oslo,Norway,FALSE
-1968-09-15,USA,Israel,3,3,Friendly,New York,USA,FALSE
+1968-09-15,United States,Israel,3,3,Friendly,New York,United States,FALSE
 1968-09-17,New Zealand,Fiji,5,0,Friendly,Auckland,New Zealand,FALSE
 1968-09-19,New Caledonia,Fiji,2,1,Friendly,Nouméa,New Caledonia,FALSE
 1968-09-22,Ghana,Benin,3,0,Friendly,Accra,Ghana,FALSE
 1968-09-22,Switzerland,Austria,1,0,Friendly,Berne,Switzerland,FALSE
 1968-09-25,Denmark,Czechoslovakia,0,3,FIFA World Cup qualification,Copenhagen,Denmark,FALSE
 1968-09-25,France,Germany,1,1,Friendly,Marseille,France,FALSE
-1968-09-25,USA,Israel,0,4,Friendly,Philadelphia,USA,FALSE
+1968-09-25,United States,Israel,0,4,Friendly,Philadelphia,United States,FALSE
 1968-09-25,Yugoslavia,Finland,9,1,FIFA World Cup qualification,Belgrade,Yugoslavia,FALSE
 1968-09-28,Tanzania,Uganda,0,2,Friendly,Dar es Salaam,Tanzania,FALSE
 1968-09-29,Kenya,Zanzibar,3,0,Friendly,Dar es Salaam,Tanzania,TRUE
@@ -6987,7 +6987,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1968-10-12,Switzerland,Greece,1,0,FIFA World Cup qualification,Basel,Switzerland,FALSE
 1968-10-12,Uganda,Zambia,1,1,Friendly,Mbale,Uganda,FALSE
 1968-10-13,Austria,Germany,0,2,FIFA World Cup qualification,Vienna,Austria,FALSE
-1968-10-13,Canada,USA,4,2,FIFA World Cup qualification,Toronto,Canada,FALSE
+1968-10-13,Canada,United States,4,2,FIFA World Cup qualification,Toronto,Canada,FALSE
 1968-10-13,Kenya,Zambia,2,1,Friendly,Nairobi,Kenya,FALSE
 1968-10-15,Ethiopia,Thailand,6,0,Friendly,León,Mexico,TRUE
 1968-10-16,Belgium,Yugoslavia,3,0,FIFA World Cup qualification,Brussels,Belgium,FALSE
@@ -6996,13 +6996,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1968-10-17,France,Spain,1,3,Friendly,Lyon,France,FALSE
 1968-10-20,Bermuda,Canada,0,0,FIFA World Cup qualification,Hamilton,Bermuda,FALSE
 1968-10-20,Czechoslovakia,Denmark,1,0,FIFA World Cup qualification,Bratislava,Czechoslovakia,FALSE
-1968-10-20,Haiti,USA,3,6,Friendly,Port-au-Prince,Haiti,FALSE
+1968-10-20,Haiti,United States,3,6,Friendly,Port-au-Prince,Haiti,FALSE
 1968-10-20,Peru,Mexico,3,3,Friendly,Lima,Peru,FALSE
 1968-10-20,Poland,German DR,1,1,Friendly,Szczecin,Poland,FALSE
-1968-10-21,Haiti,USA,5,2,Friendly,Port-au-Prince,Haiti,FALSE
+1968-10-21,Haiti,United States,5,2,Friendly,Port-au-Prince,Haiti,FALSE
 1968-10-22,Zambia,Tanzania,7,1,Friendly,Kitwe,Zambia,FALSE
 1968-10-23,Chile,Mexico,3,1,Friendly,Santiago,Chile,FALSE
-1968-10-23,Haiti,USA,1,0,Friendly,Port-au-Prince,Haiti,FALSE
+1968-10-23,Haiti,United States,1,0,Friendly,Port-au-Prince,Haiti,FALSE
 1968-10-23,Northern Ireland,Turkey,4,1,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
 1968-10-23,Wales,Italy,0,1,FIFA World Cup qualification,Cardiff,Wales,FALSE
 1968-10-24,Zambia,Tanzania,2,1,Friendly,Lusaka,Zambia,FALSE
@@ -7014,16 +7014,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1968-10-28,Nigeria,Thailand,7,2,Friendly,León,Mexico,TRUE
 1968-10-30,Poland,Republic of Ireland,1,0,Friendly,Chorzów,Poland,FALSE
 1968-10-31,Brazil,Mexico,1,2,Friendly,Rio de Janeiro,Brazil,FALSE
-1968-11-03,USA,Canada,1,0,FIFA World Cup qualification,Atlanta,USA,FALSE
+1968-11-03,United States,Canada,1,0,FIFA World Cup qualification,Atlanta,United States,FALSE
 1968-11-03,Brazil,Mexico,2,1,Friendly,Belo Horizonte,Brazil,FALSE
 1968-11-03,Morocco,Senegal,1,0,FIFA World Cup qualification,Casablanca,Morocco,FALSE
-1968-11-03,USA,Bermuda,6,2,FIFA World Cup qualification,Kansas City,USA,FALSE
+1968-11-03,United States,Bermuda,6,2,FIFA World Cup qualification,Kansas City,United States,FALSE
 1968-11-06,France,Norway,0,1,FIFA World Cup qualification,Strasbourg,France,FALSE
 1968-11-06,Romania,England,0,0,Friendly,Bucharest,Romania,FALSE
 1968-11-06,Scotland,Austria,2,1,FIFA World Cup qualification,Glasgow,Scotland,FALSE
 1968-11-08,Sudan,Zambia,4,2,FIFA World Cup qualification,Khartoum,Sudan,FALSE
 1968-11-10,Republic of Ireland,Austria,2,2,Friendly,Dublin,Republic of Ireland,FALSE
-1968-11-11,Bermuda,USA,0,2,FIFA World Cup qualification,Hamilton,Bermuda,FALSE
+1968-11-11,Bermuda,United States,0,2,FIFA World Cup qualification,Hamilton,Bermuda,FALSE
 1968-11-11,Guadeloupe,Martinique,3,1,Friendly,Basse-Terre,Guadeloupe,FALSE
 1968-11-14,Costa Rica,El Salvador,3,0,Friendly,San José,Costa Rica,FALSE
 1968-11-14,Guadeloupe,Puerto Rico,2,0,Friendly,Basse-Terre,Guadeloupe,FALSE
@@ -7157,7 +7157,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1969-04-16,Portugal,Switzerland,0,2,FIFA World Cup qualification,Lisbon,Portugal,FALSE
 1969-04-16,Scotland,Germany,1,1,FIFA World Cup qualification,Glasgow,Scotland,FALSE
 1969-04-19,Cyprus,Austria,1,2,FIFA World Cup qualification,Nicosia,Cyprus,FALSE
-1969-04-20,Haiti,USA,2,0,CONCACAF Championship qualification,Port-au-Prince,Haiti,FALSE
+1969-04-20,Haiti,United States,2,0,CONCACAF Championship qualification,Port-au-Prince,Haiti,FALSE
 1969-04-20,Poland,Luxembourg,8,1,FIFA World Cup qualification,Kraków,Poland,FALSE
 1969-04-23,Bulgaria,Luxembourg,2,1,FIFA World Cup qualification,Sofia,Bulgaria,FALSE
 1969-04-23,Israel,Austria,1,1,Friendly,Ramat-Gan,Israel,FALSE
@@ -7185,7 +7185,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1969-05-10,Nigeria,Ghana,2,1,FIFA World Cup qualification,Ibadan,Nigeria,FALSE
 1969-05-10,Northern Ireland,Wales,0,0,British Championship,Belfast,Northern Ireland,FALSE
 1969-05-11,Sudan,Ethiopia,3,1,FIFA World Cup qualification,Khartoum,Sudan,FALSE
-1969-05-11,USA,Haiti,0,1,CONCACAF Championship qualification,San Diego,USA,FALSE
+1969-05-11,United States,Haiti,0,1,CONCACAF Championship qualification,San Diego,United States,FALSE
 1969-05-14,El Salvador,Peru,1,4,Friendly,San Salvador,El Salvador,FALSE
 1969-05-14,Switzerland,Romania,0,1,FIFA World Cup qualification,Lausanne,Switzerland,FALSE
 1969-05-17,Scotland,Cyprus,8,0,FIFA World Cup qualification,Glasgow,Scotland,FALSE
@@ -8444,17 +8444,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1972-08-10,Hong Kong,Cambodia,2,1,Friendly,Kallang,Singapore,TRUE
 1972-08-15,Congo,Nigeria,1,1,FIFA World Cup qualification,Brazzaville,Congo,FALSE
 1972-08-16,Chile,Mexico,0,2,Friendly,Santiago,Chile,FALSE
-1972-08-20,Canada,USA,3,2,CONCACAF Championship qualification,St. John's,Canada,FALSE
+1972-08-20,Canada,United States,3,2,CONCACAF Championship qualification,St. John's,Canada,FALSE
 1972-08-24,Canada,Mexico,0,1,CONCACAF Championship qualification,Toronto,Canada,FALSE
-1972-08-29,USA,Canada,2,2,CONCACAF Championship qualification,Baltimore,USA,FALSE
+1972-08-29,United States,Canada,2,2,CONCACAF Championship qualification,Baltimore,United States,FALSE
 1972-08-30,Czechoslovakia,Netherlands,1,2,Friendly,Prague,Czechoslovakia,FALSE
 1972-09-02,Greece,France,1,3,Friendly,Piraeus,Greece,FALSE
 1972-09-02,Guatemala,Canada,2,2,Friendly,Guatemala,Guatemala,FALSE
-1972-09-03,Mexico,USA,3,1,CONCACAF Championship qualification,Mexico City,Mexico,FALSE
+1972-09-03,Mexico,United States,3,1,CONCACAF Championship qualification,Mexico City,Mexico,FALSE
 1972-09-03,Romania,Austria,1,1,Friendly,Craiova,Romania,FALSE
 1972-09-03,Sri Lanka,China PR,2,3,Friendly,Colombo,Sri Lanka,FALSE
 1972-09-06,Mexico,Canada,2,1,CONCACAF Championship qualification,Mexico City,Mexico,FALSE
-1972-09-10,USA,Mexico,1,2,CONCACAF Championship qualification,Los Angeles,USA,FALSE
+1972-09-10,United States,Mexico,1,2,CONCACAF Championship qualification,Los Angeles,United States,FALSE
 1972-09-12,Sri Lanka,China PR,0,1,Friendly,Colombo,Sri Lanka,FALSE
 1972-09-14,Japan,South Korea,2,2,Friendly,Tokyo,Japan,FALSE
 1972-09-17,New Zealand,New Caledonia,4,1,Friendly,Wellington,New Zealand,FALSE
@@ -8656,10 +8656,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1973-03-13,Iraq,New Zealand,2,0,FIFA World Cup qualification,Sydney,Australia,TRUE
 1973-03-16,Australia,New Zealand,3,3,FIFA World Cup qualification,Sydney,Australia,FALSE
 1973-03-16,Iraq,Indonesia,1,1,FIFA World Cup qualification,Sydney,Australia,TRUE
-1973-03-17,Bermuda,USA,4,0,Friendly,Hamilton,Bermuda,FALSE
+1973-03-17,Bermuda,United States,4,0,Friendly,Hamilton,Bermuda,FALSE
 1973-03-18,Australia,Iraq,0,0,FIFA World Cup qualification,Melbourne,Australia,FALSE
 1973-03-18,Indonesia,New Zealand,1,0,FIFA World Cup qualification,Melbourne,Australia,TRUE
-1973-03-20,Poland,USA,4,0,Friendly,Łódź,Poland,FALSE
+1973-03-20,Poland,United States,4,0,Friendly,Łódź,Poland,FALSE
 1973-03-21,Iraq,Indonesia,3,2,FIFA World Cup qualification,Sydney,Australia,TRUE
 1973-03-24,Australia,Indonesia,6,0,FIFA World Cup qualification,Sydney,Australia,FALSE
 1973-03-24,Iraq,New Zealand,4,0,FIFA World Cup qualification,Sydney,Australia,TRUE
@@ -8848,17 +8848,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1973-08-03,China PR,Guinea,5,2,Friendly,Beijing,China PR,FALSE
 1973-08-03,Cambodia,South Korea,0,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1973-08-03,Iceland,Norway,0,4,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
-1973-08-03,USA,Poland,0,1,Friendly,Chicago,USA,FALSE
+1973-08-03,United States,Poland,0,1,Friendly,Chicago,United States,FALSE
 1973-08-03,Malaysia,Thailand,2,2,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1973-08-03,Malaysia,Cambodia,1,0,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1973-08-03,Malaysia,India,4,0,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1973-08-05,India,Cambodia,3,0,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1973-08-05,Myanmar,Kuwait,2,0,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1973-08-05,India,South Korea,0,0,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
-1973-08-05,Canada,USA,0,2,Friendly,Windsor,Canada,FALSE
+1973-08-05,Canada,United States,0,2,Friendly,Windsor,Canada,FALSE
 1973-08-05,Chile,Peru,2,1,FIFA World Cup qualification,Montevideo,Uruguay,TRUE
 1973-08-05,Ghana,DR Congo,1,0,FIFA World Cup qualification,Accra,Ghana,FALSE
-1973-08-05,Mexico,Poland,0,1,Friendly,Los Angeles,USA,TRUE
+1973-08-05,Mexico,Poland,0,1,Friendly,Los Angeles,United States,TRUE
 1973-08-05,Russia,Sweden,0,0,Friendly,Moscow,Soviet Union,FALSE
 1973-08-05,Singapore,Vietnam Republic,0,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1973-08-06,Cambodia,Thailand,1,4,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
@@ -8869,7 +8869,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1973-08-09,India,Vietnam Republic,1,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1973-08-10,Cambodia,Singapore,0,3,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1973-08-10,Malaysia,Myanmar,2,1,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
-1973-08-10,USA,Poland,0,4,Friendly,San Francisco,USA,FALSE
+1973-08-10,United States,Poland,0,4,Friendly,San Francisco,United States,FALSE
 1973-08-11,Libya,United Arab Emirates,2,2,Palestine Cup,Benghazi,Libya,FALSE
 1973-08-11,South Korea,Kuwait,0,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1973-08-11,South Korea,Myanmar,1,2,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
@@ -8877,7 +8877,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1973-08-12,Egypt,Yemen DPR,6,1,Palestine Cup,Tripoli,Libya,TRUE
 1973-08-12,Malaysia,Kuwait,3,1,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1973-08-12,New Zealand,Iran,0,0,Friendly,Auckland,New Zealand,FALSE
-1973-08-12,USA,Poland,1,0,Friendly,New Britain,USA,FALSE
+1973-08-12,United States,Poland,1,0,Friendly,New Britain,United States,FALSE
 1973-08-12,Zambia,Kenya,2,0,FIFA World Cup qualification,Ndola,Zambia,FALSE
 1973-08-13,Algeria,United Arab Emirates,2,0,Palestine Cup,Benghazi,Libya,TRUE
 1973-08-13,Iraq,Yemen,2,0,Palestine Cup,Benghazi,Libya,TRUE
@@ -8915,7 +8915,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1973-09-05,Russia,Germany,0,1,Friendly,Moscow,Soviet Union,FALSE
 1973-09-08,France,Greece,3,1,Friendly,Paris,France,FALSE
 1973-09-09,Argentina,Bolivia,4,0,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
-1973-09-09,USA,Bermuda,1,0,Friendly,Hartford,USA,FALSE
+1973-09-09,United States,Bermuda,1,0,Friendly,Hartford,United States,FALSE
 1973-09-12,Norway,Netherlands,1,2,FIFA World Cup qualification,Oslo,Norway,FALSE
 1973-09-16,Paraguay,Argentina,1,1,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 1973-09-20,Mexico,Chile,1,2,Friendly,Mexico City,Mexico,FALSE
@@ -8961,7 +8961,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1973-10-13,Germany,France,2,1,Friendly,Gelsenkirchen,Germany,FALSE
 1973-10-13,Portugal,Bulgaria,2,2,FIFA World Cup qualification,Lisbon,Portugal,FALSE
 1973-10-14,Romania,Finland,9,0,FIFA World Cup qualification,Bucharest,Romania,FALSE
-1973-10-16,Mexico,USA,2,0,Friendly,Mexico City,Mexico,FALSE
+1973-10-16,Mexico,United States,2,0,Friendly,Mexico City,Mexico,FALSE
 1973-10-17,Czechoslovakia,Scotland,1,0,FIFA World Cup qualification,Bratislava,Czechoslovakia,FALSE
 1973-10-17,England,Poland,1,1,FIFA World Cup qualification,London,England,FALSE
 1973-10-17,German DR,Russia,1,0,Friendly,Leipzig,German DR,FALSE
@@ -8977,12 +8977,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1973-10-31,Belgium,Norway,2,0,FIFA World Cup qualification,Brussels,Belgium,FALSE
 1973-11-01,Vietnam Republic,Malaysia,1,5,Vietnam Independence Cup,Saigon,Vietnam Republic,FALSE
 1973-11-03,Albania,German DR,1,4,FIFA World Cup qualification,Tirana,Albania,FALSE
-1973-11-03,Haiti,USA,1,0,Friendly,Port-au-Prince,Haiti,FALSE
+1973-11-03,Haiti,United States,1,0,Friendly,Port-au-Prince,Haiti,FALSE
 1973-11-03,Malaysia,Singapore,2,1,Vietnam Independence Cup,Saigon,Vietnam Republic,TRUE
 1973-11-04,Guyana,Jamaica,2,1,Friendly,Georgetown,Guyana,FALSE
 1973-11-04,Vietnam Republic,Singapore,4,2,Vietnam Independence Cup,Saigon,Vietnam Republic,FALSE
 1973-11-04,Zambia,DR Congo,0,2,FIFA World Cup qualification,Lusaka,Zambia,FALSE
-1973-11-05,Haiti,USA,1,0,Friendly,Port-au-Prince,Haiti,FALSE
+1973-11-05,Haiti,United States,1,0,Friendly,Port-au-Prince,Haiti,FALSE
 1973-11-06,Barbados,Suriname,0,2,Friendly,Georgetown,Guyana,TRUE
 1973-11-06,Guadeloupe,Martinique,0,2,Friendly,Basse-Terre,Guadeloupe,FALSE
 1973-11-07,Albania,China PR,1,1,Friendly,Tirana,Albania,FALSE
@@ -8995,11 +8995,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1973-11-11,Saint Vincent and the Grenadines,Grenada,4,1,Windward Islands Tournament,Kingstown,Saint Vincent and the Grenadines,FALSE
 1973-11-12,Haiti,Canada,0,1,Friendly,Port-au-Prince,Haiti,FALSE
 1973-11-13,Australia,South Korea,1,0,FIFA World Cup qualification,So Kon Po,Hong Kong,TRUE
-1973-11-13,Israel,USA,3,1,Friendly,Jaffa,Israel,FALSE
+1973-11-13,Israel,United States,3,1,Friendly,Jaffa,Israel,FALSE
 1973-11-14,England,Italy,0,1,Friendly,London,England,FALSE
 1973-11-14,Portugal,Northern Ireland,1,1,FIFA World Cup qualification,Lisbon,Portugal,FALSE
 1973-11-14,Scotland,Germany,1,1,Friendly,Glasgow,Scotland,FALSE
-1973-11-15,Israel,USA,2,0,Friendly,Beer Sheva,Israel,FALSE
+1973-11-15,Israel,United States,2,0,Friendly,Beer Sheva,Israel,FALSE
 1973-11-15,Saint Lucia,Grenada,1,3,Windward Islands Tournament,Castries,Saint Lucia,FALSE
 1973-11-16,Saint Lucia,Dominica,2,1,Windward Islands Tournament,Castries,Saint Lucia,FALSE
 1973-11-18,Bulgaria,Cyprus,2,0,FIFA World Cup qualification,Sofia,Bulgaria,FALSE
@@ -9264,8 +9264,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1974-08-19,Iceland,Finland,2,2,Friendly,Reykjavík,Iceland,FALSE
 1974-08-24,Burundi,Somalia,0,1,African Cup of Nations qualification,Bujumbura,Burundi,FALSE
 1974-08-24,Malta,Libya,0,1,Friendly,Gżira,Malta,FALSE
-1974-08-30,Haiti,Jamaica,0,1,Friendly,New York,USA,TRUE
-1974-08-31,Jamaica,Trinidad and Tobago,2,1,Friendly,New York,USA,TRUE
+1974-08-30,Haiti,Jamaica,0,1,Friendly,New York,United States,TRUE
+1974-08-31,Jamaica,Trinidad and Tobago,2,1,Friendly,New York,United States,TRUE
 1974-09-01,Finland,Poland,1,2,UEFA Euro qualification,Helsinki,Finland,FALSE
 1974-09-03,Denmark,Indonesia,9,0,Friendly,Copenhagen,Denmark,FALSE
 1974-09-04,Austria,Wales,2,1,UEFA Euro qualification,Vienna,Austria,FALSE
@@ -9274,11 +9274,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1974-09-04,Poland,German DR,1,3,Friendly,Warsaw,Poland,FALSE
 1974-09-04,Sweden,Netherlands,1,5,Friendly,Solna,Sweden,FALSE
 1974-09-04,Switzerland,Germany,1,2,Friendly,Basel,Switzerland,FALSE
-1974-09-05,Mexico,USA,3,1,Friendly,Monterrey,Mexico,FALSE
+1974-09-05,Mexico,United States,3,1,Friendly,Monterrey,Mexico,FALSE
 1974-09-06,Libya,DR Congo,0,2,Friendly,Tripoli,Libya,FALSE
 1974-09-07,Poland,France,0,2,Friendly,Wrocław,Poland,FALSE
 1974-09-08,Iceland,Belgium,0,2,UEFA Euro qualification,Reykjavík,Iceland,FALSE
-1974-09-08,USA,Mexico,0,1,Friendly,Dallas,USA,FALSE
+1974-09-08,United States,Mexico,0,1,Friendly,Dallas,United States,FALSE
 1974-09-10,Libya,Somalia,3,2,Friendly,Tripoli,Libya,FALSE
 1974-09-11,Ivory Coast,Ghana,1,1,Friendly,Abidjan,Ivory Coast,FALSE
 1974-09-13,Libya,Somalia,3,2,Friendly,Tripoli,Libya,FALSE
@@ -9455,7 +9455,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1975-03-24,Thailand,South Korea,1,0,AFC Asian Cup qualification,Bangkok,Thailand,FALSE
 1975-03-26,France,Hungary,2,0,Friendly,Paris,France,FALSE
 1975-03-26,German DR,Bulgaria,0,0,Friendly,Berlin,German DR,FALSE
-1975-03-26,Poland,USA,7,0,Friendly,Poznań,Poland,FALSE
+1975-03-26,Poland,United States,7,0,Friendly,Poznań,Poland,FALSE
 1975-03-30,Congo,Ivory Coast,1,0,African Cup of Nations qualification,Brazzaville,Congo,FALSE
 1975-03-30,Ghana,Mali,4,0,African Cup of Nations qualification,Accra,Ghana,FALSE
 1975-03-30,Malawi,Zambia,1,6,African Cup of Nations qualification,Blantyre,Malawi,FALSE
@@ -9465,7 +9465,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1975-04-01,Cyprus,Greece,1,2,Friendly,Nicosia,Cyprus,FALSE
 1975-04-02,Austria,Hungary,0,0,UEFA Euro qualification,Vienna,Austria,FALSE
 1975-04-02,Iraq,Qatar,1,0,AFC Asian Cup qualification,Baghdad,Iraq,FALSE
-1975-04-02,Italy,USA,10,0,Friendly,Rome,Italy,FALSE
+1975-04-02,Italy,United States,10,0,Friendly,Rome,Italy,FALSE
 1975-04-02,Russia,Turkey,3,0,UEFA Euro qualification,Kyiv,Soviet Union,FALSE
 1975-04-02,Saudi Arabia,Afghanistan,2,0,AFC Asian Cup qualification,Baghdad,Iraq,TRUE
 1975-04-04,Iraq,Afghanistan,4,0,AFC Asian Cup qualification,Baghdad,Iraq,FALSE
@@ -9564,7 +9564,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1975-06-23,China PR,Japan,2,1,AFC Asian Cup qualification,So Kon Po,Hong Kong,TRUE
 1975-06-23,Iceland,Faroe Islands,6,0,Friendly,Reykjavík,Iceland,FALSE
 1975-06-24,Hong Kong,North Korea,3,3,AFC Asian Cup qualification,So Kon Po,Hong Kong,FALSE
-1975-06-24,USA,Poland,0,4,Friendly,Seattle,USA,FALSE
+1975-06-24,United States,Poland,0,4,Friendly,Seattle,United States,FALSE
 1975-06-25,Chile,Uruguay,1,3,Copa Juan Pinto Durán,Santiago,Chile,FALSE
 1975-06-25,Denmark,Finland,2,0,Nordic Championship,Copenhagen,Denmark,FALSE
 1975-06-25,Ecuador,Peru,1,0,Friendly,Guayaquil,Ecuador,FALSE
@@ -9616,7 +9616,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1975-07-31,Malaysia,Hong Kong,3,1,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1975-08-01,Myanmar,Indonesia,2,0,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1975-08-01,Hong Kong,South Korea,0,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
-1975-08-01,Mexico,German DR,2,3,Friendly,San Francisco,USA,TRUE
+1975-08-01,Mexico,German DR,2,3,Friendly,San Francisco,United States,TRUE
 1975-08-01,Panama,Guatemala,2,0,Friendly,Panama City,Panama,FALSE
 1975-08-02,Bangladesh,Thailand,1,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1975-08-02,New Caledonia,Tahiti,3,0,South Pacific Games,Tamuning,Guam,TRUE
@@ -9625,7 +9625,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1975-08-02,Malaysia,Japan,2,0,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1975-08-03,Myanmar,South Korea,2,3,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1975-08-03,Hong Kong,Indonesia,2,3,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
-1975-08-03,Mexico,German DR,0,1,Friendly,Los Angeles,USA,TRUE
+1975-08-03,Mexico,German DR,0,1,Friendly,Los Angeles,United States,TRUE
 1975-08-03,Venezuela,Argentina,1,5,Copa América,Caracas,Venezuela,FALSE
 1975-08-04,Bangladesh,Japan,0,3,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1975-08-04,New Caledonia,Vanuatu,3,1,South Pacific Games,Tamuning,Guam,TRUE
@@ -9674,11 +9674,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1975-08-17,Malaysia,South Korea,0,1,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1975-08-17,Mexico,Costa Rica,7,0,Friendly,Mexico City,Mexico,FALSE
 1975-08-17,Panama,Haiti,1,1,Friendly,La Chorrera,Panama,FALSE
-1975-08-19,Costa Rica,USA,3,1,Friendly,Mexico City,Mexico,TRUE
+1975-08-19,Costa Rica,United States,3,1,Friendly,Mexico City,Mexico,TRUE
 1975-08-20,Peru,Chile,3,1,Copa América,Lima,Peru,FALSE
-1975-08-21,Argentina,USA,6,0,Friendly,Mexico City,Mexico,TRUE
+1975-08-21,Argentina,United States,6,0,Friendly,Mexico City,Mexico,TRUE
 1975-08-24,Ghana,Nigeria,1,2,Friendly,Accra,Ghana,FALSE
-1975-08-24,Mexico,USA,2,0,Friendly,Mexico City,Mexico,FALSE
+1975-08-24,Mexico,United States,2,0,Friendly,Mexico City,Mexico,FALSE
 1975-08-31,Ghana,Nigeria,3,0,Friendly,Accra,Ghana,FALSE
 1975-08-31,Mexico,Argentina,1,1,Friendly,Mexico City,Mexico,FALSE
 1975-09-03,Austria,Germany,0,2,Friendly,Vienna,Austria,FALSE
@@ -9935,13 +9935,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1976-05-22,Hungary,France,1,0,Friendly,Budapest,Hungary,FALSE
 1976-05-22,Russia,Czechoslovakia,2,2,UEFA Euro qualification,Kyiv,Soviet Union,FALSE
 1976-05-22,Wales,Yugoslavia,1,1,UEFA Euro qualification,Cardiff,Wales,FALSE
-1976-05-23,Brazil,England,1,0,Friendly,Los Angeles,USA,TRUE
+1976-05-23,Brazil,England,1,0,Friendly,Los Angeles,United States,TRUE
 1976-05-23,Cyprus,Denmark,1,5,FIFA World Cup qualification,Limassol,Cyprus,FALSE
 1976-05-26,Hungary,Russia,1,1,Friendly,Budapest,Hungary,FALSE
 1976-05-26,Poland,Republic of Ireland,0,2,Friendly,Poznań,Poland,FALSE
-1976-05-28,England,Italy,3,2,Friendly,New York,USA,TRUE
+1976-05-28,England,Italy,3,2,Friendly,New York,United States,TRUE
 1976-05-30,Malawi,Zambia,0,1,FIFA World Cup qualification,Blantyre,Malawi,FALSE
-1976-05-31,Brazil,Italy,4,1,Friendly,New Haven,USA,TRUE
+1976-05-31,Brazil,Italy,4,1,Friendly,New Haven,United States,TRUE
 1976-06-01,Finland,Sweden,0,2,Nordic Championship,Helsinki,Finland,FALSE
 1976-06-03,Kuwait,Malaysia,2,0,AFC Asian Cup,Tehran,Iran,TRUE
 1976-06-04,Iran,Iraq,2,0,AFC Asian Cup,Tehran,Iran,FALSE
@@ -10065,14 +10065,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1976-09-22,Norway,Sweden,3,2,Nordic Championship,Oslo,Norway,FALSE
 1976-09-22,Romania,Czechoslovakia,1,1,Friendly,Bucharest,Romania,FALSE
 1976-09-23,South Korea,New Zealand,2,0,Korea Cup,Seoul,South Korea,FALSE
-1976-09-24,Canada,USA,1,1,CONCACAF Championship qualification,Vancouver,Canada,FALSE
+1976-09-24,Canada,United States,1,1,CONCACAF Championship qualification,Vancouver,Canada,FALSE
 1976-09-25,Italy,Yugoslavia,3,0,Friendly,Rome,Italy,FALSE
 1976-09-26,Guatemala,Panama,7,0,CONCACAF Championship qualification,Guatemala,Guatemala,FALSE
 1976-09-26,Ivory Coast,Burkina Faso,2,0,FIFA World Cup qualification,Abidjan,Ivory Coast,FALSE
 1976-09-30,Botswana,Zambia,2,3,Friendly,Gaborone,Botswana,FALSE
 1976-09-30,Saudi Arabia,Tunisia,0,1,Friendly,Dammam,Saudi Arabia,FALSE
 1976-10-02,New Caledonia,New Zealand,2,1,Friendly,Nouméa,New Caledonia,FALSE
-1976-10-03,USA,Mexico,0,0,CONCACAF Championship qualification,Los Angeles,USA,FALSE
+1976-10-03,United States,Mexico,0,0,CONCACAF Championship qualification,Los Angeles,United States,FALSE
 1976-10-06,Chile,Uruguay,0,0,Copa Juan Pinto Durán,Santiago,Chile,FALSE
 1976-10-06,Czechoslovakia,Romania,3,2,Friendly,Prague,Czechoslovakia,FALSE
 1976-10-06,Wales,Germany,0,2,Friendly,Cardiff,Wales,FALSE
@@ -10095,7 +10095,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1976-10-13,Netherlands,Northern Ireland,2,2,FIFA World Cup qualification,Rotterdam,Netherlands,FALSE
 1976-10-13,Turkey,Republic of Ireland,3,3,Friendly,Ankara,Turkey,FALSE
 1976-10-15,Colombia,Uruguay,1,2,Friendly,Bogotá,Colombia,FALSE
-1976-10-15,Mexico,USA,3,0,CONCACAF Championship qualification,Puebla,Mexico,FALSE
+1976-10-15,Mexico,United States,3,0,CONCACAF Championship qualification,Puebla,Mexico,FALSE
 1976-10-16,Luxembourg,Italy,1,4,FIFA World Cup qualification,Luxembourg,Luxembourg,FALSE
 1976-10-16,Portugal,Poland,0,2,FIFA World Cup qualification,Porto,Portugal,FALSE
 1976-10-16,Sierra Leone,Nigeria,0,0,FIFA World Cup qualification,Freetown,Sierra Leone,FALSE
@@ -10104,7 +10104,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1976-10-20,Ecuador,Uruguay,2,2,Friendly,Quito,Ecuador,FALSE
 1976-10-20,Indonesia,Australia,1,1,Friendly,Jakarta,Indonesia,FALSE
 1976-10-20,Iraq,Libya,1,0,Friendly,Baghdad,Iraq,FALSE
-1976-10-20,USA,Canada,2,0,CONCACAF Championship qualification,Seattle,USA,FALSE
+1976-10-20,United States,Canada,2,0,CONCACAF Championship qualification,Seattle,United States,FALSE
 1976-10-22,Iraq,Libya,3,1,Friendly,Baghdad,Iraq,FALSE
 1976-10-22,Singapore,Australia,0,1,Friendly,Kallang,Singapore,FALSE
 1976-10-24,Hong Kong,Australia,0,2,Friendly,So Kon Po,Hong Kong,FALSE
@@ -10134,15 +10134,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1976-11-10,Argentina,Peru,1,0,Copa Ramón Castilla,Buenos Aires,Argentina,FALSE
 1976-11-10,Belgium,Northern Ireland,2,0,FIFA World Cup qualification,Liège,Belgium,FALSE
 1976-11-10,Greece,Austria,0,3,Friendly,Kavála,Greece,FALSE
-1976-11-10,Haiti,USA,0,0,Friendly,Port-au-Prince,Haiti,FALSE
+1976-11-10,Haiti,United States,0,0,Friendly,Port-au-Prince,Haiti,FALSE
 1976-11-10,Zanzibar,Somalia,1,0,CECAFA Cup,Zanzibar,Tanzania,FALSE
 1976-11-11,Uganda,Zambia,2,3,CECAFA Cup,Zanzibar,Tanzania,TRUE
-1976-11-12,Haiti,USA,0,0,Friendly,Port-au-Prince,Haiti,FALSE
+1976-11-12,Haiti,United States,0,0,Friendly,Port-au-Prince,Haiti,FALSE
 1976-11-12,Kenya,Zambia,0,2,CECAFA Cup,Zanzibar,Tanzania,TRUE
 1976-11-12,Malawi,Uganda,1,2,CECAFA Cup,Zanzibar,Tanzania,TRUE
 1976-11-12,Saudi Arabia,Syria,2,0,FIFA World Cup qualification,Jeddah,Saudi Arabia,FALSE
 1976-11-14,Ethiopia,Egypt,1,2,FIFA World Cup qualification,Addis Ababa,Ethiopia,FALSE
-1976-11-14,Haiti,USA,0,0,Friendly,Port-au-Prince,Haiti,FALSE
+1976-11-14,Haiti,United States,0,0,Friendly,Port-au-Prince,Haiti,FALSE
 1976-11-14,Suriname,Trinidad and Tobago,1,1,CONCACAF Championship qualification,Paramaribo,Suriname,FALSE
 1976-11-14,Uganda,Zambia,2,0,CECAFA Cup,Zanzibar,Tanzania,TRUE
 1976-11-16,Tanzania,Zambia,2,3,Friendly,Dar es Salaam,Tanzania,FALSE
@@ -10179,7 +10179,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1976-12-18,Suriname,Trinidad and Tobago,3,2,CONCACAF Championship qualification,Cayenne,French Guiana,TRUE
 1976-12-19,El Salvador,Guatemala,2,0,CONCACAF Championship qualification,San Salvador,El Salvador,FALSE
 1976-12-19,Thailand,Singapore,6,0,King's Cup,Bangkok,Thailand,FALSE
-1976-12-22,Canada,USA,3,0,CONCACAF Championship qualification,Port-au-Prince,Haiti,TRUE
+1976-12-22,Canada,United States,3,0,CONCACAF Championship qualification,Port-au-Prince,Haiti,TRUE
 1976-12-22,South Korea,Malaysia,1,1,King's Cup,Bangkok,Thailand,TRUE
 1976-12-22,Portugal,Italy,2,1,Friendly,Lisbon,Portugal,FALSE
 1976-12-23,Panama,Cuba,0,5,Friendly,Panama City,Panama,FALSE
@@ -10486,9 +10486,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1977-09-11,Trinidad and Tobago,Canada,1,1,Friendly,Pointe-à-Pierre,Trinidad and Tobago,FALSE
 1977-09-13,South Korea,Malaysia,3,0,Korea Cup,Seoul,South Korea,FALSE
 1977-09-14,China PR,Thailand,5,2,Friendly,Beijing,China PR,FALSE
-1977-09-15,El Salvador,USA,1,2,Friendly,San Salvador,El Salvador,FALSE
+1977-09-15,El Salvador,United States,1,2,Friendly,San Salvador,El Salvador,FALSE
 1977-09-15,Malaysia,Thailand,1,1,Korea Cup,Seoul,South Korea,TRUE
-1977-09-18,Guatemala,USA,3,1,Friendly,Guatemala,Guatemala,FALSE
+1977-09-18,Guatemala,United States,3,1,Friendly,Guatemala,Guatemala,FALSE
 1977-09-18,Réunion,Mauritius,0,2,Friendly,Saint-Pierre,Réunion,FALSE
 1977-09-18,Suriname,Trinidad and Tobago,2,1,Friendly,Paramaribo,Suriname,FALSE
 1977-09-20,Kuwait,Wales,0,0,Friendly,Kuwait City,Kuwait,FALSE
@@ -10503,14 +10503,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1977-09-24,Austria,German DR,1,1,FIFA World Cup qualification,Vienna,Austria,FALSE
 1977-09-24,Guyana,Trinidad and Tobago,2,2,Friendly,Georgetown,Guyana,FALSE
 1977-09-24,Libya,Malta,1,0,Friendly,Tripoli,Libya,FALSE
-1977-09-25,Guatemala,USA,2,0,Friendly,Guatemala,Guatemala,FALSE
+1977-09-25,Guatemala,United States,2,0,Friendly,Guatemala,Guatemala,FALSE
 1977-09-25,Réunion,Seychelles,1,0,Friendly,Saint-Pierre,Réunion,FALSE
 1977-09-25,Tunisia,Nigeria,0,0,FIFA World Cup qualification,Tunis,Tunisia,FALSE
 1977-09-26,Guyana,Trinidad and Tobago,0,2,Friendly,Georgetown,Guyana,FALSE
-1977-09-27,Mexico,USA,3,0,Friendly,Monterrey,Mexico,FALSE
+1977-09-27,Mexico,United States,3,0,Friendly,Monterrey,Mexico,FALSE
 1977-09-28,Libya,Cyprus,1,0,Friendly,Benghazi,Libya,FALSE
 1977-09-30,Botswana,Malawi,0,2,Friendly,Gaborone,Botswana,FALSE
-1977-09-30,USA,El Salvador,0,0,Friendly,Monterey Park,USA,FALSE
+1977-09-30,United States,El Salvador,0,0,Friendly,Monterey Park,United States,FALSE
 1977-10-01,Botswana,Malawi,1,5,Friendly,Gaborone,Botswana,FALSE
 1977-10-02,Tunisia,Guinea,3,0,African Cup of Nations qualification,Tunis,Tunisia,FALSE
 1977-10-02,Hong Kong,Kuwait,1,3,FIFA World Cup qualification,So Kon Po,Hong Kong,FALSE
@@ -10519,7 +10519,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1977-10-05,Netherlands,Russia,0,0,Friendly,Rotterdam,Netherlands,FALSE
 1977-10-05,Sweden,Denmark,1,0,Friendly,Malmö,Sweden,FALSE
 1977-10-05,Switzerland,Finland,2,0,Friendly,Zürich,Switzerland,FALSE
-1977-10-06,USA,China PR,1,1,Friendly,Washington,USA,FALSE
+1977-10-06,United States,China PR,1,1,Friendly,Washington,United States,FALSE
 1977-10-08,Canada,El Salvador,1,2,CONCACAF Championship,Monterrey,Mexico,TRUE
 1977-10-08,France,Russia,0,0,Friendly,Paris,France,FALSE
 1977-10-08,Germany,Italy,2,1,Friendly,Berlin,Germany,FALSE
@@ -10529,7 +10529,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1977-10-09,South Korea,Kuwait,1,0,FIFA World Cup qualification,Seoul,South Korea,FALSE
 1977-10-09,Mexico,Haiti,4,1,CONCACAF Championship,Mexico City,Mexico,FALSE
 1977-10-09,Zambia,India,3,1,Friendly,Ndola,Zambia,FALSE
-1977-10-10,USA,China PR,1,0,Friendly,Atlanta,USA,FALSE
+1977-10-10,United States,China PR,1,0,Friendly,Atlanta,United States,FALSE
 1977-10-12,Canada,Suriname,2,1,CONCACAF Championship,Mexico City,Mexico,TRUE
 1977-10-12,German DR,Austria,1,1,FIFA World Cup qualification,Leipzig,German DR,FALSE
 1977-10-12,Guatemala,Haiti,1,2,CONCACAF Championship,Monterrey,Mexico,TRUE
@@ -10545,7 +10545,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1977-10-16,Australia,Kuwait,1,2,FIFA World Cup qualification,Sydney,Australia,FALSE
 1977-10-16,Canada,Guatemala,2,1,CONCACAF Championship,Mexico City,Mexico,TRUE
 1977-10-16,El Salvador,Haiti,0,1,CONCACAF Championship,Mexico City,Mexico,TRUE
-1977-10-16,USA,China PR,2,1,Friendly,San Francisco,USA,FALSE
+1977-10-16,United States,China PR,2,1,Friendly,San Francisco,United States,FALSE
 1977-10-19,Mexico,Guatemala,2,1,CONCACAF Championship,Mexico City,Mexico,FALSE
 1977-10-20,Canada,Haiti,1,1,CONCACAF Championship,Monterrey,Mexico,TRUE
 1977-10-20,El Salvador,Suriname,3,2,CONCACAF Championship,Monterrey,Mexico,TRUE
@@ -10692,7 +10692,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1978-04-05,Poland,Greece,5,2,Friendly,Poznań,Poland,FALSE
 1978-04-05,Russia,Finland,10,2,Friendly,Yerevan,Soviet Union,FALSE
 1978-04-05,Tunisia,Netherlands,0,4,Friendly,Tunis,Tunisia,FALSE
-1978-04-11,Mexico,Peru,0,1,Friendly,Los Angeles,USA,TRUE
+1978-04-11,Mexico,Peru,0,1,Friendly,Los Angeles,United States,TRUE
 1978-04-12,Poland,Republic of Ireland,3,0,Friendly,Łódź,Poland,FALSE
 1978-04-15,Hungary,Czechoslovakia,2,1,Friendly,Budapest,Hungary,FALSE
 1978-04-16,Martinique,Puerto Rico,3,1,Friendly,Fort-de-France,Martinique,FALSE
@@ -10852,12 +10852,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1978-09-01,France,Sweden,2,2,UEFA Euro qualification,Paris,France,FALSE
 1978-09-02,French Guiana,Trinidad and Tobago,1,4,CFU Caribbean Cup qualification,Cayenne,French Guiana,FALSE
 1978-09-03,China PR,Congo,1,0,Beijing International Friendship Tournament,Beijing,China PR,FALSE
-1978-09-03,Iceland,USA,0,0,Friendly,Reykjavík,Iceland,FALSE
+1978-09-03,Iceland,United States,0,0,Friendly,Reykjavík,Iceland,FALSE
 1978-09-06,German DR,Czechoslovakia,2,1,Friendly,Leipzig,German DR,FALSE
 1978-09-06,Iceland,Poland,0,2,UEFA Euro qualification,Reykjavík,Iceland,FALSE
 1978-09-06,Iran,Russia,0,1,Friendly,Tehran,Iran,FALSE
 1978-09-06,Eswatini,Zambia,1,6,Friendly,Lobamba,Eswatini,FALSE
-1978-09-06,Switzerland,USA,2,0,Friendly,Lucerne,Switzerland,FALSE
+1978-09-06,Switzerland,United States,2,0,Friendly,Lucerne,Switzerland,FALSE
 1978-09-07,Eswatini,Zambia,2,5,Friendly,Lobamba,Eswatini,FALSE
 1978-09-09,Bahrain,Malaysia,1,2,Korea Cup,Seoul,South Korea,TRUE
 1978-09-09,French Guiana,Martinique,4,2,Friendly,Cayenne,French Guiana,FALSE
@@ -10875,7 +10875,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1978-09-20,Italy,Bulgaria,1,0,Friendly,Turin,Italy,FALSE
 1978-09-20,Libya,Yemen DPR,2,0,Friendly,Tripoli,Libya,FALSE
 1978-09-20,Netherlands,Iceland,3,0,UEFA Euro qualification,Nijmegen,Netherlands,FALSE
-1978-09-20,Portugal,USA,1,0,Friendly,Setúbal,Portugal,FALSE
+1978-09-20,Portugal,United States,1,0,Friendly,Setúbal,Portugal,FALSE
 1978-09-20,Russia,Greece,2,0,UEFA Euro qualification,Yerevan,Soviet Union,FALSE
 1978-09-23,Italy,Turkey,1,0,Friendly,Florence,Italy,FALSE
 1978-09-23,Réunion,Mauritius,0,2,Friendly,Saint-Denis,Réunion,FALSE
@@ -11074,7 +11074,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1979-05-02,North Korea,Hong Kong,3,0,AFC Asian Cup qualification,Bangkok,Thailand,TRUE
 1979-05-02,Northern Ireland,Bulgaria,2,0,UEFA Euro qualification,Belfast,Northern Ireland,FALSE
 1979-05-02,Poland,Netherlands,2,0,UEFA Euro qualification,Chorzów,Poland,FALSE
-1979-05-02,USA,France,0,6,Friendly,East Rutherford,USA,FALSE
+1979-05-02,United States,France,0,6,Friendly,East Rutherford,United States,FALSE
 1979-05-02,Wales,Germany,0,2,UEFA Euro qualification,Wrexham,Wales,FALSE
 1979-05-05,Russia,Czechoslovakia,3,0,Friendly,Moscow,Soviet Union,FALSE
 1979-05-05,Saint Vincent and the Grenadines,Martinique,2,2,CFU Caribbean Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
@@ -11283,10 +11283,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1979-09-29,Senegal,Nigeria,0,2,Friendly,Dakar,Senegal,FALSE
 1979-09-29,Sierra Leone,Gambia,2,0,Friendly,Freetown,Sierra Leone,FALSE
 1979-10-03,Bahrain,New Zealand,0,2,Friendly,Isa Town,Bahrain,FALSE
-1979-10-07,Bermuda,USA,1,3,Friendly,Hamilton,Bermuda,FALSE
+1979-10-07,Bermuda,United States,1,3,Friendly,Hamilton,Bermuda,FALSE
 1979-10-08,Bahrain,New Zealand,1,2,Friendly,Isa Town,Bahrain,FALSE
 1979-10-10,Czechoslovakia,Sweden,4,1,UEFA Euro qualification,Prague,Czechoslovakia,FALSE
-1979-10-10,France,USA,3,0,Friendly,Paris,France,FALSE
+1979-10-10,France,United States,3,0,Friendly,Paris,France,FALSE
 1979-10-10,Peru,Paraguay,2,3,Friendly,Lima,Peru,FALSE
 1979-10-10,Poland,Iceland,2,0,UEFA Euro qualification,Kraków,Poland,FALSE
 1979-10-10,Spain,Yugoslavia,0,1,UEFA Euro qualification,Valencia,Spain,FALSE
@@ -11312,7 +11312,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1979-10-24,Chile,Peru,0,0,Copa América,Santiago,Chile,FALSE
 1979-10-24,Paraguay,Brazil,2,1,Copa América,Asunción,Paraguay,FALSE
 1979-10-25,Liberia,Nigeria,2,2,Friendly,Monrovia,Liberia,FALSE
-1979-10-26,Hungary,USA,0,2,Friendly,Budapest,Hungary,FALSE
+1979-10-26,Hungary,United States,0,2,Friendly,Budapest,Hungary,FALSE
 1979-10-26,Ivory Coast,Benin,3,1,Friendly,Abidjan,Ivory Coast,FALSE
 1979-10-26,Niger,Togo,2,2,Friendly,Abidjan,Ivory Coast,TRUE
 1979-10-27,Sierra Leone,Nigeria,0,0,Friendly,Freetown,Sierra Leone,FALSE
@@ -11320,7 +11320,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1979-10-28,Haiti,Jamaica,3,0,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
 1979-10-28,Ivory Coast,Togo,0,1,Friendly,Abidjan,Ivory Coast,FALSE
 1979-10-28,Malta,Turkey,1,2,UEFA Euro qualification,Gżira,Malta,FALSE
-1979-10-29,Republic of Ireland,USA,3,2,Friendly,Dublin,Republic of Ireland,FALSE
+1979-10-29,Republic of Ireland,United States,3,2,Friendly,Dublin,Republic of Ireland,FALSE
 1979-10-31,Brazil,Paraguay,2,2,Copa América,Rio de Janeiro,Brazil,FALSE
 1979-10-31,Bulgaria,Denmark,3,0,UEFA Euro qualification,Sofia,Bulgaria,FALSE
 1979-10-31,Russia,Finland,2,2,UEFA Euro qualification,Moscow,Soviet Union,FALSE
@@ -11423,7 +11423,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1980-02-25,Morocco,Senegal,3,2,Friendly,Casablanca,Morocco,FALSE
 1980-02-25,New Zealand,Tahiti,1,3,Oceania Nations Cup,Nouméa,New Caledonia,TRUE
 1980-02-26,Australia,Papua New Guinea,11,2,Oceania Nations Cup,Nouméa,New Caledonia,TRUE
-1980-02-26,Mexico,South Korea,0,1,Friendly,Los Angeles,USA,TRUE
+1980-02-26,Mexico,South Korea,0,1,Friendly,Los Angeles,United States,TRUE
 1980-02-26,New Caledonia,Vanuatu,4,3,Oceania Nations Cup,Nouméa,New Caledonia,FALSE
 1980-02-27,Belgium,Luxembourg,5,0,Friendly,Brussels,Belgium,FALSE
 1980-02-27,Fiji,New Zealand,4,0,Oceania Nations Cup,Nouméa,New Caledonia,TRUE
@@ -11714,9 +11714,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1980-10-01,Turkey,Libya,1,2,Friendly,İzmir,Turkey,FALSE
 1980-10-03,Turkey,Saudi Arabia,3,0,Friendly,İzmir,Turkey,FALSE
 1980-10-04,Libya,Saudi Arabia,2,0,Friendly,İzmir,Turkey,TRUE
-1980-10-04,Luxembourg,USA,0,2,Friendly,Luxembourg,Luxembourg,FALSE
+1980-10-04,Luxembourg,United States,0,2,Friendly,Luxembourg,Luxembourg,FALSE
 1980-10-05,El Salvador,Panama,4,1,CONCACAF Championship qualification,San Salvador,El Salvador,FALSE
-1980-10-07,Portugal,USA,1,1,Friendly,Lisbon,Portugal,FALSE
+1980-10-07,Portugal,United States,1,1,Friendly,Lisbon,Portugal,FALSE
 1980-10-08,Austria,Hungary,3,1,Friendly,Vienna,Austria,FALSE
 1980-10-08,Czechoslovakia,German DR,0,1,Friendly,Prague,Czechoslovakia,FALSE
 1980-10-09,Argentina,Bulgaria,2,0,Friendly,Buenos Aires,Argentina,FALSE
@@ -11759,7 +11759,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1980-10-24,Trinidad and Tobago,Guyana,2,0,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 1980-10-25,Kuwait,Indonesia,1,2,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1980-10-25,Liberia,Mali,1,1,Friendly,Monrovia,Liberia,FALSE
-1980-10-25,USA,Canada,0,0,CONCACAF Championship qualification,Fort Lauderdale,USA,FALSE
+1980-10-25,United States,Canada,0,0,CONCACAF Championship qualification,Fort Lauderdale,United States,FALSE
 1980-10-26,Honduras,Guatemala,0,0,CONCACAF Championship qualification,Tegucigalpa,Honduras,FALSE
 1980-10-26,Indonesia,Thailand,1,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1980-10-26,Malawi,Zimbabwe,0,1,African Cup of Nations qualification,Blantyre,Malawi,FALSE
@@ -11775,7 +11775,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1980-10-30,Myanmar,South Korea,1,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1980-10-30,Brazil,Paraguay,6,0,Friendly,Goiânia,Brazil,FALSE
 1980-10-31,Myanmar,Indonesia,1,0,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
-1980-11-01,Canada,USA,2,1,CONCACAF Championship qualification,Vancouver,Canada,FALSE
+1980-11-01,Canada,United States,2,1,CONCACAF Championship qualification,Vancouver,Canada,FALSE
 1980-11-01,Italy,Denmark,2,0,FIFA World Cup qualification,Rome,Italy,FALSE
 1980-11-01,Tanzania,Madagascar,0,0,Friendly,Dar es Salaam,Tanzania,FALSE
 1980-11-01,Zambia,Angola,0,0,Friendly,Lusaka,Zambia,FALSE
@@ -11787,7 +11787,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1980-11-09,Guatemala,El Salvador,0,0,CONCACAF Championship qualification,Guatemala,Guatemala,FALSE
 1980-11-09,Honduras,Canada,2,0,Friendly,Tegucigalpa,Honduras,FALSE
 1980-11-09,Liberia,Gambia,0,0,African Cup of Nations qualification,Monrovia,Liberia,FALSE
-1980-11-09,Mexico,USA,5,1,CONCACAF Championship qualification,Mexico City,Mexico,FALSE
+1980-11-09,Mexico,United States,5,1,CONCACAF Championship qualification,Mexico City,Mexico,FALSE
 1980-11-09,Senegal,Mauritania,3,0,Friendly,Dakar,Senegal,FALSE
 1980-11-09,Trinidad and Tobago,Curaçao,0,0,CONCACAF Championship qualification,Port of Spain,Trinidad and Tobago,FALSE
 1980-11-09,Zimbabwe,Malawi,1,1,African Cup of Nations qualification,Salisbury,Zimbabwe,FALSE
@@ -11829,7 +11829,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1980-11-23,El Salvador,Honduras,2,1,CONCACAF Championship qualification,San Salvador,El Salvador,FALSE
 1980-11-23,Gambia,Liberia,1,1,African Cup of Nations qualification,Banjul,Gambia,FALSE
 1980-11-23,Guinea,DR Congo,2,1,Friendly,Conakry,Guinea,FALSE
-1980-11-23,USA,Mexico,2,1,CONCACAF Championship qualification,Fort Lauderdale,USA,FALSE
+1980-11-23,United States,Mexico,2,1,CONCACAF Championship qualification,Fort Lauderdale,United States,FALSE
 1980-11-24,Malawi,Tanzania,0,1,CECAFA Cup,Khartoum,Sudan,TRUE
 1980-11-25,Singapore,Western Australia,1,1,King's Cup,Bangkok,Thailand,TRUE
 1980-11-26,Costa Rica,Guatemala,0,3,CONCACAF Championship qualification,San José,Costa Rica,FALSE
@@ -12455,7 +12455,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1982-03-20,Bahrain,Kuwait,0,2,Gulf Cup,Abu Dhabi,United Arab Emirates,TRUE
 1982-03-21,Brazil,Germany,1,0,Friendly,Rio de Janeiro,Brazil,FALSE
 1982-03-21,South Korea,Japan,3,0,Friendly,Seoul,South Korea,FALSE
-1982-03-21,Trinidad and Tobago,USA,1,2,Friendly,Port of Spain,Trinidad and Tobago,FALSE
+1982-03-21,Trinidad and Tobago,United States,1,2,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 1982-03-21,United Arab Emirates,Saudi Arabia,1,0,Gulf Cup,Abu Dhabi,United Arab Emirates,FALSE
 1982-03-22,Oman,Qatar,0,3,Gulf Cup,Abu Dhabi,United Arab Emirates,TRUE
 1982-03-23,Chile,Peru,2,1,Friendly,Santiago,Chile,FALSE
@@ -12811,9 +12811,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1983-04-03,Congo,Angola,1,0,Friendly,Brazzaville,Congo,FALSE
 1983-04-03,Ethiopia,Uganda,2,1,Friendly,Addis Ababa,Ethiopia,FALSE
 1983-04-03,Mozambique,Cameroon,3,0,African Cup of Nations qualification,Maputo,Mozambique,FALSE
-1983-04-05,Guatemala,Mexico,0,2,Friendly,Los Angeles,USA,TRUE
+1983-04-05,Guatemala,Mexico,0,2,Friendly,Los Angeles,United States,TRUE
 1983-04-08,Algeria,Benin,6,2,African Cup of Nations qualification,Algiers,Algeria,FALSE
-1983-04-08,Haiti,USA,0,2,Friendly,Port-au-Prince,Haiti,FALSE
+1983-04-08,Haiti,United States,0,2,Friendly,Port-au-Prince,Haiti,FALSE
 1983-04-08,Libya,Senegal,2,1,African Cup of Nations qualification,Tripoli,Libya,FALSE
 1983-04-09,Nigeria,Angola,2,0,African Cup of Nations qualification,Lagos,Nigeria,FALSE
 1983-04-10,Congo,Egypt,2,0,African Cup of Nations qualification,Brazzaville,Congo,FALSE
@@ -12964,7 +12964,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1983-07-25,Gambia,Guinea-Bissau,2,2,Amílcar Cabral Cup,Nouakchott,Mauritania,TRUE
 1983-07-25,Martinique,Trinidad and Tobago,3,1,CFU Caribbean Cup,Cayenne,French Guiana,TRUE
 1983-07-26,Ecuador,Colombia,0,0,Friendly,Quito,Ecuador,FALSE
-1983-07-26,El Salvador,Guatemala,0,0,Friendly,Los Angeles,USA,TRUE
+1983-07-26,El Salvador,Guatemala,0,0,Friendly,Los Angeles,United States,TRUE
 1983-07-26,German DR,Russia,1,3,Friendly,Leipzig,German DR,FALSE
 1983-07-27,Antigua and Barbuda,Trinidad and Tobago,1,2,CFU Caribbean Cup,Cayenne,French Guiana,TRUE
 1983-07-27,French Guiana,Martinique,0,0,CFU Caribbean Cup,Cayenne,French Guiana,FALSE
@@ -12974,7 +12974,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1983-07-28,Chile,Brazil,0,0,Friendly,Santiago,Chile,FALSE
 1983-07-28,Mauritania,Mali,0,2,Amílcar Cabral Cup,Nouakchott,Mauritania,FALSE
 1983-07-29,Colombia,Ecuador,0,0,Friendly,Bogotá,Colombia,FALSE
-1983-07-29,Guatemala,South Korea,1,1,Friendly,Los Angeles,USA,TRUE
+1983-07-29,Guatemala,South Korea,1,1,Friendly,Los Angeles,United States,TRUE
 1983-07-29,Guinea-Bissau,Senegal,0,3,Amílcar Cabral Cup,Nouakchott,Mauritania,TRUE
 1983-07-31,Panama,Cuba,1,0,Friendly,La Chorrera,Panama,FALSE
 1983-08-02,Congo,Cameroon,2,2,Friendly,Brazzaville,Congo,FALSE
@@ -13108,7 +13108,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1983-10-20,Uruguay,Peru,1,1,Copa América,Montevideo,Uruguay,FALSE
 1983-10-22,Tanzania,Malawi,1,1,Friendly,Dodoma,Tanzania,FALSE
 1983-10-24,Tanzania,Malawi,0,0,Friendly,Dar es Salaam,Tanzania,FALSE
-1983-10-25,El Salvador,Mexico,0,5,Friendly,Los Angeles,USA,TRUE
+1983-10-25,El Salvador,Mexico,0,5,Friendly,Los Angeles,United States,TRUE
 1983-10-26,Czechoslovakia,Bulgaria,1,2,Friendly,Prague,Czechoslovakia,FALSE
 1983-10-26,Germany,Turkey,5,1,UEFA Euro qualification,Berlin,Germany,FALSE
 1983-10-26,Hungary,Denmark,1,0,UEFA Euro qualification,Budapest,Hungary,FALSE
@@ -13342,7 +13342,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1984-05-26,Switzerland,Spain,0,4,Friendly,Geneva,Switzerland,FALSE
 1984-05-27,Finland,Northern Ireland,1,0,FIFA World Cup qualification,Pori,Finland,FALSE
 1984-05-29,El Salvador,Panama,2,1,Friendly,San Salvador,El Salvador,FALSE
-1984-05-30,USA,Italy,0,0,Friendly,East Rutherford,USA,FALSE
+1984-05-30,United States,Italy,0,0,Friendly,East Rutherford,United States,FALSE
 1984-05-31,Hungary,Spain,1,1,Friendly,Budapest,Hungary,FALSE
 1984-05-31,Japan,China PR,1,0,Kirin Cup,Saitama,Japan,FALSE
 1984-06-01,France,Scotland,2,0,Friendly,Marseille,France,FALSE
@@ -13516,7 +13516,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1984-09-26,Italy,Sweden,1,0,Friendly,Milan,Italy,FALSE
 1984-09-26,Poland,Turkey,2,0,Friendly,Słupsk,Poland,FALSE
 1984-09-26,Tunisia,Nigeria,5,0,Friendly,Tunis,Tunisia,FALSE
-1984-09-29,Curaçao,USA,0,0,CONCACAF Championship qualification,Willemstad,Netherlands Antilles,TRUE
+1984-09-29,Curaçao,United States,0,0,CONCACAF Championship qualification,Willemstad,Netherlands Antilles,TRUE
 1984-09-29,Yugoslavia,Bulgaria,0,0,FIFA World Cup qualification,Belgrade,Yugoslavia,FALSE
 1984-09-30,Botswana,Angola,1,3,Friendly,Gaborone,Botswana,FALSE
 1984-09-30,South Korea,Japan,1,2,Friendly,Seoul,South Korea,FALSE
@@ -13525,25 +13525,25 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1984-10-03,Honduras,Guatemala,1,0,Friendly,Tegucigalpa,Honduras,FALSE
 1984-10-03,Peru,Uruguay,1,3,Friendly,Lima,Peru,FALSE
 1984-10-04,South Korea,Cameroon,5,0,Friendly,Seoul,South Korea,FALSE
-1984-10-06,USA,Curaçao,4,0,CONCACAF Championship qualification,St. Louis,USA,FALSE
+1984-10-06,United States,Curaçao,4,0,CONCACAF Championship qualification,St. Louis,United States,FALSE
 1984-10-08,Saudi Arabia,Thailand,2,1,Friendly,Jeddah,Saudi Arabia,FALSE
 1984-10-09,Greece,Israel,2,2,Friendly,Athens,Greece,FALSE
-1984-10-09,Mexico,Colombia,1,0,Friendly,Los Angeles,USA,TRUE
-1984-10-09,USA,El Salvador,3,1,Friendly,Los Angeles,USA,FALSE
+1984-10-09,Mexico,Colombia,1,0,Friendly,Los Angeles,United States,TRUE
+1984-10-09,United States,El Salvador,3,1,Friendly,Los Angeles,United States,FALSE
 1984-10-10,German DR,Algeria,5,2,Friendly,Aue,German DR,FALSE
 1984-10-10,South Korea,Yemen,6,0,AFC Asian Cup qualification,Calcutta,India,TRUE
 1984-10-10,Norway,Russia,1,1,FIFA World Cup qualification,Oslo,Norway,FALSE
 1984-10-10,Saudi Arabia,Thailand,1,3,Friendly,Jeddah,Saudi Arabia,FALSE
-1984-10-11,El Salvador,Mexico,0,1,Friendly,Los Angeles,USA,TRUE
+1984-10-11,El Salvador,Mexico,0,1,Friendly,Los Angeles,United States,TRUE
 1984-10-11,Ivory Coast,Liberia,3,0,Friendly,Abidjan,Ivory Coast,FALSE
 1984-10-11,Malaysia,Pakistan,5,0,AFC Asian Cup qualification,Calcutta,India,TRUE
-1984-10-11,USA,Colombia,1,0,Friendly,Los Angeles,USA,FALSE
+1984-10-11,United States,Colombia,1,0,Friendly,Los Angeles,United States,FALSE
 1984-10-12,India,Yemen,4,0,AFC Asian Cup qualification,Calcutta,India,FALSE
 1984-10-13,Kenya,Ethiopia,2,1,FIFA World Cup qualification,Nairobi,Kenya,FALSE
 1984-10-13,South Korea,Pakistan,6,0,AFC Asian Cup qualification,Calcutta,India,TRUE
 1984-10-13,Luxembourg,France,0,4,FIFA World Cup qualification,Luxembourg,Luxembourg,FALSE
 1984-10-13,Tanzania,Sudan,1,1,FIFA World Cup qualification,Mwanza,Tanzania,FALSE
-1984-10-14,Guatemala,USA,4,0,Friendly,Guatemala,Guatemala,FALSE
+1984-10-14,Guatemala,United States,4,0,Friendly,Guatemala,Guatemala,FALSE
 1984-10-14,India,Malaysia,2,1,AFC Asian Cup qualification,Calcutta,India,FALSE
 1984-10-14,Portugal,Czechoslovakia,2,1,FIFA World Cup qualification,Porto,Portugal,FALSE
 1984-10-14,Zimbabwe,Eswatini,3,0,African Cup of Nations qualification,Bulawayo,Zimbabwe,FALSE
@@ -13557,7 +13557,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1984-10-17,England,Finland,5,0,FIFA World Cup qualification,London,England,FALSE
 1984-10-17,Germany,Sweden,2,0,FIFA World Cup qualification,Cologne,Germany,FALSE
 1984-10-17,India,Pakistan,2,0,AFC Asian Cup qualification,Calcutta,India,FALSE
-1984-10-17,Mexico,USA,2,1,Friendly,Nezahualcóyotl,Mexico,FALSE
+1984-10-17,Mexico,United States,2,1,Friendly,Nezahualcóyotl,Mexico,FALSE
 1984-10-17,Netherlands,Hungary,1,2,FIFA World Cup qualification,Rotterdam,Netherlands,FALSE
 1984-10-17,Norway,Republic of Ireland,1,0,FIFA World Cup qualification,Oslo,Norway,FALSE
 1984-10-17,Poland,Greece,3,1,FIFA World Cup qualification,Zabrze,Poland,FALSE
@@ -13641,7 +13641,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1984-11-27,Benin,Ghana,1,3,West African Cup,Ouagadougou,Burkina Faso,TRUE
 1984-11-28,Burkina Faso,Ivory Coast,0,2,West African Cup,Ouagadougou,Burkina Faso,FALSE
 1984-11-28,Ghana,Togo,1,1,West African Cup,Ouagadougou,Burkina Faso,TRUE
-1984-11-30,USA,Ecuador,0,0,Friendly,Hempstead,USA,FALSE
+1984-11-30,United States,Ecuador,0,0,Friendly,Hempstead,United States,FALSE
 1984-12-01,Iran,United Arab Emirates,3,0,AFC Asian Cup,Kallang,Singapore,TRUE
 1984-12-01,Qatar,Syria,1,1,AFC Asian Cup,Kallang,Singapore,TRUE
 1984-12-01,Uganda,Tanzania,1,1,CECAFA Cup,Kampala,Uganda,FALSE
@@ -13652,13 +13652,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1984-12-02,Sierra Leone,Gambia,2,0,African Cup of Nations qualification,Freetown,Sierra Leone,FALSE
 1984-12-02,Singapore,India,2,0,AFC Asian Cup,Kallang,Singapore,FALSE
 1984-12-02,Saint Lucia,Saint Vincent and the Grenadines,2,0,Windward Islands Tournament,Castries,Saint Lucia,FALSE
-1984-12-02,USA,Ecuador,2,2,Friendly,Miami,USA,FALSE
+1984-12-02,United States,Ecuador,2,2,Friendly,Miami,United States,FALSE
 1984-12-02,Zambia,Zimbabwe,2,0,CECAFA Cup,Kampala,Uganda,TRUE
 1984-12-03,China PR,Iran,0,2,AFC Asian Cup,Kallang,Singapore,TRUE
 1984-12-03,Kuwait,Qatar,1,0,AFC Asian Cup,Kallang,Singapore,TRUE
 1984-12-03,Somalia,Zanzibar,2,1,CECAFA Cup,Mbale,Uganda,TRUE
-1984-12-04,El Salvador,Guatemala,2,1,Friendly,Los Angeles,USA,TRUE
-1984-12-04,Mexico,Ecuador,3,2,Friendly,Los Angeles,USA,TRUE
+1984-12-04,El Salvador,Guatemala,2,1,Friendly,Los Angeles,United States,TRUE
+1984-12-04,Mexico,Ecuador,3,2,Friendly,Los Angeles,United States,TRUE
 1984-12-04,Syria,Saudi Arabia,0,1,AFC Asian Cup,Kallang,Singapore,TRUE
 1984-12-04,Uganda,Zimbabwe,4,1,CECAFA Cup,Kampala,Uganda,FALSE
 1984-12-04,United Arab Emirates,India,2,0,AFC Asian Cup,Kallang,Singapore,TRUE
@@ -13763,7 +13763,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-02-06,Ecuador,German DR,2,3,Friendly,Guayaquil,Ecuador,FALSE
 1985-02-06,Mexico,Switzerland,1,2,Friendly,Querétaro,Mexico,FALSE
 1985-02-08,Chile,Finland,2,0,Friendly,Viña del Mar,Chile,FALSE
-1985-02-08,USA,Switzerland,1,1,Friendly,Tampa,USA,FALSE
+1985-02-08,United States,Switzerland,1,1,Friendly,Tampa,United States,FALSE
 1985-02-10,Colombia,Poland,1,2,Friendly,Bogotá,Colombia,FALSE
 1985-02-10,Ecuador,German DR,3,2,Friendly,Quito,Ecuador,FALSE
 1985-02-10,Guinea,Tunisia,1,0,FIFA World Cup qualification,Conakry,Guinea,FALSE
@@ -13898,7 +13898,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-03-31,Togo,Senegal,0,1,African Cup of Nations qualification,Tsévié,Togo,FALSE
 1985-03-31,Malawi,Mozambique,1,1,African Cup of Nations qualification,Lilongwe,Malawi,FALSE
 1985-04-02,Bangladesh,Indonesia,2,1,FIFA World Cup qualification,Dhaka,Bangladesh,FALSE
-1985-04-02,Canada,USA,2,0,Friendly,Vancouver,Canada,FALSE
+1985-04-02,Canada,United States,2,0,Friendly,Vancouver,Canada,FALSE
 1985-04-02,Syria,United Arab Emirates,2,1,Friendly,Manama,Bahrain,TRUE
 1985-04-03,Guadeloupe,Trinidad and Tobago,1,1,CFU Caribbean Cup qualification,Basse-Terre,Guadeloupe,FALSE
 1985-04-03,Hungary,Cyprus,2,0,FIFA World Cup qualification,Budapest,Hungary,FALSE
@@ -13906,7 +13906,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-04-03,Malta,Jordan,3,1,Friendly,Attard,Malta,FALSE
 1985-04-03,Romania,Turkey,3,0,FIFA World Cup qualification,Craiova,Romania,FALSE
 1985-04-03,Yugoslavia,France,0,0,FIFA World Cup qualification,Sarajevo,Yugoslavia,FALSE
-1985-04-04,USA,Canada,1,1,Friendly,Portland,USA,FALSE
+1985-04-04,United States,Canada,1,1,Friendly,Portland,United States,FALSE
 1985-04-05,Bahrain,United Arab Emirates,3,2,Friendly,Manama,Bahrain,FALSE
 1985-04-05,Bangladesh,Thailand,1,0,FIFA World Cup qualification,Dhaka,Bangladesh,FALSE
 1985-04-05,Egypt,Madagascar,1,0,FIFA World Cup qualification,Cairo,Egypt,FALSE
@@ -14011,13 +14011,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-05-14,Hungary,Netherlands,0,1,FIFA World Cup qualification,Budapest,Hungary,FALSE
 1985-05-15,Colombia,Brazil,1,0,Friendly,Bogotá,Colombia,FALSE
 1985-05-15,Guatemala,Haiti,4,0,CONCACAF Championship,Guatemala,Guatemala,FALSE
-1985-05-15,USA,Trinidad and Tobago,2,1,CONCACAF Championship,St. Louis,USA,FALSE
+1985-05-15,United States,Trinidad and Tobago,2,1,CONCACAF Championship,St. Louis,United States,FALSE
 1985-05-18,German DR,Luxembourg,3,1,FIFA World Cup qualification,Potsdam,German DR,FALSE
 1985-05-18,Japan,Singapore,5,0,FIFA World Cup qualification,Tokyo,Japan,FALSE
 1985-05-19,China PR,Hong Kong,1,2,FIFA World Cup qualification,Beijing,China PR,FALSE
 1985-05-19,Greece,Poland,1,4,FIFA World Cup qualification,Athens,Greece,FALSE
 1985-05-19,South Korea,Malaysia,2,0,FIFA World Cup qualification,Seoul,South Korea,FALSE
-1985-05-19,USA,Trinidad and Tobago,1,0,CONCACAF Championship,Torrance,USA,FALSE
+1985-05-19,United States,Trinidad and Tobago,1,0,CONCACAF Championship,Torrance,United States,FALSE
 1985-05-21,Chile,Brazil,2,1,Friendly,Santiago,Chile,FALSE
 1985-05-22,Finland,England,1,1,FIFA World Cup qualification,Helsinki,Finland,FALSE
 1985-05-22,Sweden,Norway,1,0,Friendly,Gothenburg,Sweden,FALSE
@@ -14025,13 +14025,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-05-25,Scotland,England,1,0,Rous Cup,Glasgow,Scotland,FALSE
 1985-05-26,Bolivia,Paraguay,1,1,FIFA World Cup qualification,Santa Cruz,Bolivia,FALSE
 1985-05-26,Colombia,Peru,1,0,FIFA World Cup qualification,Bogotá,Colombia,FALSE
-1985-05-26,Costa Rica,USA,1,1,CONCACAF Championship,Alajuela,Costa Rica,FALSE
+1985-05-26,Costa Rica,United States,1,1,CONCACAF Championship,Alajuela,Costa Rica,FALSE
 1985-05-26,Japan,Uruguay,1,4,Kirin Cup,Tokyo,Japan,FALSE
 1985-05-26,Republic of Ireland,Spain,0,0,Friendly,Cork,Republic of Ireland,FALSE
 1985-05-26,Venezuela,Argentina,2,3,FIFA World Cup qualification,San Cristóbal,Venezuela,FALSE
 1985-05-28,Iceland,Scotland,0,1,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
 1985-05-30,Albania,Poland,0,1,FIFA World Cup qualification,Tirana,Albania,FALSE
-1985-05-31,USA,Costa Rica,0,1,CONCACAF Championship,Torrance,USA,FALSE
+1985-05-31,United States,Costa Rica,0,1,CONCACAF Championship,Torrance,United States,FALSE
 1985-06-01,Bulgaria,Yugoslavia,2,1,FIFA World Cup qualification,Sofia,Bulgaria,FALSE
 1985-06-01,Hong Kong,Macau,2,0,Friendly,Siu Sai Wan,Hong Kong,FALSE
 1985-06-02,Bolivia,Brazil,0,2,FIFA World Cup qualification,Santa Cruz,Bolivia,FALSE
@@ -14065,7 +14065,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-06-16,Argentina,Colombia,1,0,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
 1985-06-16,Paraguay,Brazil,0,2,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 1985-06-16,Peru,Venezuela,4,1,FIFA World Cup qualification,Lima,Peru,FALSE
-1985-06-16,USA,England,0,5,Friendly,Los Angeles,USA,FALSE
+1985-06-16,United States,England,0,5,Friendly,Los Angeles,United States,FALSE
 1985-06-19,Nigeria,Ivory Coast,2,0,Friendly,Lagos,Nigeria,FALSE
 1985-06-23,Brazil,Paraguay,1,1,FIFA World Cup qualification,Rio de Janeiro,Brazil,FALSE
 1985-06-23,Ivory Coast,Nigeria,1,1,Friendly,Abidjan,Ivory Coast,FALSE
@@ -14140,7 +14140,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-08-25,Honduras,Canada,0,1,CONCACAF Championship,Tegucigalpa,Honduras,FALSE
 1985-08-25,Mali,Guinea,1,1,Friendly,Bamako,Mali,FALSE
 1985-08-25,Morocco,DR Congo,1,0,African Cup of Nations qualification,Casablanca,Morocco,FALSE
-1985-08-27,Mexico,Bulgaria,1,1,Friendly,Los Angeles,USA,TRUE
+1985-08-27,Mexico,Bulgaria,1,1,Friendly,Los Angeles,United States,TRUE
 1985-08-28,Romania,Finland,2,0,FIFA World Cup qualification,Timişoara,Romania,FALSE
 1985-08-28,Russia,Germany,1,0,Friendly,Moscow,Soviet Union,FALSE
 1985-08-28,Switzerland,Turkey,0,0,Friendly,St. Gallen,Switzerland,FALSE
@@ -14166,12 +14166,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-09-15,Mozambique,Libya,2,1,African Cup of Nations qualification,Maputo,Mozambique,FALSE
 1985-09-16,Papua New Guinea,China PR,1,4,Friendly,Lae,Papua New Guinea,FALSE
 1985-09-19,Papua New Guinea,China PR,1,1,Friendly,Port Moresby,Papua New Guinea,FALSE
-1985-09-20,Mexico,Peru,0,0,Friendly,Los Angeles,USA,TRUE
+1985-09-20,Mexico,Peru,0,0,Friendly,Los Angeles,United States,TRUE
 1985-09-20,Syria,Bahrain,1,0,FIFA World Cup qualification,Damascus,Syria,FALSE
 1985-09-20,United Arab Emirates,Iraq,2,3,FIFA World Cup qualification,Dubai,United Arab Emirates,FALSE
 1985-09-21,New Zealand,Australia,0,0,FIFA World Cup qualification,Auckland,New Zealand,FALSE
 1985-09-22,Hong Kong,Japan,1,2,FIFA World Cup qualification,Siu Sai Wan,Hong Kong,FALSE
-1985-09-22,Mexico,Peru,1,0,Friendly,San Jose,USA,TRUE
+1985-09-22,Mexico,Peru,1,0,Friendly,San Jose,United States,TRUE
 1985-09-25,Czechoslovakia,Portugal,1,0,FIFA World Cup qualification,Prague,Czechoslovakia,FALSE
 1985-09-25,Finland,Turkey,1,0,FIFA World Cup qualification,Tampere,Finland,FALSE
 1985-09-25,Italy,Norway,1,2,Friendly,Lecce,Italy,FALSE
@@ -14247,7 +14247,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-11-13,Republic of Ireland,Denmark,1,4,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
 1985-11-13,Switzerland,Norway,1,1,FIFA World Cup qualification,Lucerne,Switzerland,FALSE
 1985-11-13,Turkey,Romania,1,3,FIFA World Cup qualification,İzmir,Turkey,FALSE
-1985-11-14,Mexico,Argentina,1,1,Friendly,Los Angeles,USA,TRUE
+1985-11-14,Mexico,Argentina,1,1,Friendly,Los Angeles,United States,TRUE
 1985-11-15,Syria,Iraq,0,0,FIFA World Cup qualification,Damascus,Syria,FALSE
 1985-11-16,France,Yugoslavia,2,0,FIFA World Cup qualification,Paris,France,FALSE
 1985-11-16,German DR,Bulgaria,2,1,FIFA World Cup qualification,Karl-Marx-Stadt,German DR,FALSE
@@ -14273,7 +14273,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1985-11-29,Congo,Ivory Coast,0,1,Friendly,Kinshasa,Zaïre,TRUE
 1985-11-29,Iraq,Syria,3,1,FIFA World Cup qualification,Taif,Saudi Arabia,TRUE
 1985-12-01,Dominica,Saint Kitts and Nevis,0,1,Friendly,Roseau,Dominica,FALSE
-1985-12-03,Mexico,South Korea,2,1,Friendly,Los Angeles,USA,TRUE
+1985-12-03,Mexico,South Korea,2,1,Friendly,Los Angeles,United States,TRUE
 1985-12-04,Australia,Scotland,0,0,FIFA World Cup qualification,Melbourne,Australia,FALSE
 1985-12-07,Gabon,Congo,1,0,UDEAC Cup,Libreville,Gabon,FALSE
 1985-12-07,Mexico,Algeria,2,0,Friendly,Mexico City,Mexico,FALSE
@@ -14312,7 +14312,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1986-01-29,Egypt,England,0,4,Friendly,Cairo,Egypt,FALSE
 1986-01-30,India,Peru,0,1,Nehru Cup,Trivandrum,India,FALSE
 1986-02-01,Senegal,Guinea,2,1,Amílcar Cabral Cup,Dakar,Senegal,FALSE
-1986-02-02,Canada,Uruguay,1,3,Friendly,Miami,USA,TRUE
+1986-02-02,Canada,Uruguay,1,3,Friendly,Miami,United States,TRUE
 1986-02-02,Gambia,Guinea-Bissau,3,0,Amílcar Cabral Cup,Dakar,Senegal,TRUE
 1986-02-02,Mauritania,Sierra Leone,0,1,Amílcar Cabral Cup,Dakar,Senegal,TRUE
 1986-02-02,Qatar,Hungary,0,3,Friendly,Doha,Qatar,FALSE
@@ -14320,19 +14320,19 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1986-02-04,Gambia,Sierra Leone,1,2,Amílcar Cabral Cup,Dakar,Senegal,TRUE
 1986-02-04,Guinea-Bissau,Mauritania,1,0,Amílcar Cabral Cup,Dakar,Senegal,TRUE
 1986-02-05,Italy,Germany,1,2,Friendly,Avellino,Italy,FALSE
-1986-02-05,Jamaica,Paraguay,1,4,Friendly,Miami,USA,TRUE
+1986-02-05,Jamaica,Paraguay,1,4,Friendly,Miami,United States,TRUE
 1986-02-05,Portugal,Luxembourg,2,0,Friendly,Portimão,Portugal,FALSE
 1986-02-05,Senegal,Mali,1,0,Amílcar Cabral Cup,Dakar,Senegal,FALSE
-1986-02-05,USA,Canada,0,0,Friendly,Miami,USA,FALSE
+1986-02-05,United States,Canada,0,0,Friendly,Miami,United States,FALSE
 1986-02-06,Gambia,Mauritania,3,1,Amílcar Cabral Cup,Dakar,Senegal,TRUE
 1986-02-06,Guinea-Bissau,Sierra Leone,2,3,Amílcar Cabral Cup,Dakar,Senegal,TRUE
-1986-02-07,USA,Uruguay,1,1,Friendly,Miami,USA,FALSE
+1986-02-07,United States,Uruguay,1,1,Friendly,Miami,United States,FALSE
 1986-02-08,Guinea,Sierra Leone,1,2,Amílcar Cabral Cup,Dakar,Senegal,TRUE
 1986-02-08,Senegal,Gambia,1,0,Amílcar Cabral Cup,Dakar,Senegal,FALSE
 1986-02-09,Bulgaria,German DR,1,2,Friendly,Querétaro,Mexico,TRUE
 1986-02-10,Senegal,Sierra Leone,3,1,Amílcar Cabral Cup,Dakar,Senegal,FALSE
 1986-02-14,South Korea,Paraguay,1,3,Lunar New Year Cup,So Kon Po,Hong Kong,TRUE
-1986-02-15,Mexico,German DR,1,2,Friendly,San Jose,USA,TRUE
+1986-02-15,Mexico,German DR,1,2,Friendly,San Jose,United States,TRUE
 1986-02-15,Zambia,Botswana,6,0,Friendly,Ndola,Zambia,FALSE
 1986-02-16,Indonesia,Paraguay,2,3,Friendly,Jakarta,Indonesia,FALSE
 1986-02-16,Iran,Pakistan,2,0,Friendly,Tehran,Iran,FALSE
@@ -14377,7 +14377,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1986-03-03,Guadeloupe,Norway,1,2,Friendly,Basse-Terre,Guadeloupe,FALSE
 1986-03-05,Martinique,Norway,0,1,Friendly,Fort-de-France,Martinique,FALSE
 1986-03-05,Thailand,Indonesia,1,1,King's Cup,Bangkok,Thailand,FALSE
-1986-03-06,Mexico,Denmark,1,1,Friendly,Los Angeles,USA,TRUE
+1986-03-06,Mexico,Denmark,1,1,Friendly,Los Angeles,United States,TRUE
 1986-03-07,Egypt,Senegal,0,1,African Cup of Nations,Cairo,Egypt,FALSE
 1986-03-07,Ivory Coast,Mozambique,3,0,African Cup of Nations,Cairo,Egypt,TRUE
 1986-03-08,Algeria,Morocco,0,0,African Cup of Nations,Alexandria,Egypt,TRUE
@@ -14439,7 +14439,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1986-04-08,Brazil,German DR,3,0,Friendly,Goiânia,Brazil,FALSE
 1986-04-09,Bulgaria,Denmark,3,0,Friendly,Sofia,Bulgaria,FALSE
 1986-04-09,Switzerland,Germany,0,1,Friendly,Basel,Switzerland,FALSE
-1986-04-13,Mexico,Uruguay,1,0,Friendly,Los Angeles,USA,TRUE
+1986-04-13,Mexico,Uruguay,1,0,Friendly,Los Angeles,United States,TRUE
 1986-04-17,Brazil,Finland,3,0,Friendly,Brasília,Brazil,FALSE
 1986-04-21,Wales,Uruguay,0,0,Friendly,Wrexham,Wales,FALSE
 1986-04-23,Belgium,Bulgaria,2,0,Friendly,Brussels,Belgium,FALSE
@@ -14477,7 +14477,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1986-05-14,Austria,Sweden,1,0,Friendly,Salzburg,Austria,FALSE
 1986-05-14,Germany,Netherlands,3,1,Friendly,Dortmund,Germany,FALSE
 1986-05-16,Denmark,Poland,1,0,Friendly,Copenhagen,Denmark,FALSE
-1986-05-17,Mexico,England,0,3,Friendly,Los Angeles,USA,TRUE
+1986-05-17,Mexico,England,0,3,Friendly,Los Angeles,United States,TRUE
 1986-05-19,Belgium,Yugoslavia,1,3,Friendly,Brussels,Belgium,FALSE
 1986-05-19,Canada,Wales,0,3,Friendly,Vancouver,Canada,FALSE
 1986-05-21,Panama,Dominican Republic,2,1,Friendly,Panama City,Panama,FALSE
@@ -14689,7 +14689,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1986-12-21,Cyprus,Netherlands,0,2,UEFA Euro qualification,Limassol,Cyprus,FALSE
 1987-01-04,Barbados,Saint Vincent and the Grenadines,3,0,Friendly,Bridgetown,Barbados,FALSE
 1987-01-07,Portugal,Greece,1,1,Friendly,Portalegre,Portugal,FALSE
-1987-01-13,El Salvador,Mexico,1,3,Friendly,Los Angeles,USA,TRUE
+1987-01-13,El Salvador,Mexico,1,3,Friendly,Los Angeles,United States,TRUE
 1987-01-14,Greece,Cyprus,3,1,UEFA Euro qualification,Athens,Greece,FALSE
 1987-01-14,India,China PR,1,1,Nehru Cup,Calicut,India,FALSE
 1987-01-17,Mali,Burkina Faso,2,0,Friendly,Bamako,Mali,FALSE
@@ -14837,13 +14837,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1987-06-03,Iceland,German DR,0,6,UEFA Euro qualification,Reykjavík,Iceland,FALSE
 1987-06-03,Norway,Russia,0,1,UEFA Euro qualification,Oslo,Norway,FALSE
 1987-06-03,Sweden,Italy,1,0,UEFA Euro qualification,Solna,Sweden,FALSE
-1987-06-08,Egypt,USA,3,1,Korea Cup,Seoul,South Korea,TRUE
+1987-06-08,Egypt,United States,3,1,Korea Cup,Seoul,South Korea,TRUE
 1987-06-09,Australia,Morocco,1,0,Korea Cup,Gangneung,South Korea,TRUE
 1987-06-10,Argentina,Italy,1,3,Friendly,Zürich,Switzerland,TRUE
 1987-06-10,South Korea,Egypt,0,0,Korea Cup,Masan,South Korea,FALSE
 1987-06-11,Colombia,Ecuador,1,0,Friendly,Medellín,Colombia,FALSE
 1987-06-12,Egypt,Thailand,1,1,Korea Cup,Busan,South Korea,TRUE
-1987-06-12,South Korea,USA,1,0,Korea Cup,Busan,South Korea,FALSE
+1987-06-12,South Korea,United States,1,0,Korea Cup,Busan,South Korea,FALSE
 1987-06-13,Malawi,Zimbabwe,1,4,Friendly,Lilongwe,Malawi,FALSE
 1987-06-14,Bolivia,Paraguay,0,2,Friendly,Santa Cruz,Bolivia,FALSE
 1987-06-14,Congo,Seychelles,1,1,Friendly,Antananarivo,Madagascar,TRUE
@@ -14851,7 +14851,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1987-06-14,South Korea,Thailand,4,2,Korea Cup,Daejeon,South Korea,FALSE
 1987-06-14,Malawi,Zimbabwe,2,1,Friendly,Blantyre,Malawi,FALSE
 1987-06-16,Norway,France,2,0,UEFA Euro qualification,Oslo,Norway,FALSE
-1987-06-16,Thailand,USA,0,1,Korea Cup,Cheongju,South Korea,TRUE
+1987-06-16,Thailand,United States,0,1,Korea Cup,Cheongju,South Korea,TRUE
 1987-06-17,Switzerland,Sweden,1,1,UEFA Euro qualification,Lausanne,Switzerland,FALSE
 1987-06-18,Madagascar,Seychelles,2,0,Friendly,Antananarivo,Madagascar,FALSE
 1987-06-19,Australia,Egypt,0,0,Korea Cup,Seoul,South Korea,TRUE
@@ -14933,7 +14933,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1987-09-30,El Salvador,Canada,2,1,Friendly,San Salvador,El Salvador,FALSE
 1987-10-02,Honduras,Canada,1,1,Friendly,Tegucigalpa,Honduras,FALSE
 1987-10-06,Mexico,Canada,4,0,Friendly,Toluca,Mexico,FALSE
-1987-10-07,El Salvador,Guatemala,1,0,Friendly,Los Angeles,USA,TRUE
+1987-10-07,El Salvador,Guatemala,1,0,Friendly,Los Angeles,United States,TRUE
 1987-10-07,Romania,Greece,2,2,Friendly,Bucharest,Romania,FALSE
 1987-10-10,German DR,Russia,1,1,UEFA Euro qualification,Berlin,German DR,FALSE
 1987-10-14,Denmark,Wales,1,0,UEFA Euro qualification,Copenhagen,Denmark,FALSE
@@ -15053,10 +15053,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-01-05,Gambia,Ghana,0,0,Friendly,Banjul,Gambia,FALSE
 1988-01-06,Guatemala,Costa Rica,1,2,Friendly,Guatemala,Guatemala,FALSE
 1988-01-06,South Korea,Egypt,1,1,Friendly,Doha,Qatar,TRUE
-1988-01-10,Guatemala,USA,1,0,Friendly,Guatemala,Guatemala,FALSE
+1988-01-10,Guatemala,United States,1,0,Friendly,Guatemala,Guatemala,FALSE
 1988-01-12,Czechoslovakia,Finland,0,2,Friendly,Las Palmas,Spain,TRUE
 1988-01-12,German DR,Sweden,1,4,Friendly,Las Palmas,Spain,TRUE
-1988-01-13,Guatemala,USA,0,1,Friendly,Guatemala,Guatemala,FALSE
+1988-01-13,Guatemala,United States,0,1,Friendly,Guatemala,Guatemala,FALSE
 1988-01-13,Honduras,Mexico,0,1,Friendly,San Pedro Sula,Honduras,FALSE
 1988-01-14,Thailand,Indonesia,3,3,King's Cup,Bangkok,Thailand,FALSE
 1988-01-15,Czechoslovakia,German DR,1,0,Friendly,Las Palmas,Spain,TRUE
@@ -15147,7 +15147,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-03-17,Egypt,Kenya,3,0,African Cup of Nations,Rabat,Morocco,TRUE
 1988-03-17,United Arab Emirates,Oman,1,0,Gulf Cup,Riyadh,Saudi Arabia,TRUE
 1988-03-18,Bahrain,Iraq,0,1,Gulf Cup,Riyadh,Saudi Arabia,TRUE
-1988-03-18,El Salvador,Honduras,0,0,Friendly,Los Angeles,USA,TRUE
+1988-03-18,El Salvador,Honduras,0,0,Friendly,Los Angeles,United States,TRUE
 1988-03-18,Saudi Arabia,Kuwait,0,0,Gulf Cup,Riyadh,Saudi Arabia,FALSE
 1988-03-19,Algeria,DR Congo,1,0,African Cup of Nations,Casablanca,Morocco,TRUE
 1988-03-19,Morocco,Ivory Coast,0,0,African Cup of Nations,Casablanca,Morocco,FALSE
@@ -15193,7 +15193,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-04-18,Japan,Pakistan,4,1,AFC Asian Cup qualification,Kuala Lumpur,Malaysia,TRUE
 1988-04-18,Malaysia,Kuwait,0,5,AFC Asian Cup qualification,Kuala Lumpur,Malaysia,FALSE
 1988-04-19,Guadeloupe,Suriname,1,1,CFU Caribbean Cup qualification,Basse-Terre,Guadeloupe,FALSE
-1988-04-21,El Salvador,Guatemala,1,0,Friendly,Los Angeles,USA,TRUE
+1988-04-21,El Salvador,Guatemala,1,0,Friendly,Los Angeles,United States,TRUE
 1988-04-26,Mexico,Honduras,4,1,Friendly,Ciudad Victoria,Mexico,FALSE
 1988-04-27,Austria,Denmark,1,0,Friendly,Vienna,Austria,FALSE
 1988-04-27,Czechoslovakia,Russia,1,1,Friendly,Trnava,Czechoslovakia,FALSE
@@ -15259,32 +15259,32 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-06-01,Norway,Republic of Ireland,0,0,Friendly,Oslo,Norway,FALSE
 1988-06-01,Russia,Poland,2,1,Friendly,Moscow,Soviet Union,FALSE
 1988-06-01,Spain,Sweden,1,3,Friendly,Salamanca,Spain,FALSE
-1988-06-01,USA,Chile,1,1,Friendly,Stockton,USA,FALSE
+1988-06-01,United States,Chile,1,1,Friendly,Stockton,United States,FALSE
 1988-06-02,Iran,North Korea,0,0,AFC Asian Cup qualification,Kathmandu,Nepal,TRUE
 1988-06-02,Japan,China PR,0,3,Kirin Cup,Nagoya,Japan,FALSE
 1988-06-03,Libya,Burkina Faso,3,0,FIFA World Cup qualification,Tripoli,Libya,FALSE
 1988-06-03,Syria,Hong Kong,2,0,AFC Asian Cup qualification,Kathmandu,Nepal,TRUE
-1988-06-03,USA,Chile,1,3,Friendly,San Diego,USA,FALSE
+1988-06-03,United States,Chile,1,3,Friendly,San Diego,United States,FALSE
 1988-06-04,Germany,Yugoslavia,1,1,Friendly,Bremen,Germany,FALSE
 1988-06-04,Italy,Wales,0,1,Friendly,Brescia,Italy,FALSE
 1988-06-04,Nepal,Iran,0,3,AFC Asian Cup qualification,Kathmandu,Nepal,FALSE
 1988-06-04,Zambia,Zimbabwe,3,2,Friendly,Lusaka,Zambia,FALSE
 1988-06-05,Denmark,Belgium,3,1,Friendly,Odense,Denmark,FALSE
 1988-06-05,Switzerland,Spain,1,1,Friendly,Basel,Switzerland,FALSE
-1988-06-05,USA,Chile,0,3,Friendly,Fresno,USA,FALSE
-1988-06-07,USA,Ecuador,0,1,Friendly,Albuquerque,USA,FALSE
+1988-06-05,United States,Chile,0,3,Friendly,Fresno,United States,FALSE
+1988-06-07,United States,Ecuador,0,1,Friendly,Albuquerque,United States,FALSE
 1988-06-09,Seychelles,Tanzania,1,1,Friendly,Victoria,Seychelles,FALSE
 1988-06-10,Germany,Italy,1,1,UEFA Euro,Düsseldorf,Germany,FALSE
 1988-06-10,Mozambique,Malawi,1,2,Friendly,Maputo,Mozambique,FALSE
-1988-06-10,USA,Ecuador,0,2,Friendly,Houston,USA,FALSE
+1988-06-10,United States,Ecuador,0,2,Friendly,Houston,United States,FALSE
 1988-06-11,Denmark,Spain,2,3,UEFA Euro,Hanover,Germany,TRUE
 1988-06-12,England,Republic of Ireland,0,1,UEFA Euro,Stuttgart,Germany,TRUE
 1988-06-12,Netherlands,Russia,0,1,UEFA Euro,Cologne,Germany,TRUE
-1988-06-12,USA,Ecuador,0,0,Friendly,Fort Worth,USA,FALSE
+1988-06-12,United States,Ecuador,0,0,Friendly,Fort Worth,United States,FALSE
 1988-06-14,Germany,Denmark,2,0,UEFA Euro,Gelsenkirchen,Germany,FALSE
 1988-06-14,Italy,Spain,1,0,UEFA Euro,Frankfurt am Main,Germany,TRUE
 1988-06-14,Mozambique,Malawi,1,1,Friendly,Maputo,Mozambique,FALSE
-1988-06-14,USA,Costa Rica,1,0,Friendly,San Antonio,USA,FALSE
+1988-06-14,United States,Costa Rica,1,0,Friendly,San Antonio,United States,FALSE
 1988-06-15,England,Netherlands,1,3,UEFA Euro,Düsseldorf,Germany,TRUE
 1988-06-15,Honduras,Ecuador,1,1,Friendly,Tegucigalpa,Honduras,FALSE
 1988-06-15,Republic of Ireland,Russia,1,1,UEFA Euro,Hanover,Germany,TRUE
@@ -15346,7 +15346,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-07-21,Iraq,Syria,1,1,Arab Cup,Amman,Jordan,TRUE
 1988-07-21,Jordan,Egypt,0,2,Arab Cup,Amman,Jordan,FALSE
 1988-07-24,Burkina Faso,Niger,1,0,Tournament Burkina Faso,Ouagadougou,Burkina Faso,FALSE
-1988-07-24,Jamaica,USA,0,0,CONCACAF Championship qualification,Kingston,Jamaica,FALSE
+1988-07-24,Jamaica,United States,0,0,CONCACAF Championship qualification,Kingston,Jamaica,FALSE
 1988-07-25,Benin,Ghana,1,1,Tournament Burkina Faso,Ouagadougou,Burkina Faso,TRUE
 1988-07-27,Burkina Faso,Ghana,3,1,Tournament Burkina Faso,Ouagadougou,Burkina Faso,FALSE
 1988-07-27,Mali,Niger,1,0,Tournament Burkina Faso,Ouagadougou,Burkina Faso,TRUE
@@ -15366,7 +15366,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-08-04,Burkina Faso,Niger,1,0,Tournament Burkina Faso,Ouagadougou,Burkina Faso,FALSE
 1988-08-04,Finland,Bulgaria,1,1,Friendly,Vaasa,Finland,FALSE
 1988-08-04,Zambia,Malawi,7,1,Friendly,Lusaka,Zambia,FALSE
-1988-08-05,El Salvador,Guatemala,1,2,Friendly,Los Angeles,USA,TRUE
+1988-08-05,El Salvador,Guatemala,1,2,Friendly,Los Angeles,United States,TRUE
 1988-08-05,Indonesia,Thailand,1,0,Indonesia Tournament,Jakarta,Indonesia,FALSE
 1988-08-05,Tunisia,Guinea,5,0,FIFA World Cup qualification,Tunis,Tunisia,FALSE
 1988-08-06,Albania,Cuba,0,0,Friendly,Berat,Albania,FALSE
@@ -15375,7 +15375,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-08-07,Ghana,Liberia,0,0,FIFA World Cup qualification,Accra,Ghana,FALSE
 1988-08-07,Iceland,Bulgaria,2,3,Friendly,Reykjavík,Iceland,FALSE
 1988-08-09,Norway,Bulgaria,1,1,Friendly,Oslo,Norway,FALSE
-1988-08-13,USA,Jamaica,5,1,CONCACAF Championship qualification,St. Louis,USA,FALSE
+1988-08-13,United States,Jamaica,5,1,CONCACAF Championship qualification,St. Louis,United States,FALSE
 1988-08-17,Finland,Russia,0,0,Friendly,Turku,Finland,FALSE
 1988-08-21,Guinea,Tunisia,3,0,FIFA World Cup qualification,Conakry,Guinea,FALSE
 1988-08-21,Liberia,Ghana,2,0,FIFA World Cup qualification,Monrovia,Liberia,FALSE
@@ -15406,7 +15406,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-09-21,Luxembourg,Switzerland,1,4,FIFA World Cup qualification,Luxembourg,Luxembourg,FALSE
 1988-09-21,Peru,Paraguay,0,1,Friendly,Lima,Peru,FALSE
 1988-09-21,Turkey,Greece,3,1,Friendly,Istanbul,Turkey,FALSE
-1988-09-25,El Salvador,Honduras,0,0,Friendly,Los Angeles,USA,TRUE
+1988-09-25,El Salvador,Honduras,0,0,Friendly,Los Angeles,United States,TRUE
 1988-09-26,Curaçao,Venezuela,0,0,Friendly,Willemstad,Netherlands Antilles,FALSE
 1988-09-26,Malawi,Mozambique,1,1,Friendly,Blantyre,Malawi,FALSE
 1988-09-27,Ecuador,Uruguay,1,2,Friendly,Asunción,Paraguay,TRUE
@@ -15484,7 +15484,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1988-11-08,Kenya,Zanzibar,2,0,CECAFA Cup,Lilongwe,Malawi,TRUE
 1988-11-08,Tunisia,Angola,5,0,Friendly,Tunis,Tunisia,FALSE
 1988-11-08,Uganda,Zimbabwe,0,0,CECAFA Cup,Blantyre,Malawi,TRUE
-1988-11-09,El Salvador,Guatemala,0,0,Friendly,Los Angeles,USA,TRUE
+1988-11-09,El Salvador,Guatemala,0,0,Friendly,Los Angeles,United States,TRUE
 1988-11-09,Indonesia,Qatar,0,1,Friendly,Jakarta,Indonesia,FALSE
 1988-11-09,Uruguay,Chile,3,1,Copa Juan Pinto Durán,Montevideo,Uruguay,FALSE
 1988-11-10,Kenya,Tanzania,2,0,CECAFA Cup,Lilongwe,Malawi,TRUE
@@ -15656,13 +15656,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-02-15,Portugal,Belgium,1,1,FIFA World Cup qualification,Lisbon,Portugal,FALSE
 1989-02-19,Thailand,Bangladesh,1,0,FIFA World Cup qualification,Bangkok,Thailand,FALSE
 1989-02-21,Bulgaria,Russia,1,2,Friendly,Sofia,Bulgaria,FALSE
-1989-02-21,Costa Rica,El Salvador,1,1,Friendly,Los Angeles,USA,TRUE
-1989-02-21,Guatemala,Mexico,1,2,Friendly,Los Angeles,USA,TRUE
+1989-02-21,Costa Rica,El Salvador,1,1,Friendly,Los Angeles,United States,TRUE
+1989-02-21,Guatemala,Mexico,1,2,Friendly,Los Angeles,United States,TRUE
 1989-02-22,Greece,Norway,4,2,Friendly,Athens,Greece,FALSE
 1989-02-22,Italy,Denmark,1,0,Friendly,Pisa,Italy,FALSE
 1989-02-23,China PR,Bangladesh,2,0,FIFA World Cup qualification,Guangzhou,China PR,FALSE
-1989-02-23,Costa Rica,Guatemala,2,3,Friendly,Los Angeles,USA,TRUE
-1989-02-23,El Salvador,Mexico,0,2,Friendly,Los Angeles,USA,TRUE
+1989-02-23,Costa Rica,Guatemala,2,3,Friendly,Los Angeles,United States,TRUE
+1989-02-23,El Salvador,Mexico,0,2,Friendly,Los Angeles,United States,TRUE
 1989-02-23,Thailand,Iran,0,3,FIFA World Cup qualification,Bangkok,Thailand,FALSE
 1989-02-27,Bangladesh,Iran,1,2,FIFA World Cup qualification,Dhaka,Bangladesh,FALSE
 1989-02-28,Thailand,China PR,0,3,FIFA World Cup qualification,Bangkok,Thailand,FALSE
@@ -15739,7 +15739,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-04-14,Faroe Islands,Canada,1,0,Friendly,Tórshavn,Faroe Islands,FALSE
 1989-04-15,Guinea,Nigeria,1,1,African Cup of Nations qualification,Conakry,Guinea,FALSE
 1989-04-16,Australia,Israel,1,1,FIFA World Cup qualification,Sydney,Australia,FALSE
-1989-04-16,Costa Rica,USA,1,0,CONCACAF Championship,San José,Costa Rica,FALSE
+1989-04-16,Costa Rica,United States,1,0,CONCACAF Championship,San José,Costa Rica,FALSE
 1989-04-16,Faroe Islands,Canada,0,1,Friendly,Klaksvík,Faroe Islands,FALSE
 1989-04-16,Mozambique,Zambia,0,1,African Cup of Nations qualification,Maputo,Mozambique,FALSE
 1989-04-16,Trinidad and Tobago,Bermuda,1,1,Friendly,Port of Spain,Trinidad and Tobago,FALSE
@@ -15772,16 +15772,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-04-26,Wales,Sweden,0,2,Friendly,Wrexham,Wales,FALSE
 1989-04-29,Belgium,Czechoslovakia,2,1,FIFA World Cup qualification,Brussels,Belgium,FALSE
 1989-04-29,France,Yugoslavia,0,0,FIFA World Cup qualification,Paris,France,FALSE
-1989-04-30,USA,Costa Rica,1,0,CONCACAF Championship,St. Louis,USA,FALSE
+1989-04-30,United States,Costa Rica,1,0,CONCACAF Championship,St. Louis,United States,FALSE
 1989-04-30,Zambia,Mozambique,3,0,African Cup of Nations qualification,Lusaka,Zambia,FALSE
 1989-05-02,Norway,Poland,0,3,Friendly,Oslo,Norway,FALSE
 1989-05-03,Uruguay,Ecuador,3,1,Friendly,Montevideo,Uruguay,FALSE
-1989-05-05,El Salvador,Paraguay,1,2,Friendly,Los Angeles,USA,TRUE
-1989-05-05,Guatemala,Chile,0,1,Friendly,Los Angeles,USA,TRUE
+1989-05-05,El Salvador,Paraguay,1,2,Friendly,Los Angeles,United States,TRUE
+1989-05-05,Guatemala,Chile,0,1,Friendly,Los Angeles,United States,TRUE
 1989-05-05,South Korea,Japan,1,0,Friendly,Seoul,South Korea,FALSE
-1989-05-07,El Salvador,Chile,0,1,Friendly,Los Angeles,USA,TRUE
+1989-05-07,El Salvador,Chile,0,1,Friendly,Los Angeles,United States,TRUE
 1989-05-07,Grenada,Saint Kitts and Nevis,2,1,CFU Caribbean Cup qualification,St. George's,Grenada,FALSE
-1989-05-07,Guatemala,Paraguay,1,2,Friendly,Los Angeles,USA,TRUE
+1989-05-07,Guatemala,Paraguay,1,2,Friendly,Los Angeles,United States,TRUE
 1989-05-07,Jamaica,Guadeloupe,1,3,CFU Caribbean Cup qualification,Kingston,Jamaica,FALSE
 1989-05-07,Sint Maarten,British Virgin Islands,1,2,CFU Caribbean Cup qualification,Philipsburg,Sint Maarten,FALSE
 1989-05-07,Sweden,Poland,2,1,FIFA World Cup qualification,Solna,Sweden,FALSE
@@ -15794,7 +15794,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-05-13,Hong Kong,Macau,2,1,Friendly,So Kon Po,Hong Kong,FALSE
 1989-05-13,Japan,China PR,2,0,Friendly,Okayama,Japan,FALSE
 1989-05-13,Singapore,Indonesia,1,2,Friendly,Singapore,Singapore,FALSE
-1989-05-13,USA,Trinidad and Tobago,1,1,CONCACAF Championship,Torrance,USA,FALSE
+1989-05-13,United States,Trinidad and Tobago,1,1,CONCACAF Championship,Torrance,United States,FALSE
 1989-05-15,Paraguay,Peru,1,1,Friendly,Asunción,Paraguay,FALSE
 1989-05-16,Namibia,Angola,0,1,Friendly,Windhoek,Namibia,FALSE
 1989-05-17,Denmark,Greece,7,1,FIFA World Cup qualification,Copenhagen,Denmark,FALSE
@@ -15860,7 +15860,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-06-04,Republic of Ireland,Hungary,2,0,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
 1989-06-04,Japan,North Korea,2,1,FIFA World Cup qualification,Tokyo,Japan,FALSE
 1989-06-04,Mali,Guinea,3,0,Amílcar Cabral Cup,Bamako,Mali,FALSE
-1989-06-04,USA,Peru,3,0,Friendly,East Rutherford,USA,FALSE
+1989-06-04,United States,Peru,3,0,Friendly,East Rutherford,United States,FALSE
 1989-06-05,Malaysia,South Korea,0,3,FIFA World Cup qualification,Singapore,Singapore,TRUE
 1989-06-05,Singapore,Nepal,7,0,FIFA World Cup qualification,Singapore,Singapore,FALSE
 1989-06-06,Grenada,Trinidad and Tobago,1,0,CFU Caribbean Cup qualification,St. George's,Grenada,FALSE
@@ -15889,7 +15889,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-06-16,Brazil,Sweden,1,2,Friendly,Copenhagen,Denmark,TRUE
 1989-06-16,Trinidad and Tobago,Peru,2,1,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 1989-06-16,Zimbabwe,Zambia,0,0,Friendly,Harare,Zimbabwe,FALSE
-1989-06-17,USA,Guatemala,2,1,CONCACAF Championship,New Britain,USA,FALSE
+1989-06-17,United States,Guatemala,2,1,CONCACAF Championship,New Britain,United States,FALSE
 1989-06-18,Aruba,Saint Kitts and Nevis,1,4,CFU Caribbean Cup qualification,Oranjestad,Aruba,FALSE
 1989-06-18,Denmark,Brazil,4,0,Friendly,Copenhagen,Denmark,FALSE
 1989-06-18,Jamaica,Saint Lucia,1,1,CFU Caribbean Cup qualification,Kingston,Jamaica,FALSE
@@ -15900,7 +15900,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-06-21,Switzerland,Brazil,1,0,Friendly,Basel,Switzerland,FALSE
 1989-06-22,Bolivia,Chile,0,1,Friendly,Santa Cruz,Bolivia,FALSE
 1989-06-24,Malawi,Kenya,1,0,FIFA World Cup qualification,Lilongwe,Malawi,FALSE
-1989-06-24,USA,Colombia,0,1,Friendly,Miami,USA,FALSE
+1989-06-24,United States,Colombia,0,1,Friendly,Miami,United States,FALSE
 1989-06-25,Angola,Cameroon,1,2,FIFA World Cup qualification,Luanda,Angola,FALSE
 1989-06-25,El Salvador,Costa Rica,2,4,CONCACAF Championship,San Salvador,El Salvador,FALSE
 1989-06-25,Gabon,Nigeria,2,1,FIFA World Cup qualification,Libreville,Gabon,FALSE
@@ -15913,7 +15913,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-06-25,Zimbabwe,Algeria,1,2,FIFA World Cup qualification,Harare,Zimbabwe,FALSE
 1989-06-26,South Korea,Czechoslovakia,0,0,Korea Cup,Seoul,South Korea,FALSE
 1989-06-27,Chile,Bolivia,2,1,Friendly,Santiago,Chile,FALSE
-1989-06-27,Haiti,Colombia,0,4,Friendly,Miami,USA,TRUE
+1989-06-27,Haiti,Colombia,0,4,Friendly,Miami,United States,TRUE
 1989-06-30,Grenada,French Guiana,0,0,CFU Caribbean Cup qualification,St. George's,Grenada,FALSE
 1989-07-01,Brazil,Venezuela,3,1,Copa América,Salvador,Brazil,FALSE
 1989-07-01,Paraguay,Peru,5,2,Copa América,Salvador,Brazil,TRUE
@@ -15989,7 +15989,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-08-05,Tunisia,Malawi,3,0,Friendly,Tunis,Tunisia,FALSE
 1989-08-06,Uruguay,Colombia,0,0,Friendly,Montevideo,Uruguay,FALSE
 1989-08-06,Venezuela,Chile,1,3,FIFA World Cup qualification,Caracas,Venezuela,FALSE
-1989-08-10,Mexico,South Korea,4,2,Friendly,Los Angeles,USA,TRUE
+1989-08-10,Mexico,South Korea,4,2,Friendly,Los Angeles,United States,TRUE
 1989-08-12,Egypt,Malawi,1,0,FIFA World Cup qualification,Cairo,Egypt,FALSE
 1989-08-12,Kenya,Liberia,1,0,FIFA World Cup qualification,Nairobi,Kenya,FALSE
 1989-08-12,Nigeria,Angola,1,0,FIFA World Cup qualification,Lagos,Nigeria,FALSE
@@ -15999,7 +15999,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-08-13,El Salvador,Trinidad and Tobago,0,0,CONCACAF Championship,Tegucigalpa,Honduras,TRUE
 1989-08-13,Ivory Coast,Zimbabwe,5,0,FIFA World Cup qualification,Abidjan,Ivory Coast,FALSE
 1989-08-13,Morocco,Tunisia,0,0,FIFA World Cup qualification,Casablanca,Morocco,FALSE
-1989-08-13,USA,South Korea,1,2,Friendly,Los Angeles,USA,FALSE
+1989-08-13,United States,South Korea,1,2,Friendly,Los Angeles,United States,FALSE
 1989-08-16,Sweden,France,2,4,Friendly,Malmö,Sweden,FALSE
 1989-08-20,Bolivia,Peru,2,1,FIFA World Cup qualification,La Paz,Bolivia,FALSE
 1989-08-20,Brazil,Venezuela,6,0,FIFA World Cup qualification,São Paulo,Brazil,FALSE
@@ -16043,7 +16043,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-09-10,Peru,Bolivia,1,2,FIFA World Cup qualification,Lima,Peru,FALSE
 1989-09-16,South Korea,Egypt,0,1,Friendly,Seoul,South Korea,FALSE
 1989-09-17,Colombia,Paraguay,2,1,FIFA World Cup qualification,Barranquilla,Colombia,FALSE
-1989-09-17,El Salvador,USA,0,1,CONCACAF Championship,Tegucigalpa,Honduras,TRUE
+1989-09-17,El Salvador,United States,0,1,CONCACAF Championship,Tegucigalpa,Honduras,TRUE
 1989-09-17,Uruguay,Bolivia,2,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 1989-09-20,Iceland,Turkey,2,1,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
 1989-09-20,Italy,Bulgaria,4,0,Friendly,Cesena,Italy,FALSE
@@ -16061,7 +16061,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-10-08,Algeria,Egypt,0,0,FIFA World Cup qualification,Constantine,Algeria,FALSE
 1989-10-08,Cameroon,Tunisia,2,0,FIFA World Cup qualification,Yaoundé,Cameroon,FALSE
 1989-10-08,German DR,Russia,2,1,FIFA World Cup qualification,Karl-Marx-Stadt,German DR,FALSE
-1989-10-08,Guatemala,USA,0,0,CONCACAF Championship,Guatemala,Guatemala,FALSE
+1989-10-08,Guatemala,United States,0,0,CONCACAF Championship,Guatemala,Guatemala,FALSE
 1989-10-08,Sweden,Albania,3,1,FIFA World Cup qualification,Solna,Sweden,FALSE
 1989-10-11,Bulgaria,Greece,4,0,FIFA World Cup qualification,Varna,Bulgaria,FALSE
 1989-10-11,Cyprus,Malta,0,0,Friendly,Larnaca,Cyprus,FALSE
@@ -16125,14 +16125,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-11-04,New Caledonia,Papua New Guinea,2,1,Friendly,Suva,Fiji,TRUE
 1989-11-05,Guinea,Yemen DPR,0,1,Friendly,Kuwait City,Kuwait,TRUE
 1989-11-05,Iran,Iraq,0,0,Friendly,Kuwait City,Kuwait,TRUE
-1989-11-05,USA,El Salvador,0,0,CONCACAF Championship,St. Louis,USA,FALSE
+1989-11-05,United States,El Salvador,0,0,CONCACAF Championship,St. Louis,United States,FALSE
 1989-11-08,Iran,Uganda,2,2,Friendly,Kuwait City,Kuwait,TRUE
 1989-11-08,Kuwait,Iraq,1,2,Friendly,Kuwait City,Kuwait,FALSE
 1989-11-11,Italy,Algeria,1,0,Friendly,Vicenza,Italy,FALSE
 1989-11-12,Iraq,Uganda,1,1,Friendly,Kuwait City,Kuwait,TRUE
 1989-11-12,Kuwait,Iran,1,0,Friendly,Kuwait City,Kuwait,FALSE
 1989-11-14,Brazil,Yugoslavia,0,0,Friendly,João Pessoa,Brazil,FALSE
-1989-11-14,USA,Bermuda,2,1,Friendly,Cocoa Beach,USA,FALSE
+1989-11-14,United States,Bermuda,2,1,Friendly,Cocoa Beach,United States,FALSE
 1989-11-15,Albania,Poland,1,2,FIFA World Cup qualification,Tirana,Albania,FALSE
 1989-11-15,Austria,German DR,3,0,FIFA World Cup qualification,Vienna,Austria,FALSE
 1989-11-15,England,Italy,0,0,Friendly,London,England,FALSE
@@ -16148,7 +16148,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1989-11-15,Switzerland,Luxembourg,2,1,FIFA World Cup qualification,St. Gallen,Switzerland,FALSE
 1989-11-17,Egypt,Algeria,1,0,FIFA World Cup qualification,Cairo,Egypt,FALSE
 1989-11-18,France,Cyprus,2,0,FIFA World Cup qualification,Toulouse,France,FALSE
-1989-11-19,Trinidad and Tobago,USA,0,1,CONCACAF Championship,Port of Spain,Trinidad and Tobago,FALSE
+1989-11-19,Trinidad and Tobago,United States,0,1,CONCACAF Championship,Port of Spain,Trinidad and Tobago,FALSE
 1989-11-19,Tunisia,Cameroon,0,1,FIFA World Cup qualification,Tunis,Tunisia,FALSE
 1989-11-21,Senegal,Central African Republic,3,0,Friendly,Dakar,Senegal,FALSE
 1989-11-26,Ghana,Guinea,1,1,Friendly,Paynesville,Liberia,TRUE
@@ -16182,7 +16182,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-01-12,Algeria,Mali,5,0,Friendly,Paris,France,TRUE
 1990-01-14,Algeria,Cameroon,3,1,Friendly,Paris,France,TRUE
 1990-01-17,Greece,Belgium,2,0,Friendly,Athens,Greece,FALSE
-1990-01-17,Mexico,Argentina,2,0,Friendly,Los Angeles,USA,TRUE
+1990-01-17,Mexico,Argentina,2,0,Friendly,Los Angeles,United States,TRUE
 1990-01-20,Malawi,Tanzania,2,2,Friendly,Lobamba,Eswatini,TRUE
 1990-01-20,Eswatini,Botswana,3,1,Friendly,Lobamba,Eswatini,FALSE
 1990-01-21,Botswana,Malawi,2,2,Friendly,Lobamba,Eswatini,TRUE
@@ -16198,15 +16198,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-01-27,United Arab Emirates,Egypt,1,0,Friendly,Abu Dhabi,United Arab Emirates,FALSE
 1990-01-28,Nigeria,Senegal,1,1,Friendly,Bauchi,Nigeria,FALSE
 1990-01-29,Thailand,Kenya,2,1,King's Cup,Bangkok,Thailand,FALSE
-1990-02-02,Colombia,Uruguay,0,2,Friendly,Miami,USA,TRUE
+1990-02-02,Colombia,Uruguay,0,2,Friendly,Miami,United States,TRUE
 1990-02-02,Indonesia,Kenya,2,3,King's Cup,Bangkok,Thailand,TRUE
 1990-02-02,Iran,Poland,0,2,Friendly,Tehran,Iran,FALSE
-1990-02-02,USA,Costa Rica,0,2,Friendly,Miami,USA,FALSE
+1990-02-02,United States,Costa Rica,0,2,Friendly,Miami,United States,FALSE
 1990-02-04,Algeria,Romania,0,0,Friendly,Algiers,Algeria,FALSE
-1990-02-04,Costa Rica,Uruguay,0,2,Friendly,Miami,USA,TRUE
+1990-02-04,Costa Rica,Uruguay,0,2,Friendly,Miami,United States,TRUE
 1990-02-04,Iran,Poland,0,1,Friendly,Tehran,Iran,FALSE
 1990-02-04,South Korea,Norway,2,3,Malta International Tournament,Attard,Malta,TRUE
-1990-02-04,USA,Colombia,1,1,Friendly,Miami,USA,FALSE
+1990-02-04,United States,Colombia,1,1,Friendly,Miami,United States,FALSE
 1990-02-05,Thailand,Indonesia,1,1,King's Cup,Bangkok,Thailand,FALSE
 1990-02-05,United Arab Emirates,Denmark,1,1,Friendly,Dubai,United Arab Emirates,FALSE
 1990-02-07,Malta,Norway,1,1,Malta International Tournament,Attard,Malta,FALSE
@@ -16215,25 +16215,25 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-02-11,Kuwait,Poland,1,1,Friendly,Cairo,Egypt,TRUE
 1990-02-11,Togo,Cameroon,1,1,Friendly,Lomé,Togo,FALSE
 1990-02-12,United Arab Emirates,Finland,1,1,Friendly,Dubai,United Arab Emirates,FALSE
-1990-02-13,Bermuda,USA,0,1,Friendly,Hamilton,Bermuda,FALSE
+1990-02-13,Bermuda,United States,0,1,Friendly,Hamilton,Bermuda,FALSE
 1990-02-14,Egypt,Denmark,0,0,Friendly,Cairo,Egypt,FALSE
 1990-02-14,United Arab Emirates,Sweden,2,1,Friendly,Dubai,United Arab Emirates,FALSE
 1990-02-15,Iraq,South Korea,0,0,Friendly,Baghdad,Iraq,FALSE
 1990-02-15,Kuwait,Finland,0,1,Friendly,Kuwait City,Kuwait,FALSE
 1990-02-17,United Arab Emirates,Sweden,0,2,Friendly,Dubai,United Arab Emirates,FALSE
 1990-02-18,Egypt,South Korea,0,0,Friendly,Cairo,Egypt,FALSE
-1990-02-20,Colombia,Russia,0,0,Friendly,Los Angeles,USA,TRUE
+1990-02-20,Colombia,Russia,0,0,Friendly,Los Angeles,United States,TRUE
 1990-02-21,Belgium,Sweden,0,0,Friendly,Brussels,Belgium,FALSE
 1990-02-21,Gambia,Guinea-Bissau,0,1,Friendly,Banjul,Gambia,FALSE
 1990-02-21,Kuwait,Bahrain,1,0,Gulf Cup,Kuwait City,Kuwait,FALSE
 1990-02-21,Morocco,Ivory Coast,2,1,Friendly,Rabat,Morocco,FALSE
 1990-02-21,Netherlands,Italy,0,0,Friendly,Rotterdam,Netherlands,FALSE
 1990-02-21,Spain,Czechoslovakia,1,0,Friendly,Alicante,Spain,FALSE
-1990-02-22,Costa Rica,Russia,1,2,Friendly,Los Angeles,USA,TRUE
+1990-02-22,Costa Rica,Russia,1,2,Friendly,Los Angeles,United States,TRUE
 1990-02-22,Oman,United Arab Emirates,1,1,Gulf Cup,Kuwait City,Kuwait,TRUE
 1990-02-23,Qatar,Bahrain,0,0,Gulf Cup,Kuwait City,Kuwait,TRUE
 1990-02-24,Kuwait,Oman,1,1,Gulf Cup,Kuwait City,Kuwait,FALSE
-1990-02-24,USA,Russia,1,3,Friendly,Palo Alto,USA,FALSE
+1990-02-24,United States,Russia,1,3,Friendly,Palo Alto,United States,FALSE
 1990-02-27,Qatar,United Arab Emirates,0,0,Gulf Cup,Kuwait City,Kuwait,TRUE
 1990-02-28,Egypt,Austria,0,0,Friendly,Cairo,Egypt,FALSE
 1990-02-28,France,Germany,2,1,Friendly,Montpellier,France,FALSE
@@ -16259,7 +16259,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-03-09,Zambia,Senegal,0,0,African Cup of Nations,Annaba,Algeria,TRUE
 1990-03-10,Angola,Lesotho,3,1,Friendly,Maputo,Mozambique,TRUE
 1990-03-10,Mozambique,Zimbabwe,3,1,Friendly,Maputo,Mozambique,FALSE
-1990-03-10,USA,Finland,2,1,Friendly,Tampa,USA,FALSE
+1990-03-10,United States,Finland,2,1,Friendly,Tampa,United States,FALSE
 1990-03-11,Mozambique,Lesotho,3,0,Friendly,Maputo,Mozambique,FALSE
 1990-03-12,Algeria,Senegal,2,1,African Cup of Nations,Algiers,Algeria,FALSE
 1990-03-12,Nigeria,Zambia,2,0,African Cup of Nations,Annaba,Algeria,TRUE
@@ -16267,8 +16267,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-03-16,Algeria,Nigeria,1,0,African Cup of Nations,Algiers,Algeria,FALSE
 1990-03-16,Jamaica,Barbados,0,1,Friendly,Kingston,Jamaica,FALSE
 1990-03-18,Jamaica,Barbados,1,0,Friendly,Kingston,Jamaica,FALSE
-1990-03-20,Hungary,USA,2,0,Friendly,Budapest,Hungary,FALSE
-1990-03-20,Mexico,Uruguay,2,1,Friendly,Los Angeles,USA,TRUE
+1990-03-20,Hungary,United States,2,0,Friendly,Budapest,Hungary,FALSE
+1990-03-20,Mexico,Uruguay,2,1,Friendly,Los Angeles,United States,TRUE
 1990-03-21,Basque Country,Romania,2,2,Friendly,Bilbao,Spain,FALSE
 1990-03-24,Sint Maarten,Cayman Islands,1,1,CFU Caribbean Cup qualification,Marigot,Saint Martin,TRUE
 1990-03-24,Saint Kitts and Nevis,Antigua and Barbuda,3,1,Friendly,Basseterre,Saint Kitts and Nevis,FALSE
@@ -16276,7 +16276,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-03-27,Northern Ireland,Norway,2,3,Friendly,Belfast,Northern Ireland,FALSE
 1990-03-28,Egypt,Romania,1,3,Friendly,Cairo,Egypt,FALSE
 1990-03-28,England,Brazil,1,0,Friendly,London,England,FALSE
-1990-03-28,German DR,USA,3,2,Friendly,Berlin,German DR,FALSE
+1990-03-28,German DR,United States,3,2,Friendly,Berlin,German DR,FALSE
 1990-03-28,Greece,Israel,2,1,Friendly,Athens,Greece,FALSE
 1990-03-28,Hungary,France,1,3,Friendly,Budapest,Hungary,FALSE
 1990-03-28,Republic of Ireland,Wales,1,0,Friendly,Dublin,Republic of Ireland,FALSE
@@ -16290,7 +16290,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-04-03,Bermuda,Iceland,0,4,Friendly,Hamilton,Bermuda,FALSE
 1990-04-03,Switzerland,Romania,2,1,Friendly,Lucerne,Switzerland,FALSE
 1990-04-04,Czechoslovakia,Egypt,0,1,Friendly,Brno,Czechoslovakia,FALSE
-1990-04-08,USA,Iceland,4,1,Friendly,St. Louis,USA,FALSE
+1990-04-08,United States,Iceland,4,1,Friendly,St. Louis,United States,FALSE
 1990-04-11,Algeria,Sweden,1,1,Friendly,Algiers,Algeria,FALSE
 1990-04-11,Austria,Hungary,3,0,Friendly,Salzburg,Austria,FALSE
 1990-04-11,Denmark,Turkey,1,0,Friendly,Copenhagen,Denmark,FALSE
@@ -16299,10 +16299,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-04-15,Barbados,Saint Lucia,1,0,CFU Caribbean Cup qualification,Bridgetown,Barbados,FALSE
 1990-04-16,Bermuda,Antigua and Barbuda,3,0,Friendly,Hamilton,Bermuda,FALSE
 1990-04-17,Grenada,Curaçao,1,1,CFU Caribbean Cup qualification,St. George's,Grenada,FALSE
-1990-04-17,Mexico,Colombia,2,0,Friendly,Los Angeles,USA,TRUE
+1990-04-17,Mexico,Colombia,2,0,Friendly,Los Angeles,United States,TRUE
 1990-04-22,Martinique,French Guiana,4,0,CFU Caribbean Cup qualification,Fort-de-France,Martinique,FALSE
 1990-04-22,Saint Vincent and the Grenadines,Dominica,2,1,CFU Caribbean Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
-1990-04-22,USA,Colombia,0,1,Friendly,Miami,USA,FALSE
+1990-04-22,United States,Colombia,0,1,Friendly,Miami,United States,FALSE
 1990-04-25,England,Czechoslovakia,4,2,Friendly,London,England,FALSE
 1990-04-25,Germany,Uruguay,3,3,Friendly,Stuttgart,Germany,FALSE
 1990-04-25,Republic of Ireland,Russia,1,0,Friendly,Dublin,Republic of Ireland,FALSE
@@ -16315,15 +16315,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-04-29,Suriname,Guyana,5,0,CFU Caribbean Cup qualification,Paramaribo,Suriname,FALSE
 1990-05-01,Guadeloupe,Martinique,1,0,Friendly,Paris,France,TRUE
 1990-05-03,Austria,Argentina,1,1,Friendly,Vienna,Austria,FALSE
-1990-05-04,Colombia,Poland,2,1,Friendly,Chicago,USA,TRUE
+1990-05-04,Colombia,Poland,2,1,Friendly,Chicago,United States,TRUE
 1990-05-05,Brazil,Bulgaria,2,1,Friendly,Campinas,Brazil,FALSE
-1990-05-05,USA,Malta,1,0,Friendly,Piscataway,USA,FALSE
+1990-05-05,United States,Malta,1,0,Friendly,Piscataway,United States,FALSE
 1990-05-06,Cayman Islands,Jamaica,1,2,Friendly,George Town,Cayman Islands,FALSE
-1990-05-06,Costa Rica,Poland,0,2,Friendly,Chicago,USA,TRUE
+1990-05-06,Costa Rica,Poland,0,2,Friendly,Chicago,United States,TRUE
 1990-05-06,Saint Martin,Guadeloupe,2,1,CFU Caribbean Cup qualification,Marigot,Saint Martin,FALSE
 1990-05-08,Switzerland,Argentina,1,1,Friendly,Berne,Switzerland,FALSE
 1990-05-08,Andalusia,Uruguay,1,1,Friendly,Seville,Spain,FALSE
-1990-05-09,USA,Poland,3,1,Friendly,Hershey,USA,FALSE
+1990-05-09,United States,Poland,3,1,Friendly,Hershey,United States,FALSE
 1990-05-13,Brazil,German DR,3,3,Friendly,Rio de Janeiro,Brazil,FALSE
 1990-05-13,Canada,Mexico,2,1,"NAFU Championship",Burnaby,Canada,FALSE
 1990-05-13,Dominica,French Guiana,1,1,CFU Caribbean Cup qualification,Roseau,Dominica,FALSE
@@ -16368,14 +16368,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-05-30,Guadeloupe,Jamaica,0,0,CFU Caribbean Cup qualification,Pointe-à-Pitre,Guadeloupe,FALSE
 1990-05-30,Iceland,Albania,2,0,UEFA Euro qualification,Reykjavík,Iceland,FALSE
 1990-05-30,Italy,Greece,0,0,Friendly,Perugia,Italy,FALSE
-1990-05-30,Liechtenstein,USA,1,4,Friendly,Eschen,Liechtenstein,FALSE
+1990-05-30,Liechtenstein,United States,1,4,Friendly,Eschen,Liechtenstein,FALSE
 1990-05-30,Martinique,Dominica,0,0,CFU Caribbean Cup qualification,Fort-de-France,Martinique,FALSE
 1990-05-31,Andalusia,Yugoslavia,0,0,Friendly,Cádiz,Spain,FALSE
 1990-06-01,Jordan,Iraq,0,2,Friendly,Amman,Jordan,FALSE
 1990-06-02,Belgium,Mexico,3,0,Friendly,Brussels,Belgium,FALSE
 1990-06-02,Hungary,Colombia,3,1,Friendly,Budapest,Hungary,FALSE
 1990-06-02,Malta,Republic of Ireland,0,3,Friendly,Attard,Malta,FALSE
-1990-06-02,Switzerland,USA,2,1,Friendly,St. Gallen,Switzerland,FALSE
+1990-06-02,Switzerland,United States,2,1,Friendly,St. Gallen,Switzerland,FALSE
 1990-06-02,Tunisia,England,1,1,Friendly,Tunis,Tunisia,FALSE
 1990-06-03,Gambia,Mauritania,2,1,African Cup of Nations qualification,Banjul,Gambia,FALSE
 1990-06-03,Yugoslavia,Netherlands,0,2,Friendly,Zagreb,Yugoslavia,FALSE
@@ -16389,7 +16389,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-06-10,Botswana,Mauritius,0,1,Friendly,Gaborone,Botswana,FALSE
 1990-06-10,Brazil,Sweden,2,1,FIFA World Cup,Turin,Italy,TRUE
 1990-06-10,Germany,Yugoslavia,4,1,FIFA World Cup,Milan,Italy,TRUE
-1990-06-10,USA,Czechoslovakia,1,5,FIFA World Cup,Florence,Italy,TRUE
+1990-06-10,United States,Czechoslovakia,1,5,FIFA World Cup,Florence,Italy,TRUE
 1990-06-11,Costa Rica,Scotland,1,0,FIFA World Cup,Genoa,Italy,TRUE
 1990-06-11,England,Republic of Ireland,1,1,FIFA World Cup,Cagliari,Italy,TRUE
 1990-06-12,Belgium,South Korea,2,0,FIFA World Cup,Verona,Italy,TRUE
@@ -16397,7 +16397,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-06-13,Argentina,Russia,2,0,FIFA World Cup,Naples,Italy,TRUE
 1990-06-13,Uruguay,Spain,0,0,FIFA World Cup,Udine,Italy,TRUE
 1990-06-14,Cameroon,Romania,2,1,FIFA World Cup,Bari,Italy,TRUE
-1990-06-14,Italy,USA,1,0,FIFA World Cup,Rome,Italy,FALSE
+1990-06-14,Italy,United States,1,0,FIFA World Cup,Rome,Italy,FALSE
 1990-06-14,Yugoslavia,Colombia,1,0,FIFA World Cup,Bologna,Italy,TRUE
 1990-06-15,Austria,Czechoslovakia,0,1,FIFA World Cup,Florence,Italy,TRUE
 1990-06-15,Germany,United Arab Emirates,5,1,FIFA World Cup,Milan,Italy,TRUE
@@ -16409,7 +16409,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-06-17,South Korea,Spain,1,3,FIFA World Cup,Udine,Italy,TRUE
 1990-06-18,Argentina,Romania,1,1,FIFA World Cup,Naples,Italy,TRUE
 1990-06-18,Cameroon,Russia,0,4,FIFA World Cup,Bari,Italy,TRUE
-1990-06-19,Austria,USA,2,1,FIFA World Cup,Florence,Italy,TRUE
+1990-06-19,Austria,United States,2,1,FIFA World Cup,Florence,Italy,TRUE
 1990-06-19,Germany,Colombia,1,1,FIFA World Cup,Milan,Italy,TRUE
 1990-06-19,Italy,Czechoslovakia,2,0,FIFA World Cup,Rome,Italy,FALSE
 1990-06-19,Yugoslavia,United Arab Emirates,4,1,FIFA World Cup,Bologna,Italy,TRUE
@@ -16520,7 +16520,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-09-12,Spain,Brazil,3,0,Friendly,Gijón,Spain,FALSE
 1990-09-12,Switzerland,Bulgaria,2,0,UEFA Euro qualification,Geneva,Switzerland,FALSE
 1990-09-13,Singapore,Malaysia,3,0,Friendly,Singapore,Singapore,FALSE
-1990-09-15,USA,Trinidad and Tobago,3,0,Friendly,High Point,USA,FALSE
+1990-09-15,United States,Trinidad and Tobago,3,0,Friendly,High Point,United States,FALSE
 1990-09-26,Czechoslovakia,Iceland,1,0,UEFA Euro qualification,Košice,Czechoslovakia,FALSE
 1990-09-26,Italy,Netherlands,1,0,Friendly,Palermo,Italy,FALSE
 1990-09-26,Romania,Poland,2,1,Friendly,Bucharest,Romania,FALSE
@@ -16533,7 +16533,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-10-10,Denmark,Faroe Islands,4,1,UEFA Euro qualification,Copenhagen,Denmark,FALSE
 1990-10-10,Greece,Egypt,6,1,Friendly,Athens,Greece,FALSE
 1990-10-10,Norway,Hungary,0,0,UEFA Euro qualification,Bergen,Norway,FALSE
-1990-10-10,Poland,USA,2,3,Friendly,Warsaw,Poland,FALSE
+1990-10-10,Poland,United States,2,3,Friendly,Warsaw,Poland,FALSE
 1990-10-10,Spain,Iceland,2,1,UEFA Euro qualification,Seville,Spain,FALSE
 1990-10-10,Sweden,Germany,1,3,Friendly,Solna,Sweden,FALSE
 1990-10-11,North Korea,South Korea,2,1,Friendly,Pyongyang,North Korea,FALSE
@@ -16541,7 +16541,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-10-14,Benin,Togo,1,1,African Cup of Nations qualification,Cotonou,Benin,FALSE
 1990-10-14,Niger,Mauritania,7,1,African Cup of Nations qualification,Niamey,Niger,FALSE
 1990-10-14,Ghana,Burkina Faso,2,0,African Cup of Nations qualification,Accra,Ghana,FALSE
-1990-10-17,Croatia,USA,2,1,Friendly,Zagreb,Croatia,FALSE
+1990-10-17,Croatia,United States,2,1,Friendly,Zagreb,Croatia,FALSE
 1990-10-17,England,Poland,2,0,UEFA Euro qualification,London,England,FALSE
 1990-10-17,Hungary,Italy,1,1,UEFA Euro qualification,Budapest,Hungary,FALSE
 1990-10-17,Republic of Ireland,Turkey,5,0,UEFA Euro qualification,Dublin,Republic of Ireland,FALSE
@@ -16584,8 +16584,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-11-14,Turkey,Poland,0,1,UEFA Euro qualification,Istanbul,Turkey,FALSE
 1990-11-17,Albania,France,0,1,UEFA Euro qualification,Tirana,Albania,FALSE
 1990-11-18,Ethiopia,Tunisia,0,2,African Cup of Nations qualification,Addis Ababa,Ethiopia,FALSE
-1990-11-18,Trinidad and Tobago,USA,0,0,Friendly,Port of Spain,Trinidad and Tobago,FALSE
-1990-11-21,USA,Russia,0,0,Friendly,Port of Spain,Trinidad and Tobago,TRUE
+1990-11-18,Trinidad and Tobago,United States,0,0,Friendly,Port of Spain,Trinidad and Tobago,FALSE
+1990-11-21,United States,Russia,0,0,Friendly,Port of Spain,Trinidad and Tobago,TRUE
 1990-11-24,Trinidad and Tobago,Russia,0,2,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 1990-11-25,Malta,Finland,1,1,UEFA Euro qualification,Attard,Malta,FALSE
 1990-11-29,Tanzania,Uganda,1,1,Friendly,Dar es Salaam,Tanzania,FALSE
@@ -16600,7 +16600,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-12-11,Malawi,Tanzania,1,0,CECAFA Cup,Zanzibar,Zanzibar,TRUE
 1990-12-12,Chad,Equatorial Guinea,1,0,UDEAC Cup,Brazzaville,Congo,TRUE
 1990-12-12,Kenya,Sudan,1,2,CECAFA Cup,Zanzibar,Zanzibar,TRUE
-1990-12-12,Mexico,Brazil,0,0,Friendly,Los Angeles,USA,TRUE
+1990-12-12,Mexico,Brazil,0,0,Friendly,Los Angeles,United States,TRUE
 1990-12-12,Zanzibar,Zimbabwe,0,1,CECAFA Cup,Zanzibar,Zanzibar,FALSE
 1990-12-13,Central African Republic,Cameroon,0,3,UDEAC Cup,Brazzaville,Congo,TRUE
 1990-12-13,Congo,Equatorial Guinea,6,0,UDEAC Cup,Brazzaville,Congo,FALSE
@@ -16618,7 +16618,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1990-12-19,Germany,Switzerland,4,0,Friendly,Stuttgart,Germany,FALSE
 1990-12-19,Greece,Poland,1,2,Friendly,Vólos,Greece,FALSE
 1990-12-19,Malta,Netherlands,0,8,UEFA Euro qualification,Attard,Malta,FALSE
-1990-12-19,Portugal,USA,1,0,Friendly,Maia,Portugal,FALSE
+1990-12-19,Portugal,United States,1,0,Friendly,Maia,Portugal,FALSE
 1990-12-19,Spain,Albania,9,0,UEFA Euro qualification,Seville,Spain,FALSE
 1990-12-19,Zanzibar,Tanzania,1,2,CECAFA Cup,Zanzibar,Zanzibar,FALSE
 1990-12-20,Sudan,Uganda,0,2,CECAFA Cup,Zanzibar,Zanzibar,TRUE
@@ -16646,8 +16646,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-01-27,Togo,Nigeria,0,0,African Cup of Nations qualification,Lomé,Togo,FALSE
 1991-01-29,Mexico,Colombia,0,0,Friendly,León,Mexico,FALSE
 1991-01-30,Australia,Czechoslovakia,0,1,Friendly,Melbourne,Australia,FALSE
-1991-02-01,USA,Switzerland,0,1,Friendly,Miami,USA,FALSE
-1991-02-03,Colombia,Switzerland,2,3,Friendly,Miami,USA,TRUE
+1991-02-01,United States,Switzerland,0,1,Friendly,Miami,United States,FALSE
+1991-02-03,Colombia,Switzerland,2,3,Friendly,Miami,United States,TRUE
 1991-02-05,Northern Ireland,Poland,3,1,Friendly,Belfast,Northern Ireland,FALSE
 1991-02-06,Malaysia,Indonesia,1,2,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1991-02-06,Australia,Czechoslovakia,0,2,Friendly,Parramatta,Australia,FALSE
@@ -16666,7 +16666,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-02-19,Argentina,Hungary,2,0,Friendly,Rosario,Argentina,FALSE
 1991-02-20,France,Spain,3,1,UEFA Euro qualification,Paris,France,FALSE
 1991-02-20,Portugal,Malta,5,0,UEFA Euro qualification,Porto,Portugal,FALSE
-1991-02-21,Bermuda,USA,1,0,Friendly,Hamilton,Bermuda,FALSE
+1991-02-21,Bermuda,United States,1,0,Friendly,Hamilton,Bermuda,FALSE
 1991-02-27,Belgium,Luxembourg,3,0,UEFA Euro qualification,Brussels,Belgium,FALSE
 1991-02-27,Brazil,Paraguay,1,1,Friendly,Campo Grande,Brazil,FALSE
 1991-02-27,Cyprus,Greece,1,1,Friendly,Limassol,Cyprus,FALSE
@@ -16675,12 +16675,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-03-05,Algeria,Tunisia,2,1,Friendly,Annaba,Algeria,FALSE
 1991-03-09,Uganda,Sudan,0,1,Friendly,Kampala,Uganda,FALSE
 1991-03-12,Liechtenstein,Switzerland,0,6,Friendly,Balzers,Liechtenstein,FALSE
-1991-03-12,USA,Mexico,2,2,"NAFU Championship",Los Angeles,USA,FALSE
+1991-03-12,United States,Mexico,2,2,"NAFU Championship",Los Angeles,United States,FALSE
 1991-03-13,Argentina,Mexico,0,0,Friendly,Buenos Aires,Argentina,FALSE
 1991-03-13,Netherlands,Malta,1,0,UEFA Euro qualification,Rotterdam,Netherlands,FALSE
 1991-03-13,Poland,Finland,1,1,Friendly,Warsaw,Poland,FALSE
-1991-03-14,Canada,Mexico,0,3,"NAFU Championship",Los Angeles,USA,TRUE
-1991-03-16,USA,Canada,2,0,"NAFU Championship",Torrance,USA,FALSE
+1991-03-14,Canada,Mexico,0,3,"NAFU Championship",Los Angeles,United States,TRUE
+1991-03-16,United States,Canada,2,0,"NAFU Championship",Torrance,United States,FALSE
 1991-03-27,Argentina,Brazil,3,3,Friendly,Buenos Aires,Argentina,FALSE
 1991-03-27,Belgium,Wales,1,1,UEFA Euro qualification,Brussels,Belgium,FALSE
 1991-03-27,Czechoslovakia,Poland,4,0,Friendly,Olomouc,Czechoslovakia,FALSE
@@ -16748,10 +16748,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-05-04,Madagascar,Angola,0,0,African Cup of Nations qualification,Antananarivo,Madagascar,FALSE
 1991-05-05,Jamaica,Haiti,2,1,Friendly,Kingston,Jamaica,FALSE
 1991-05-05,Senegal,Ivory Coast,0,0,Friendly,Dakar,Senegal,FALSE
-1991-05-05,USA,Uruguay,1,0,Friendly,Denver,USA,FALSE
+1991-05-05,United States,Uruguay,1,0,Friendly,Denver,United States,FALSE
 1991-05-06,Jamaica,Haiti,2,0,Friendly,Savanna-la-Mar,Jamaica,FALSE
 1991-05-07,Malta,Iceland,1,4,Friendly,Attard,Malta,FALSE
-1991-05-07,Mexico,Uruguay,0,2,Friendly,Los Angeles,USA,TRUE
+1991-05-07,Mexico,Uruguay,0,2,Friendly,Los Angeles,United States,TRUE
 1991-05-08,Aruba,Suriname,0,1,CFU Caribbean Cup qualification,Georgetown,Guyana,TRUE
 1991-05-08,Martinique,DR Congo,0,0,Friendly,Paris,France,TRUE
 1991-05-10,Cayman Islands,British Virgin Islands,2,1,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,TRUE
@@ -16775,7 +16775,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-05-17,Guadeloupe,French Guiana,1,0,CFU Caribbean Cup qualification,Fort-de-France,Martinique,TRUE
 1991-05-18,Honduras,Panama,3,0,UNCAF Cup,San Pedro Sula,Honduras,FALSE
 1991-05-19,Martinique,Guadeloupe,3,1,CFU Caribbean Cup qualification,Fort-de-France,Martinique,FALSE
-1991-05-19,USA,Argentina,0,1,Friendly,Palo Alto,USA,FALSE
+1991-05-19,United States,Argentina,0,1,Friendly,Palo Alto,United States,FALSE
 1991-05-21,England,Russia,3,1,Friendly,London,England,FALSE
 1991-05-21,Guyana,Haiti,1,1,Friendly,Georgetown,Guyana,FALSE
 1991-05-22,Austria,Faroe Islands,3,0,UEFA Euro qualification,Salzburg,Austria,FALSE
@@ -16805,7 +16805,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-05-30,Guyana,Trinidad and Tobago,1,3,CFU Caribbean Cup,Kingston,Jamaica,TRUE
 1991-05-30,Jamaica,Saint Lucia,2,0,CFU Caribbean Cup,Kingston,Jamaica,FALSE
 1991-06-01,Australia,England,0,1,Friendly,Sydney,Australia,FALSE
-1991-06-01,USA,Republic of Ireland,1,1,Friendly,Foxborough,USA,FALSE
+1991-06-01,United States,Republic of Ireland,1,1,Friendly,Foxborough,United States,FALSE
 1991-06-02,Costa Rica,Guatemala,1,0,UNCAF Cup,San José,Costa Rica,FALSE
 1991-06-02,Guyana,Saint Lucia,1,4,CFU Caribbean Cup,Kingston,Jamaica,TRUE
 1991-06-02,Honduras,El Salvador,2,1,UNCAF Cup,San José,Costa Rica,TRUE
@@ -16861,35 +16861,35 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-06-26,Åland Islands,Ynys Môn,0,1,Island Games,Åland,Finland,FALSE
 1991-06-26,Isle of Wight,Guernsey,1,1,Island Games,Åland,Finland,TRUE
 1991-06-27,Brazil,Argentina,1,1,Friendly,Curitiba,Brazil,FALSE
-1991-06-28,Canada,Honduras,2,4,Gold Cup,Los Angeles,USA,TRUE
+1991-06-28,Canada,Honduras,2,4,Gold Cup,Los Angeles,United States,TRUE
 1991-06-28,Gambia,Ghana,2,3,Friendly,Lagos,Nigeria,TRUE
-1991-06-28,Mexico,Jamaica,4,1,Gold Cup,Los Angeles,USA,TRUE
+1991-06-28,Mexico,Jamaica,4,1,Gold Cup,Los Angeles,United States,TRUE
 1991-06-28,Isle of Wight,Greenland,3,1,Island Games,Åland,Finland,TRUE
 1991-06-28,Shetland,Guernsey,2,1,Island Games,Åland,Finland,TRUE
 1991-06-28,Åland Islands,Jersey,0,2,Island Games,Åland,Finland,FALSE
-1991-06-29,Costa Rica,Guatemala,2,0,Gold Cup,Pasadena,USA,TRUE
-1991-06-29,USA,Trinidad and Tobago,2,1,Gold Cup,Pasadena,USA,FALSE
+1991-06-29,Costa Rica,Guatemala,2,0,Gold Cup,Pasadena,United States,TRUE
+1991-06-29,United States,Trinidad and Tobago,2,1,Gold Cup,Pasadena,United States,FALSE
 1991-06-29,Faroe Islands,Ynys Môn,2,0,Island Games,Åland,Finland,TRUE
-1991-06-30,Canada,Mexico,1,3,Gold Cup,Los Angeles,USA,TRUE
+1991-06-30,Canada,Mexico,1,3,Gold Cup,Los Angeles,United States,TRUE
 1991-06-30,Chile,Ecuador,3,1,Friendly,Santiago,Chile,FALSE
-1991-06-30,Jamaica,Honduras,0,5,Gold Cup,Los Angeles,USA,TRUE
-1991-07-01,Trinidad and Tobago,Costa Rica,2,1,Gold Cup,Pasadena,USA,TRUE
-1991-07-01,USA,Guatemala,3,0,Gold Cup,Pasadena,USA,FALSE
+1991-06-30,Jamaica,Honduras,0,5,Gold Cup,Los Angeles,United States,TRUE
+1991-07-01,Trinidad and Tobago,Costa Rica,2,1,Gold Cup,Pasadena,United States,TRUE
+1991-07-01,United States,Guatemala,3,0,Gold Cup,Pasadena,United States,FALSE
 1991-07-02,Moldova,Georgia,2,4,Friendly,Chișinău,Moldova,FALSE
-1991-07-03,Jamaica,Canada,2,3,Gold Cup,Los Angeles,USA,TRUE
-1991-07-03,Mexico,Honduras,1,1,Gold Cup,Los Angeles,USA,TRUE
-1991-07-03,Trinidad and Tobago,Guatemala,0,1,Gold Cup,Los Angeles,USA,TRUE
-1991-07-03,USA,Costa Rica,3,2,Gold Cup,Los Angeles,USA,FALSE
-1991-07-05,Honduras,Costa Rica,2,0,Gold Cup,Los Angeles,USA,TRUE
-1991-07-05,USA,Mexico,2,0,Gold Cup,Los Angeles,USA,FALSE
+1991-07-03,Jamaica,Canada,2,3,Gold Cup,Los Angeles,United States,TRUE
+1991-07-03,Mexico,Honduras,1,1,Gold Cup,Los Angeles,United States,TRUE
+1991-07-03,Trinidad and Tobago,Guatemala,0,1,Gold Cup,Los Angeles,United States,TRUE
+1991-07-03,United States,Costa Rica,3,2,Gold Cup,Los Angeles,United States,FALSE
+1991-07-05,Honduras,Costa Rica,2,0,Gold Cup,Los Angeles,United States,TRUE
+1991-07-05,United States,Mexico,2,0,Gold Cup,Los Angeles,United States,FALSE
 1991-07-06,Chile,Venezuela,2,0,Copa América,Santiago,Chile,FALSE
 1991-07-06,Malawi,Kenya,0,2,Friendly,Blantyre,Malawi,FALSE
 1991-07-06,Paraguay,Peru,1,0,Copa América,Santiago,Chile,TRUE
 1991-07-07,Bolivia,Uruguay,1,1,Copa América,Valparaíso,Chile,TRUE
 1991-07-07,Colombia,Ecuador,1,0,Copa América,Valparaíso,Chile,TRUE
 1991-07-07,Gabon,Ghana,0,1,Friendly,Libreville,Gabon,FALSE
-1991-07-07,Mexico,Costa Rica,2,0,Gold Cup,Los Angeles,USA,TRUE
-1991-07-07,USA,Honduras,0,0,Gold Cup,Los Angeles,USA,FALSE
+1991-07-07,Mexico,Costa Rica,2,0,Gold Cup,Los Angeles,United States,TRUE
+1991-07-07,United States,Honduras,0,0,Gold Cup,Los Angeles,United States,FALSE
 1991-07-08,Argentina,Venezuela,3,0,Copa América,Santiago,Chile,TRUE
 1991-07-08,Chile,Peru,4,2,Copa América,Concepción,Chile,FALSE
 1991-07-08,Malawi,Kenya,1,1,Friendly,Lilongwe,Malawi,FALSE
@@ -16952,7 +16952,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-08-21,Czechoslovakia,Switzerland,1,1,Friendly,Prague,Czechoslovakia,FALSE
 1991-08-21,Poland,Sweden,2,0,Friendly,Gdynia,Poland,FALSE
 1991-08-28,Norway,Russia,0,1,UEFA Euro qualification,Oslo,Norway,FALSE
-1991-08-28,Romania,USA,0,2,Friendly,Braşov,Romania,FALSE
+1991-08-28,Romania,United States,0,2,Friendly,Braşov,Romania,FALSE
 1991-09-01,Ivory Coast,Benin,1,0,Friendly,Abidjan,Ivory Coast,FALSE
 1991-09-04,Czechoslovakia,France,1,2,UEFA Euro qualification,Bratislava,Czechoslovakia,FALSE
 1991-09-04,Greece,Albania,0,2,Friendly,Athens,Greece,FALSE
@@ -16960,7 +16960,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-09-04,Portugal,Austria,1,1,Friendly,Porto,Portugal,FALSE
 1991-09-04,Spain,Uruguay,2,1,Friendly,Oviedo,Spain,FALSE
 1991-09-04,Sweden,Yugoslavia,4,3,Friendly,Solna,Sweden,FALSE
-1991-09-04,Turkey,USA,1,1,Friendly,Istanbul,Turkey,FALSE
+1991-09-04,Turkey,United States,1,1,Friendly,Istanbul,Turkey,FALSE
 1991-09-08,Mali,Guinea,0,0,Friendly,Bamako,Mali,FALSE
 1991-09-09,Guam,Tahiti,0,15,South Pacific Games,Lae,Papua New Guinea,TRUE
 1991-09-09,Papua New Guinea,Solomon Islands,0,0,South Pacific Games,Lae,Papua New Guinea,FALSE
@@ -16981,7 +16981,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-09-12,Papua New Guinea,Vanuatu,0,1,South Pacific Games,Lae,Papua New Guinea,FALSE
 1991-09-14,Fiji,Tahiti,3,0,South Pacific Games,Lae,Papua New Guinea,TRUE
 1991-09-14,Solomon Islands,Vanuatu,3,0,South Pacific Games,Lae,Papua New Guinea,TRUE
-1991-09-14,USA,Jamaica,1,0,Friendly,High Point,USA,FALSE
+1991-09-14,United States,Jamaica,1,0,Friendly,High Point,United States,FALSE
 1991-09-15,Guam,New Caledonia,0,18,South Pacific Games,Lae,Papua New Guinea,TRUE
 1991-09-15,Papua New Guinea,Wallis Islands and Futuna,5,0,South Pacific Games,Lae,Papua New Guinea,FALSE
 1991-09-17,Fiji,Vanuatu,3,1,South Pacific Games,Lae,Papua New Guinea,TRUE
@@ -17034,7 +17034,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-10-16,Northern Ireland,Austria,2,1,UEFA Euro qualification,Belfast,Northern Ireland,FALSE
 1991-10-16,Poland,Republic of Ireland,3,3,UEFA Euro qualification,Poznań,Poland,FALSE
 1991-10-16,Romania,Scotland,1,0,UEFA Euro qualification,Bucharest,Romania,FALSE
-1991-10-19,USA,North Korea,1,2,Friendly,Washington,USA,FALSE
+1991-10-19,United States,North Korea,1,2,Friendly,Washington,United States,FALSE
 1991-10-30,Brazil,Yugoslavia,3,1,Friendly,Varginha,Brazil,FALSE
 1991-10-30,Greece,Finland,2,0,UEFA Euro qualification,Athens,Greece,FALSE
 1991-10-30,Hungary,Norway,0,0,UEFA Euro qualification,Szombathely,Hungary,FALSE
@@ -17069,11 +17069,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1991-11-24,Guinea,Sierra Leone,0,1,Amílcar Cabral Cup,Dakar,Senegal,TRUE
 1991-11-24,Senegal,Guinea-Bissau,4,0,Amílcar Cabral Cup,Dakar,Senegal,FALSE
 1991-11-24,Sudan,Tanzania,1,1,CECAFA Cup,Kampala,Uganda,TRUE
-1991-11-24,USA,Costa Rica,1,1,Friendly,Dallas,USA,FALSE
+1991-11-24,United States,Costa Rica,1,1,Friendly,Dallas,United States,FALSE
 1991-11-25,Malawi,Zanzibar,1,0,CECAFA Cup,Kampala,Uganda,TRUE
 1991-11-26,Gambia,Guinea,0,0,Amílcar Cabral Cup,Dakar,Senegal,TRUE
 1991-11-26,Mali,Sierra Leone,1,1,Amílcar Cabral Cup,Dakar,Senegal,TRUE
-1991-11-27,Costa Rica,Mexico,1,1,Friendly,Los Angeles,USA,TRUE
+1991-11-27,Costa Rica,Mexico,1,1,Friendly,Los Angeles,United States,TRUE
 1991-11-27,Malta,Libya,2,0,Friendly,Attard,Malta,FALSE
 1991-11-27,Senegal,Cape Verde,0,0,Amílcar Cabral Cup,Dakar,Senegal,FALSE
 1991-11-27,Tunisia,Ivory Coast,5,3,Friendly,Tunis,Tunisia,FALSE
@@ -17133,29 +17133,29 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-01-23,Cameroon,Ivory Coast,0,0,African Cup of Nations,Dakar,Senegal,TRUE
 1992-01-23,Nigeria,Ghana,1,2,African Cup of Nations,Dakar,Senegal,TRUE
 1992-01-25,Cameroon,Nigeria,1,2,African Cup of Nations,Dakar,Senegal,TRUE
-1992-01-25,USA,Russia,0,1,Friendly,Miami Gardens,USA,FALSE
+1992-01-25,United States,Russia,0,1,Friendly,Miami Gardens,United States,FALSE
 1992-01-26,Australia,Sweden,0,0,Friendly,Sydney,Australia,FALSE
 1992-01-26,Ghana,Ivory Coast,0,0,African Cup of Nations,Dakar,Senegal,TRUE
 1992-01-29,Albania,Greece,1,0,Friendly,Tirana,Albania,FALSE
 1992-01-29,Australia,Sweden,1,0,Friendly,Adelaide,Australia,FALSE
 1992-01-29,El Salvador,Russia,0,3,Friendly,San Salvador,El Salvador,FALSE
 1992-02-02,Australia,Sweden,1,0,Friendly,Melbourne,Australia,FALSE
-1992-02-02,USA,Russia,2,1,Friendly,Pontiac,USA,FALSE
+1992-02-02,United States,Russia,2,1,Friendly,Pontiac,United States,FALSE
 1992-02-04,Bermuda,Norway,1,3,Friendly,Hamilton,Bermuda,FALSE
 1992-02-10,Malta,Iceland,1,0,Malta International Tournament,Attard,Malta,FALSE
-1992-02-12,Costa Rica,USA,0,0,Friendly,San José,Costa Rica,FALSE
+1992-02-12,Costa Rica,United States,0,0,Friendly,San José,Costa Rica,FALSE
 1992-02-12,Greece,Romania,1,0,Friendly,Ioannina,Greece,FALSE
 1992-02-12,Israel,Russia,1,2,Friendly,Jerusalem,Israel,FALSE
 1992-02-12,Portugal,Netherlands,2,0,Friendly,Faro,Portugal,FALSE
 1992-02-12,Turkey,Finland,1,1,Friendly,Adana,Turkey,FALSE
-1992-02-18,El Salvador,USA,2,0,Friendly,San Salvador,El Salvador,FALSE
+1992-02-18,El Salvador,United States,2,0,Friendly,San Salvador,El Salvador,FALSE
 1992-02-19,England,France,2,0,Friendly,London,England,FALSE
 1992-02-19,Republic of Ireland,Wales,0,1,Friendly,Dublin,Republic of Ireland,FALSE
 1992-02-19,Italy,San Marino,4,0,Friendly,Cesena,Italy,FALSE
 1992-02-19,Scotland,Northern Ireland,1,0,Friendly,Glasgow,Scotland,FALSE
 1992-02-19,Spain,Russia,1,1,Friendly,Valencia,Spain,FALSE
 1992-02-22,Tunisia,Nigeria,1,1,Friendly,Tunis,Tunisia,FALSE
-1992-02-26,Brazil,USA,3,0,Friendly,Fortaleza,Brazil,FALSE
+1992-02-26,Brazil,United States,3,0,Friendly,Fortaleza,Brazil,FALSE
 1992-02-26,Tunisia,Belgium,2,1,Friendly,Tunis,Tunisia,FALSE
 1992-03-02,United Arab Emirates,Iceland,0,1,Friendly,Dubai,United Arab Emirates,FALSE
 1992-03-03,Israel,Cyprus,2,1,Friendly,Bat Yam,Israel,FALSE
@@ -17166,9 +17166,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-03-08,Grenada,Curaçao,0,1,CFU Caribbean Cup qualification,Bridgetown,Barbados,TRUE
 1992-03-08,Mexico,Russia,4,0,Friendly,Mexico City,Mexico,FALSE
 1992-03-11,Mexico,Russia,1,1,Friendly,Ciudad Madero,Mexico,FALSE
-1992-03-11,Spain,USA,2,0,Friendly,Valladolid,Spain,FALSE
-1992-03-17,El Salvador,Honduras,1,1,Friendly,Los Angeles,USA,TRUE
-1992-03-18,Morocco,USA,3,1,Friendly,Casablanca,Morocco,FALSE
+1992-03-11,Spain,United States,2,0,Friendly,Valladolid,Spain,FALSE
+1992-03-17,El Salvador,Honduras,1,1,Friendly,Los Angeles,United States,TRUE
+1992-03-18,Morocco,United States,3,1,Friendly,Casablanca,Morocco,FALSE
 1992-03-21,Dominican Republic,Puerto Rico,1,2,FIFA World Cup qualification,Santo Domingo,Dominican Republic,FALSE
 1992-03-22,Saint Lucia,Saint Vincent and the Grenadines,1,0,FIFA World Cup qualification,Castries,Saint Lucia,FALSE
 1992-03-25,Cyprus,Greece,1,3,Friendly,Limassol,Cyprus,FALSE
@@ -17185,7 +17185,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-04-01,Cayman Islands,Martinique,0,7,CFU Caribbean Cup qualification,Philipsburg,Sint Maarten,TRUE
 1992-04-02,Canada,China PR,5,2,Friendly,Victoria,Canada,FALSE
 1992-04-03,Sint Maarten,Cayman Islands,4,2,CFU Caribbean Cup qualification,Philipsburg,Sint Maarten,FALSE
-1992-04-04,USA,China PR,5,0,Friendly,Palo Alto,USA,FALSE
+1992-04-04,United States,China PR,5,0,Friendly,Palo Alto,United States,FALSE
 1992-04-05,Sint Maarten,Martinique,1,1,CFU Caribbean Cup qualification,Philipsburg,Sint Maarten,FALSE
 1992-04-05,Togo,Ghana,1,0,Friendly,Lomé,Togo,FALSE
 1992-04-08,Israel,Iceland,2,2,Friendly,Ramat-Gan,Israel,FALSE
@@ -17218,7 +17218,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-04-29,Austria,Wales,1,1,Friendly,Vienna,Austria,FALSE
 1992-04-29,Denmark,Norway,1,0,Friendly,Aarhus,Denmark,FALSE
 1992-04-29,El Salvador,Costa Rica,1,1,Friendly,San Salvador,El Salvador,FALSE
-1992-04-29,Republic of Ireland,USA,4,1,Friendly,Dublin,Republic of Ireland,FALSE
+1992-04-29,Republic of Ireland,United States,4,1,Friendly,Dublin,Republic of Ireland,FALSE
 1992-04-29,Russia,England,2,2,Friendly,Moscow,Russia,FALSE
 1992-04-29,Ukraine,Hungary,1,3,Friendly,Uzhhorod,Ukraine,FALSE
 1992-04-30,Uruguay,Brazil,1,0,Friendly,Montevideo,Uruguay,FALSE
@@ -17242,7 +17242,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-05-17,England,Brazil,1,1,Friendly,London,England,FALSE
 1992-05-17,Qatar,Kuwait,0,0,Friendly,Doha,Qatar,FALSE
 1992-05-17,United Arab Emirates,Syria,2,0,Friendly,Al Ain,United Arab Emirates,FALSE
-1992-05-17,USA,Scotland,0,1,Friendly,Denver,USA,FALSE
+1992-05-17,United States,Scotland,0,1,Friendly,Denver,United States,FALSE
 1992-05-19,Austria,Poland,2,4,Friendly,Salzburg,Austria,FALSE
 1992-05-19,Bahrain,Algeria,0,0,Friendly,Manama,Bahrain,FALSE
 1992-05-20,Canada,Scotland,1,3,Friendly,Toronto,Canada,FALSE
@@ -17266,8 +17266,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-05-30,Japan,Argentina,0,1,Kirin Cup,Tokyo,Japan,FALSE
 1992-05-30,Netherlands,Wales,4,0,Friendly,Utrecht,Netherlands,FALSE
 1992-05-30,Puerto Rico,Jamaica,0,1,FIFA World Cup qualification,San Juan,Puerto Rico,FALSE
-1992-05-30,USA,Republic of Ireland,3,1,USA Cup,Washington,USA,FALSE
-1992-05-31,Italy,Portugal,0,0,USA Cup,New Haven,USA,TRUE
+1992-05-30,United States,Republic of Ireland,3,1,USA Cup,Washington,United States,FALSE
+1992-05-31,Italy,Portugal,0,0,USA Cup,New Haven,United States,TRUE
 1992-05-31,Qatar,Oman,4,0,AFC Asian Cup qualification,Doha,Qatar,FALSE
 1992-05-31,Trinidad and Tobago,Barbados,3,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 1992-06-01,Kazakhstan,Turkmenistan,1,0,Friendly,Almaty,Kazakhstan,FALSE
@@ -17282,14 +17282,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-06-03,North Korea,Taiwan,6,0,AFC Asian Cup qualification,Pyongyang,North Korea,FALSE
 1992-06-03,Macau,Hong Kong,2,2,AFC Asian Cup qualification,Pyongyang,North Korea,TRUE
 1992-06-03,Norway,Scotland,0,0,Friendly,Oslo,Norway,FALSE
-1992-06-03,USA,Portugal,1,0,USA Cup,Chicago,USA,FALSE
-1992-06-04,Republic of Ireland,Italy,0,2,USA Cup,Foxborough,USA,TRUE
+1992-06-03,United States,Portugal,1,0,USA Cup,Chicago,United States,FALSE
+1992-06-04,Republic of Ireland,Italy,0,2,USA Cup,Foxborough,United States,TRUE
 1992-06-05,France,Netherlands,1,1,Friendly,Lens,France,FALSE
 1992-06-05,Hong Kong,Taiwan,0,0,AFC Asian Cup qualification,Pyongyang,North Korea,TRUE
 1992-06-05,North Korea,Macau,2,0,AFC Asian Cup qualification,Pyongyang,North Korea,FALSE
-1992-06-06,USA,Italy,1,1,USA Cup,Chicago,USA,FALSE
+1992-06-06,United States,Italy,1,1,USA Cup,Chicago,United States,FALSE
 1992-06-07,Guatemala,Nicaragua,7,1,Friendly,Guatemala,Guatemala,FALSE
-1992-06-07,Republic of Ireland,Portugal,2,0,USA Cup,Foxborough,USA,TRUE
+1992-06-07,Republic of Ireland,Portugal,2,0,USA Cup,Foxborough,United States,TRUE
 1992-06-07,Japan,Wales,0,1,Kirin Cup,Matsuyama,Japan,FALSE
 1992-06-07,North Korea,Hong Kong,0,0,AFC Asian Cup qualification,Pyongyang,North Korea,FALSE
 1992-06-07,Macau,Taiwan,2,0,AFC Asian Cup qualification,Pyongyang,North Korea,TRUE
@@ -17299,7 +17299,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-06-12,Netherlands,Scotland,1,0,UEFA Euro,Gothenburg,Sweden,TRUE
 1992-06-12,Russia,Germany,1,1,UEFA Euro,Norrköping,Sweden,TRUE
 1992-06-13,Canada,Hong Kong,3,1,Friendly,Toronto,Canada,FALSE
-1992-06-13,USA,Australia,0,1,Friendly,Orlando,USA,FALSE
+1992-06-13,United States,Australia,0,1,Friendly,Orlando,United States,FALSE
 1992-06-14,Antigua and Barbuda,Bermuda,0,3,FIFA World Cup qualification,St. John's,Antigua and Barbuda,FALSE
 1992-06-14,France,England,0,0,UEFA Euro,Malmö,Sweden,TRUE
 1992-06-14,Gabon,Togo,1,0,Friendly,Libreville,Gabon,FALSE
@@ -17333,7 +17333,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-06-26,Sudan,Eritrea,1,1,Friendly,Khartoum,Sudan,FALSE
 1992-06-27,Cuba,Martinique,1,1,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,TRUE
 1992-06-27,Trinidad and Tobago,Jamaica,3,1,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,FALSE
-1992-06-27,USA,Ukraine,0,0,Friendly,Piscataway,USA,FALSE
+1992-06-27,United States,Ukraine,0,0,Friendly,Piscataway,United States,FALSE
 1992-06-27,Vanuatu,New Zealand,1,4,FIFA World Cup qualification,Port Vila,Vanuatu,FALSE
 1992-06-28,Botswana,Lesotho,0,4,African Cup of Nations qualification,Gaborone,Botswana,FALSE
 1992-06-28,Cape Verde,Guinea-Bissau,1,0,African Cup of Nations qualification,Praia,Cape Verde,FALSE
@@ -17381,13 +17381,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-07-28,Ivory Coast,Egypt,2,2,Friendly,Abidjan,Ivory Coast,FALSE
 1992-07-30,New Caledonia,Solomon Islands,1,0,Friendly,Port Vila,Vanuatu,TRUE
 1992-07-30,Vanuatu,Fiji,0,2,Friendly,Port Vila,Vanuatu,FALSE
-1992-07-31,Brazil,Mexico,5,0,Friendly,Los Angeles,USA,TRUE
-1992-07-31,USA,Colombia,0,1,Friendly,Los Angeles,USA,FALSE
+1992-07-31,Brazil,Mexico,5,0,Friendly,Los Angeles,United States,TRUE
+1992-07-31,United States,Colombia,0,1,Friendly,Los Angeles,United States,FALSE
 1992-08-01,Lesotho,Namibia,2,0,Friendly,Maseru,Lesotho,FALSE
 1992-08-02,Lesotho,Namibia,2,2,Friendly,Maseru,Lesotho,FALSE
-1992-08-02,Mexico,Colombia,0,0,Friendly,Los Angeles,USA,TRUE
+1992-08-02,Mexico,Colombia,0,0,Friendly,Los Angeles,United States,TRUE
 1992-08-02,Uruguay,Costa Rica,2,1,Friendly,Montevideo,Uruguay,FALSE
-1992-08-02,USA,Brazil,0,1,Friendly,Los Angeles,USA,FALSE
+1992-08-02,United States,Brazil,0,1,Friendly,Los Angeles,United States,FALSE
 1992-08-05,Faroe Islands,Israel,1,1,Friendly,Toftir,Faroe Islands,FALSE
 1992-08-06,Ecuador,Costa Rica,1,1,Friendly,Guayaquil,Ecuador,FALSE
 1992-08-08,Indonesia,Malaysia,1,1,Friendly,Jakarta,Indonesia,FALSE
@@ -17396,7 +17396,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-08-09,Lesotho,Mauritius,2,2,Friendly,Maseru,Lesotho,FALSE
 1992-08-09,Libya,Niger,0,0,Friendly,Tripoli,Libya,FALSE
 1992-08-11,Australia,Malaysia,0,1,Friendly,Jakarta,Indonesia,TRUE
-1992-08-12,El Salvador,Honduras,0,3,Friendly,Los Angeles,USA,TRUE
+1992-08-12,El Salvador,Honduras,0,3,Friendly,Los Angeles,United States,TRUE
 1992-08-12,Latvia,Lithuania,1,2,FIFA World Cup qualification,Riga,Latvia,FALSE
 1992-08-12,Libya,Mali,0,1,Friendly,Tripoli,Libya,FALSE
 1992-08-14,Algeria,Guinea-Bissau,3,1,African Cup of Nations qualification,Oran,Algeria,FALSE
@@ -17462,7 +17462,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-09-02,Czechoslovakia,Belgium,1,2,FIFA World Cup qualification,Prague,Czechoslovakia,FALSE
 1992-09-02,Greece,Cyprus,2,3,Friendly,Salonica,Greece,FALSE
 1992-09-02,Lithuania,Georgia,1,0,Friendly,Kaunas,Lithuania,FALSE
-1992-09-03,Canada,USA,0,2,Friendly,Saint John,Canada,FALSE
+1992-09-03,Canada,United States,0,2,Friendly,Saint John,Canada,FALSE
 1992-09-04,Solomon Islands,Australia,1,2,FIFA World Cup qualification,Honiara,Solomon Islands,FALSE
 1992-09-08,Egypt,Jordan,1,1,Arab Cup,Aleppo,Syria,TRUE
 1992-09-09,Syria,Saudi Arabia,1,1,Arab Cup,Aleppo,Syria,FALSE
@@ -17518,13 +17518,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-10-04,Mali,Morocco,2,1,African Cup of Nations qualification,Bamako,Mali,FALSE
 1992-10-06,Saudi Arabia,Cameroon,2,1,Friendly,Riyadh,Saudi Arabia,FALSE
 1992-10-07,Cyprus,Malta,3,0,Friendly,Limassol,Cyprus,FALSE
-1992-10-07,El Salvador,Mexico,0,2,Friendly,Los Angeles,USA,TRUE
+1992-10-07,El Salvador,Mexico,0,2,Friendly,Los Angeles,United States,TRUE
 1992-10-07,Iceland,Greece,0,1,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
 1992-10-07,San Marino,Norway,0,2,FIFA World Cup qualification,Serravalle,San Marino,FALSE
 1992-10-07,Sweden,Bulgaria,2,0,FIFA World Cup qualification,Solna,Sweden,FALSE
 1992-10-09,Algeria,Burundi,3,1,FIFA World Cup qualification,Tlemcen,Algeria,FALSE
 1992-10-09,Tahiti,Solomon Islands,4,2,FIFA World Cup qualification,Papeete,French Polynesia,TRUE
-1992-10-09,USA,Canada,0,0,Friendly,Greensboro,USA,FALSE
+1992-10-09,United States,Canada,0,0,Friendly,Greensboro,United States,FALSE
 1992-10-09,Zimbabwe,Togo,1,0,FIFA World Cup qualification,Harare,Zimbabwe,FALSE
 1992-10-10,Nigeria,South Africa,4,0,FIFA World Cup qualification,Lagos,Nigeria,FALSE
 1992-10-11,DR Congo,Liberia,4,2,FIFA World Cup qualification,Kinshasa,Zaïre,FALSE
@@ -17552,14 +17552,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1992-10-14,Scotland,Portugal,0,0,FIFA World Cup qualification,Glasgow,Scotland,FALSE
 1992-10-14,Turkmenistan,Kyrgyzstan,4,0,Friendly,Ashgabat,Turkmenistan,FALSE
 1992-10-14,Uzbekistan,Kazakhstan,1,1,Friendly,Tashkent,Uzbekistan,FALSE
-1992-10-15,Saudi Arabia,USA,3,0,Confederations Cup,Riyadh,Saudi Arabia,FALSE
+1992-10-15,Saudi Arabia,United States,3,0,Confederations Cup,Riyadh,Saudi Arabia,FALSE
 1992-10-16,Argentina,Ivory Coast,4,0,Confederations Cup,Riyadh,Saudi Arabia,TRUE
 1992-10-18,Bermuda,El Salvador,1,0,FIFA World Cup qualification,Hamilton,Bermuda,FALSE
 1992-10-18,Cameroon,Eswatini,5,0,FIFA World Cup qualification,Yaoundé,Cameroon,FALSE
 1992-10-18,Jamaica,Canada,1,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 1992-10-18,Kuwait,Iran,1,1,Friendly,Kuwait City,Kuwait,FALSE
 1992-10-18,Niger,Mali,0,2,Friendly,Niamey,Niger,FALSE
-1992-10-19,USA,Ivory Coast,5,2,Confederations Cup,Riyadh,Saudi Arabia,TRUE
+1992-10-19,United States,Ivory Coast,5,2,Confederations Cup,Riyadh,Saudi Arabia,TRUE
 1992-10-20,Saudi Arabia,Argentina,1,3,Confederations Cup,Riyadh,Saudi Arabia,FALSE
 1992-10-21,South Korea,United Arab Emirates,0,0,Friendly,Anyang,South Korea,FALSE
 1992-10-22,Croatia,Mexico,3,0,Friendly,Zagreb,Croatia,FALSE
@@ -17743,7 +17743,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-01-30,India,Cameroon,2,2,Nehru Cup,Madras,India,FALSE
 1993-01-30,Peru,Belarus,1,1,Friendly,Lima,Peru,FALSE
 1993-01-30,Senegal,Mozambique,6,1,FIFA World Cup qualification,Dakar,Senegal,FALSE
-1993-01-30,USA,Denmark,2,2,Friendly,Tempe,USA,FALSE
+1993-01-30,United States,Denmark,2,2,Friendly,Tempe,United States,FALSE
 1993-01-30,Zambia,Namibia,4,0,FIFA World Cup qualification,Lusaka,Zambia,FALSE
 1993-01-31,Congo,South Africa,0,1,FIFA World Cup qualification,Pointe-Noire,Congo,FALSE
 1993-01-31,Ecuador,Romania,3,0,Friendly,Guayaquil,Ecuador,FALSE
@@ -17759,18 +17759,18 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-02-03,Peru,Romania,0,2,Friendly,Lima,Peru,FALSE
 1993-02-05,Malaysia,Singapore,2,1,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1993-02-06,Ghana,Indonesia,2,0,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
-1993-02-06,USA,Romania,1,1,Friendly,Santa Barbara,USA,FALSE
+1993-02-06,United States,Romania,1,1,Friendly,Santa Barbara,United States,FALSE
 1993-02-07,Malaysia,Thailand,1,1,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 1993-02-09,Singapore,Thailand,1,1,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 1993-02-10,Mexico,Romania,0,2,Friendly,Monterrey,Mexico,FALSE
 1993-02-10,Portugal,Norway,1,1,Friendly,Faro,Portugal,FALSE
 1993-02-10,Thailand,China PR,1,0,King's Cup,Bangkok,Thailand,FALSE
 1993-02-13,Cyprus,Belgium,0,3,FIFA World Cup qualification,Nicosia,Cyprus,FALSE
-1993-02-13,USA,Russia,0,1,Friendly,Orlando,USA,FALSE
+1993-02-13,United States,Russia,0,1,Friendly,Orlando,United States,FALSE
 1993-02-16,Costa Rica,Nicaragua,6,0,UNCAF Cup,San José,Costa Rica,FALSE
 1993-02-16,Thailand,China PR,0,4,King's Cup,Bangkok,Thailand,FALSE
 1993-02-17,Albania,Northern Ireland,1,2,FIFA World Cup qualification,Tirana,Albania,FALSE
-1993-02-17,El Salvador,Russia,1,2,Friendly,Pasadena,USA,TRUE
+1993-02-17,El Salvador,Russia,1,2,Friendly,Pasadena,United States,TRUE
 1993-02-17,England,San Marino,6,0,FIFA World Cup qualification,London,England,FALSE
 1993-02-17,Greece,Luxembourg,2,0,FIFA World Cup qualification,Athens,Greece,FALSE
 1993-02-17,Republic of Ireland,Wales,2,1,Friendly,Dublin,Republic of Ireland,FALSE
@@ -17784,7 +17784,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-02-20,United Arab Emirates,Bulgaria,1,3,Friendly,Dubai,United Arab Emirates,FALSE
 1993-02-21,Estonia,Latvia,0,2,Friendly,Vantaa,Finland,TRUE
 1993-02-21,Finland,Lithuania,3,0,Friendly,Vantaa,Finland,FALSE
-1993-02-21,USA,Russia,0,0,Friendly,Palo Alto,USA,FALSE
+1993-02-21,United States,Russia,0,0,Friendly,Palo Alto,United States,FALSE
 1993-02-24,Argentina,Denmark,1,1,CONMEBOL–UEFA Cup of Champions,Mar del Plata,Argentina,FALSE
 1993-02-24,Kuwait,China PR,1,0,Friendly,Kuwait City,Kuwait,FALSE
 1993-02-24,Netherlands,Turkey,3,1,FIFA World Cup qualification,Utrecht,Netherlands,FALSE
@@ -17813,7 +17813,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-03-09,Costa Rica,Panama,2,0,UNCAF Cup,Tegucigalpa,Honduras,TRUE
 1993-03-09,Honduras,El Salvador,3,0,UNCAF Cup,Tegucigalpa,Honduras,FALSE
 1993-03-10,Austria,Greece,2,1,Friendly,Vienna,Austria,FALSE
-1993-03-10,Hungary,USA,0,0,Kirin Cup,Nagoya,Japan,TRUE
+1993-03-10,Hungary,United States,0,0,Kirin Cup,Nagoya,Japan,TRUE
 1993-03-10,San Marino,Turkey,0,0,FIFA World Cup qualification,Serravalle,San Marino,FALSE
 1993-03-11,Canada,South Korea,2,0,Friendly,Victoria,Canada,FALSE
 1993-03-11,Guyana,Cayman Islands,3,2,CFU Caribbean Cup qualification,Georgetown,Guyana,FALSE
@@ -17824,13 +17824,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-03-12,Qatar,Jordan,1,2,Friendly,Doha,Qatar,FALSE
 1993-03-14,Guyana,Barbados,0,3,CFU Caribbean Cup qualification,Georgetown,Guyana,FALSE
 1993-03-14,Honduras,Bolivia,0,0,Friendly,San Pedro Sula,Honduras,FALSE
-1993-03-14,Japan,USA,3,1,Kirin Cup,Tokyo,Japan,FALSE
+1993-03-14,Japan,United States,3,1,Kirin Cup,Tokyo,Japan,FALSE
 1993-03-14,Puerto Rico,Cayman Islands,4,0,CFU Caribbean Cup qualification,Georgetown,Guyana,TRUE
 1993-03-16,Honduras,Bolivia,0,0,Friendly,Tegucigalpa,Honduras,FALSE
 1993-03-16,Kuwait,Syria,2,1,Friendly,Kuwait City,Kuwait,FALSE
 1993-03-17,Brazil,Poland,2,2,Friendly,Ribeirão Preto,Brazil,FALSE
 1993-03-17,Tunisia,Switzerland,0,1,Friendly,Tunis,Tunisia,FALSE
-1993-03-23,El Salvador,USA,2,2,Friendly,San Salvador,El Salvador,FALSE
+1993-03-23,El Salvador,United States,2,2,Friendly,San Salvador,El Salvador,FALSE
 1993-03-24,Costa Rica,Canada,0,1,Friendly,San José,Costa Rica,FALSE
 1993-03-24,Cyprus,Czech Republic,1,1,FIFA World Cup qualification,Limassol,Cyprus,FALSE
 1993-03-24,French Guiana,Guadeloupe,2,1,CFU Caribbean Cup qualification,Cayenne,French Guiana,FALSE
@@ -17838,7 +17838,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-03-24,Italy,Malta,6,1,FIFA World Cup qualification,Palermo,Italy,FALSE
 1993-03-24,Netherlands,San Marino,6,0,FIFA World Cup qualification,Utrecht,Netherlands,FALSE
 1993-03-24,Scotland,Germany,0,1,Friendly,Glasgow,Scotland,FALSE
-1993-03-25,Honduras,USA,4,1,Friendly,Tegucigalpa,Honduras,FALSE
+1993-03-25,Honduras,United States,4,1,Friendly,Tegucigalpa,Honduras,FALSE
 1993-03-26,Lebanon,Jordan,1,0,Friendly,Beirut,Lebanon,FALSE
 1993-03-27,Austria,France,0,1,FIFA World Cup qualification,Vienna,Austria,FALSE
 1993-03-27,Malawi,Zambia,1,0,Friendly,Lilongwe,Malawi,FALSE
@@ -17912,7 +17912,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-04-16,Qatar,Singapore,4,1,FIFA World Cup qualification,Doha,Qatar,FALSE
 1993-04-16,Vietnam,Indonesia,1,0,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-04-17,Malta,Switzerland,0,2,FIFA World Cup qualification,Attard,Malta,FALSE
-1993-04-17,USA,Iceland,1,1,Friendly,Costa Mesa,USA,FALSE
+1993-04-17,United States,Iceland,1,1,Friendly,Costa Mesa,United States,FALSE
 1993-04-18,Cameroon,Guinea,3,1,FIFA World Cup qualification,Yaoundé,Cameroon,FALSE
 1993-04-18,Canada,Honduras,3,1,FIFA World Cup qualification,Burnaby,Canada,FALSE
 1993-04-18,Indonesia,Singapore,0,2,FIFA World Cup qualification,Doha,Qatar,TRUE
@@ -17994,7 +17994,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-05-07,Hong Kong,Bahrain,2,1,FIFA World Cup qualification,Beirut,Lebanon,TRUE
 1993-05-07,Lebanon,India,2,2,FIFA World Cup qualification,Beirut,Lebanon,FALSE
 1993-05-07,United Arab Emirates,Japan,1,1,FIFA World Cup qualification,Al Ain,United Arab Emirates,FALSE
-1993-05-08,USA,Colombia,1,2,Friendly,Miami,USA,FALSE
+1993-05-08,United States,Colombia,1,2,Friendly,Miami,United States,FALSE
 1993-05-09,Bahrain,South Korea,0,0,FIFA World Cup qualification,Beirut,Lebanon,TRUE
 1993-05-09,Canada,Mexico,1,2,FIFA World Cup qualification,Toronto,Canada,FALSE
 1993-05-09,El Salvador,Honduras,2,1,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
@@ -18036,7 +18036,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-05-23,Russia,Greece,1,1,FIFA World Cup qualification,Moscow,Russia,FALSE
 1993-05-23,Saint Kitts and Nevis,Puerto Rico,1,0,CFU Caribbean Cup,Kingston,Jamaica,TRUE
 1993-05-23,Trinidad and Tobago,Saint Lucia,1,1,CFU Caribbean Cup,Montego Bay,Jamaica,TRUE
-1993-05-23,USA,Bolivia,0,0,Friendly,Fullerton,USA,FALSE
+1993-05-23,United States,Bolivia,0,0,Friendly,Fullerton,United States,FALSE
 1993-05-24,Jordan,Iraq,1,1,FIFA World Cup qualification,Irbid,Jordan,FALSE
 1993-05-24,New Zealand,Fiji,5,0,Friendly,Palmerston North,New Zealand,FALSE
 1993-05-24,Yemen,Pakistan,5,1,FIFA World Cup qualification,Irbid,Jordan,TRUE
@@ -18050,7 +18050,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-05-26,Albania,Republic of Ireland,1,2,FIFA World Cup qualification,Tirana,Albania,FALSE
 1993-05-26,Ethiopia,Sudan,1,1,Friendly,Addis Ababa,Ethiopia,FALSE
 1993-05-26,Jordan,China PR,0,3,FIFA World Cup qualification,Irbid,Jordan,FALSE
-1993-05-26,USA,Peru,0,0,Friendly,Mission Viejo,USA,FALSE
+1993-05-26,United States,Peru,0,0,Friendly,Mission Viejo,United States,FALSE
 1993-05-26,Yemen,Iraq,1,6,FIFA World Cup qualification,Irbid,Jordan,TRUE
 1993-05-27,Bolivia,Paraguay,2,1,Copa Paz del Chaco,Cochabamba,Bolivia,FALSE
 1993-05-28,Jamaica,Trinidad and Tobago,3,0,CFU Caribbean Cup,Kingston,Jamaica,FALSE
@@ -18083,7 +18083,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-06-06,Faroe Islands,Wales,0,3,FIFA World Cup qualification,Toftir,Faroe Islands,FALSE
 1993-06-06,Iran,Pakistan,5,0,Friendly,Tehran,Iran,FALSE
 1993-06-06,Peru,Bolivia,1,0,Friendly,Lima,Peru,FALSE
-1993-06-06,USA,Brazil,0,2,USA Cup,New Haven,USA,FALSE
+1993-06-06,United States,Brazil,0,2,USA Cup,New Haven,United States,FALSE
 1993-06-07,Azerbaijan,Kyrgyzstan,3,2,Friendly,Tehran,Iran,TRUE
 1993-06-07,India,Bahrain,0,3,FIFA World Cup qualification,Seoul,South Korea,TRUE
 1993-06-07,South Korea,Lebanon,2,0,FIFA World Cup qualification,Seoul,South Korea,FALSE
@@ -18095,8 +18095,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-06-09,South Korea,India,7,0,FIFA World Cup qualification,Seoul,South Korea,FALSE
 1993-06-09,Latvia,Republic of Ireland,0,2,FIFA World Cup qualification,Riga,Latvia,FALSE
 1993-06-09,Netherlands,Norway,0,0,FIFA World Cup qualification,Rotterdam,Netherlands,FALSE
-1993-06-09,USA,England,2,0,USA Cup,Foxborough,USA,FALSE
-1993-06-10,Brazil,Germany,3,3,USA Cup,Washington,USA,TRUE
+1993-06-09,United States,England,2,0,USA Cup,Foxborough,United States,FALSE
+1993-06-10,Brazil,Germany,3,3,USA Cup,Washington,United States,TRUE
 1993-06-10,Mexico,Paraguay,3,1,Friendly,Mexico City,Mexico,FALSE
 1993-06-11,Bahrain,Hong Kong,3,0,FIFA World Cup qualification,Seoul,South Korea,TRUE
 1993-06-11,India,Lebanon,1,2,FIFA World Cup qualification,Seoul,South Korea,TRUE
@@ -18106,11 +18106,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-06-12,China PR,Pakistan,3,0,FIFA World Cup qualification,Chengdu,China PR,FALSE
 1993-06-12,Yemen,Jordan,1,1,FIFA World Cup qualification,Chengdu,China PR,TRUE
 1993-06-13,Bolivia,Chile,1,3,Friendly,La Paz,Bolivia,FALSE
-1993-06-13,Brazil,England,1,1,USA Cup,Washington,USA,TRUE
+1993-06-13,Brazil,England,1,1,USA Cup,Washington,United States,TRUE
 1993-06-13,Hong Kong,India,1,3,FIFA World Cup qualification,Seoul,South Korea,TRUE
 1993-06-13,Iran,Tajikistan,1,0,Friendly,Tehran,Iran,FALSE
 1993-06-13,South Korea,Bahrain,3,0,FIFA World Cup qualification,Seoul,South Korea,FALSE
-1993-06-13,USA,Germany,3,4,USA Cup,Chicago,USA,FALSE
+1993-06-13,United States,Germany,3,4,USA Cup,Chicago,United States,FALSE
 1993-06-14,Iran,Turkmenistan,2,1,Friendly,Tehran,Iran,FALSE
 1993-06-14,Iraq,Jordan,4,0,FIFA World Cup qualification,Chengdu,China PR,TRUE
 1993-06-14,South Korea,Czech Republic,1,2,Korea Cup,Seoul,South Korea,FALSE
@@ -18123,14 +18123,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-06-16,Iceland,Hungary,2,0,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
 1993-06-16,Iraq,Yemen,3,0,FIFA World Cup qualification,Chengdu,China PR,TRUE
 1993-06-16,Lithuania,Republic of Ireland,0,1,FIFA World Cup qualification,Vilnius,Lithuania,FALSE
-1993-06-16,Uruguay,USA,1,0,Copa América,Ambato,Ecuador,TRUE
+1993-06-16,Uruguay,United States,1,0,Copa América,Ambato,Ecuador,TRUE
 1993-06-17,Argentina,Bolivia,1,0,Copa América,Guayaquil,Ecuador,TRUE
 1993-06-18,Brazil,Peru,0,0,Copa América,Cuenca,Ecuador,TRUE
 1993-06-18,China PR,Yemen,1,0,FIFA World Cup qualification,Chengdu,China PR,FALSE
 1993-06-18,Iraq,Pakistan,4,0,FIFA World Cup qualification,Chengdu,China PR,TRUE
 1993-06-18,Paraguay,Chile,1,0,Copa América,Cuenca,Ecuador,TRUE
-1993-06-19,Ecuador,USA,2,0,Copa América,Quito,Ecuador,FALSE
-1993-06-19,England,Germany,1,2,USA Cup,Pontiac,USA,TRUE
+1993-06-19,Ecuador,United States,2,0,Copa América,Quito,Ecuador,FALSE
+1993-06-19,England,Germany,1,2,USA Cup,Pontiac,United States,TRUE
 1993-06-19,South Korea,Egypt,1,2,Korea Cup,Seoul,South Korea,FALSE
 1993-06-19,Portugal,Malta,4,0,FIFA World Cup qualification,Porto,Portugal,FALSE
 1993-06-19,Uruguay,Venezuela,2,2,Copa América,Ambato,Ecuador,TRUE
@@ -18142,7 +18142,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-06-21,Brazil,Chile,2,3,Copa América,Cuenca,Ecuador,TRUE
 1993-06-21,Paraguay,Peru,1,1,Copa América,Cuenca,Ecuador,TRUE
 1993-06-22,Ecuador,Uruguay,2,1,Copa América,Quito,Ecuador,FALSE
-1993-06-22,USA,Venezuela,3,3,Copa América,Quito,Ecuador,TRUE
+1993-06-22,United States,Venezuela,3,3,Copa América,Quito,Ecuador,TRUE
 1993-06-23,Argentina,Colombia,1,1,Copa América,Guayaquil,Ecuador,TRUE
 1993-06-23,Costa Rica,Panama,3,1,Friendly,San José,Costa Rica,FALSE
 1993-06-23,Iran,Oman,0,0,FIFA World Cup qualification,Tehran,Iran,FALSE
@@ -18198,9 +18198,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-07-09,Greenland,Åland Islands,1,2,Island Games,Isle of Wight,England,TRUE
 1993-07-09,Jersey,Isle of Man,5,1,Island Games,Isle of Wight,England,TRUE
 1993-07-09,Sudan,Ethiopia,1,0,African Cup of Nations qualification,Khartoum,Sudan,FALSE
-1993-07-10,Honduras,Panama,5,1,Gold Cup,Dallas,USA,TRUE
+1993-07-10,Honduras,Panama,5,1,Gold Cup,Dallas,United States,TRUE
 1993-07-10,Malawi,Eswatini,0,1,Friendly,Mzuzu,Malawi,FALSE
-1993-07-10,USA,Jamaica,1,0,Gold Cup,Dallas,USA,FALSE
+1993-07-10,United States,Jamaica,1,0,Gold Cup,Dallas,United States,FALSE
 1993-07-11,Benin,Cameroon,0,3,African Cup of Nations qualification,Cotonou,Benin,FALSE
 1993-07-11,Burundi,Guinea,2,2,African Cup of Nations qualification,Bujumbura,Burundi,FALSE
 1993-07-11,Canada,Costa Rica,1,1,Gold Cup,Mexico City,Mexico,TRUE
@@ -18215,22 +18215,22 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-07-11,Zimbabwe,Mauritius,2,0,African Cup of Nations qualification,Harare,Zimbabwe,FALSE
 1993-07-13,Peru,Uruguay,1,2,Friendly,Lima,Peru,FALSE
 1993-07-14,Brazil,Paraguay,2,0,Friendly,Rio de Janeiro,Brazil,FALSE
-1993-07-14,Honduras,Jamaica,1,3,Gold Cup,Dallas,USA,TRUE
-1993-07-14,USA,Panama,2,1,Gold Cup,Dallas,USA,FALSE
+1993-07-14,Honduras,Jamaica,1,3,Gold Cup,Dallas,United States,TRUE
+1993-07-14,United States,Panama,2,1,Gold Cup,Dallas,United States,FALSE
 1993-07-15,Canada,Martinique,2,2,Gold Cup,Mexico City,Mexico,TRUE
 1993-07-15,Mexico,Costa Rica,1,1,Gold Cup,Mexico City,Mexico,FALSE
-1993-07-17,Jamaica,Panama,1,1,Gold Cup,Dallas,USA,TRUE
+1993-07-17,Jamaica,Panama,1,1,Gold Cup,Dallas,United States,TRUE
 1993-07-17,Senegal,Morocco,1,3,FIFA World Cup qualification,Dakar,Senegal,FALSE
 1993-07-17,Uganda,Nigeria,0,0,African Cup of Nations qualification,Kampala,Uganda,FALSE
 1993-07-17,Uruguay,Peru,3,0,Friendly,Montevideo,Uruguay,FALSE
-1993-07-17,USA,Honduras,1,0,Gold Cup,Dallas,USA,FALSE
+1993-07-17,United States,Honduras,1,0,Gold Cup,Dallas,United States,FALSE
 1993-07-18,Costa Rica,Martinique,3,1,Gold Cup,Mexico City,Mexico,TRUE
 1993-07-18,Ecuador,Brazil,0,0,FIFA World Cup qualification,Guayaquil,Ecuador,FALSE
 1993-07-18,Guinea,Cameroon,0,1,FIFA World Cup qualification,Conakry,Guinea,FALSE
 1993-07-18,Ivory Coast,Algeria,1,0,FIFA World Cup qualification,Abidjan,Ivory Coast,FALSE
 1993-07-18,Mexico,Canada,8,0,Gold Cup,Mexico City,Mexico,FALSE
 1993-07-18,Venezuela,Bolivia,1,7,FIFA World Cup qualification,Puerto Ordaz,Venezuela,FALSE
-1993-07-21,USA,Costa Rica,1,0,Gold Cup,Dallas,USA,FALSE
+1993-07-21,United States,Costa Rica,1,0,Gold Cup,Dallas,United States,FALSE
 1993-07-22,Mexico,Jamaica,6,1,Gold Cup,Mexico City,Mexico,FALSE
 1993-07-24,Nigeria,Ethiopia,6,0,African Cup of Nations qualification,Lagos,Nigeria,FALSE
 1993-07-24,Uganda,Sudan,1,0,African Cup of Nations qualification,Kampala,Uganda,FALSE
@@ -18245,7 +18245,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-07-25,Malawi,Morocco,0,2,African Cup of Nations qualification,Lilongwe,Malawi,FALSE
 1993-07-25,Mali,Egypt,2,1,African Cup of Nations qualification,Bamako,Mali,FALSE
 1993-07-25,Mauritius,South Africa,1,3,African Cup of Nations qualification,Mapou,Mauritius,FALSE
-1993-07-25,Mexico,USA,4,0,Gold Cup,Mexico City,Mexico,FALSE
+1993-07-25,Mexico,United States,4,0,Gold Cup,Mexico City,Mexico,FALSE
 1993-07-25,Venezuela,Uruguay,0,1,FIFA World Cup qualification,San Cristóbal,Venezuela,FALSE
 1993-07-25,Zimbabwe,Zambia,1,1,African Cup of Nations qualification,Harare,Zimbabwe,FALSE
 1993-07-28,France,Russia,3,1,Friendly,Caen,France,FALSE
@@ -18282,7 +18282,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-08-29,Brazil,Bolivia,6,0,FIFA World Cup qualification,Recife,Brazil,FALSE
 1993-08-29,Colombia,Peru,4,0,FIFA World Cup qualification,Barranquilla,Colombia,FALSE
 1993-08-29,Uruguay,Venezuela,4,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-1993-08-31,Iceland,USA,0,1,Friendly,Reykjavík,Iceland,FALSE
+1993-08-31,Iceland,United States,0,1,Friendly,Reykjavík,Iceland,FALSE
 1993-09-05,Argentina,Colombia,0,5,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
 1993-09-05,Brazil,Venezuela,4,0,FIFA World Cup qualification,Belo Horizonte,Brazil,FALSE
 1993-09-05,Ecuador,Uruguay,0,1,FIFA World Cup qualification,Guayaquil,Ecuador,FALSE
@@ -18298,7 +18298,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-09-08,Iceland,Luxembourg,1,0,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
 1993-09-08,Republic of Ireland,Lithuania,2,0,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
 1993-09-08,Northern Ireland,Latvia,2,0,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
-1993-09-08,Norway,USA,1,0,Friendly,Oslo,Norway,FALSE
+1993-09-08,Norway,United States,1,0,Friendly,Oslo,Norway,FALSE
 1993-09-08,Scotland,Switzerland,1,1,FIFA World Cup qualification,Aberdeen,Scotland,FALSE
 1993-09-08,Spain,Chile,2,0,Friendly,Alicante,Spain,FALSE
 1993-09-08,Wales,Czech Republic,2,2,FIFA World Cup qualification,Cardiff,Wales,FALSE
@@ -18312,7 +18312,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-09-20,Saudi Arabia,Thailand,3,0,Friendly,Dammam,Saudi Arabia,FALSE
 1993-09-22,Albania,Spain,1,5,FIFA World Cup qualification,Tirana,Albania,FALSE
 1993-09-22,Estonia,Italy,0,3,FIFA World Cup qualification,Tallinn,Estonia,FALSE
-1993-09-22,Mexico,Cameroon,1,0,Friendly,Los Angeles,USA,TRUE
+1993-09-22,Mexico,Cameroon,1,0,Friendly,Los Angeles,United States,TRUE
 1993-09-22,Norway,Poland,1,0,FIFA World Cup qualification,Oslo,Norway,FALSE
 1993-09-22,Romania,Israel,1,0,Friendly,Bucharest,Romania,FALSE
 1993-09-22,San Marino,Netherlands,0,7,FIFA World Cup qualification,Bologna,Italy,TRUE
@@ -18324,12 +18324,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-09-26,Zambia,Senegal,4,0,FIFA World Cup qualification,Lusaka,Zambia,FALSE
 1993-09-26,Zimbabwe,Guinea,1,0,FIFA World Cup qualification,Harare,Zimbabwe,FALSE
 1993-09-27,Saudi Arabia,Costa Rica,3,2,Friendly,Khobar,Saudi Arabia,FALSE
-1993-09-29,Mexico,Poland,0,0,Friendly,Oakland,USA,TRUE
+1993-09-29,Mexico,Poland,0,0,Friendly,Oakland,United States,TRUE
 1993-10-01,Morocco,Gabon,1,0,Friendly,Rabat,Morocco,FALSE
 1993-10-04,Japan,Ivory Coast,1,0,Friendly,Tokyo,Japan,FALSE
 1993-10-05,Cyprus,Israel,2,2,Friendly,Limassol,Cyprus,FALSE
 1993-10-06,Belgium,Gabon,2,1,Friendly,Brussels,Belgium,FALSE
-1993-10-06,Mexico,South Africa,4,0,Friendly,Los Angeles,USA,TRUE
+1993-10-06,Mexico,South Africa,4,0,Friendly,Los Angeles,United States,TRUE
 1993-10-06,Saudi Arabia,Russia,4,2,Friendly,Khobar,Saudi Arabia,FALSE
 1993-10-08,Algeria,Nigeria,1,1,FIFA World Cup qualification,Algiers,Algeria,FALSE
 1993-10-10,Cameroon,Zimbabwe,3,1,FIFA World Cup qualification,Yaoundé,Cameroon,FALSE
@@ -18347,21 +18347,21 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-10-13,Romania,Belgium,2,1,FIFA World Cup qualification,Bucharest,Romania,FALSE
 1993-10-13,Slovenia,North Macedonia,1,4,Friendly,Kranj,Slovenia,FALSE
 1993-10-13,Sweden,Finland,3,2,FIFA World Cup qualification,Solna,Sweden,FALSE
-1993-10-13,USA,Mexico,1,1,Friendly,Washington,USA,FALSE
+1993-10-13,United States,Mexico,1,1,Friendly,Washington,United States,FALSE
 1993-10-13,Wales,Cyprus,2,0,FIFA World Cup qualification,Cardiff,Wales,FALSE
 1993-10-15,North Korea,Iraq,3,2,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-10-15,Saudi Arabia,Japan,0,0,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-10-16,Iran,South Korea,0,3,FIFA World Cup qualification,Doha,Qatar,TRUE
-1993-10-16,USA,Ukraine,1,2,Friendly,High Point,USA,FALSE
+1993-10-16,United States,Ukraine,1,2,Friendly,High Point,United States,FALSE
 1993-10-17,Tunisia,Iceland,3,1,Friendly,Tunis,Tunisia,FALSE
 1993-10-18,Japan,Iran,1,2,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-10-18,North Korea,Saudi Arabia,1,2,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-10-19,Iraq,South Korea,2,2,FIFA World Cup qualification,Doha,Qatar,TRUE
-1993-10-20,Mexico,Ukraine,2,1,Friendly,San Diego,USA,TRUE
+1993-10-20,Mexico,Ukraine,2,1,Friendly,San Diego,United States,TRUE
 1993-10-21,North Korea,Japan,0,3,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-10-22,Iran,Iraq,1,2,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-10-22,South Korea,Saudi Arabia,1,1,FIFA World Cup qualification,Doha,Qatar,TRUE
-1993-10-23,USA,Ukraine,0,1,Friendly,Bethlehem,USA,FALSE
+1993-10-23,United States,Ukraine,0,1,Friendly,Bethlehem,United States,FALSE
 1993-10-24,Burundi,Guinea,0,0,African Cup of Nations qualification,Libreville,Gabon,TRUE
 1993-10-24,Iraq,Saudi Arabia,1,1,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-10-25,Iran,North Korea,2,1,FIFA World Cup qualification,Doha,Qatar,TRUE
@@ -18377,18 +18377,18 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-10-28,Saudi Arabia,Iran,4,3,FIFA World Cup qualification,Doha,Qatar,TRUE
 1993-10-28,United Arab Emirates,Jordan,0,2,Friendly,Al Ain,United Arab Emirates,FALSE
 1993-10-31,Australia,Argentina,1,1,FIFA World Cup qualification,Sydney,Australia,FALSE
-1993-11-03,Mexico,China PR,3,0,Friendly,San Diego,USA,TRUE
+1993-11-03,Mexico,China PR,3,0,Friendly,San Diego,United States,TRUE
 1993-11-05,Egypt,Malta,3,0,Friendly,Tunis,Tunisia,TRUE
 1993-11-05,Tunisia,Gabon,4,0,Friendly,Tunis,Tunisia,FALSE
 1993-11-07,Gabon,Malta,1,2,Friendly,Tunis,Tunisia,TRUE
 1993-11-07,Tunisia,Egypt,2,1,Friendly,Tunis,Tunisia,FALSE
-1993-11-07,USA,Jamaica,1,0,Friendly,Fullerton,USA,FALSE
+1993-11-07,United States,Jamaica,1,0,Friendly,Fullerton,United States,FALSE
 1993-11-10,Austria,Sweden,1,1,FIFA World Cup qualification,Vienna,Austria,FALSE
 1993-11-10,Israel,Finland,1,3,FIFA World Cup qualification,Ramat-Gan,Israel,FALSE
 1993-11-10,Portugal,Estonia,3,0,FIFA World Cup qualification,Lisbon,Portugal,FALSE
 1993-11-10,Turkey,Norway,2,1,FIFA World Cup qualification,Istanbul,Turkey,FALSE
 1993-11-14,Antigua and Barbuda,Saint Kitts and Nevis,3,0,Friendly,St. John's,Antigua and Barbuda,FALSE
-1993-11-14,USA,Cayman Islands,8,1,Friendly,Mission Viejo,USA,FALSE
+1993-11-14,United States,Cayman Islands,8,1,Friendly,Mission Viejo,United States,FALSE
 1993-11-16,Slovakia,Slovenia,2,0,Friendly,Prievidza,Slovakia,FALSE
 1993-11-17,Argentina,Australia,1,0,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
 1993-11-17,Belgium,Czech Republic,0,0,FIFA World Cup qualification,Brussels,Belgium,FALSE
@@ -18422,13 +18422,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1993-12-03,Sierra Leone,Mali,2,0,Amílcar Cabral Cup,Freetown,Sierra Leone,FALSE
 1993-12-05,Gambia,Mali,2,0,Amílcar Cabral Cup,Freetown,Sierra Leone,TRUE
 1993-12-05,Sierra Leone,Senegal,2,0,Amílcar Cabral Cup,Freetown,Sierra Leone,FALSE
-1993-12-05,USA,El Salvador,7,0,Friendly,Mission Viejo,USA,FALSE
+1993-12-05,United States,El Salvador,7,0,Friendly,Mission Viejo,United States,FALSE
 1993-12-06,Tanzania,Uganda,1,0,Friendly,Nairobi,Kenya,TRUE
 1993-12-10,Bangladesh,Myanmar,3,1,Friendly,Dhaka,Bangladesh,FALSE
 1993-12-10,Kenya,Tanzania,2,1,Friendly,Nairobi,Kenya,FALSE
-1993-12-15,Argentina,Germany,2,1,Friendly,Miami,USA,TRUE
+1993-12-15,Argentina,Germany,2,1,Friendly,Miami,United States,TRUE
 1993-12-16,Mexico,Brazil,0,1,Friendly,Guadalajara,Mexico,FALSE
-1993-12-18,USA,Germany,0,3,Friendly,Palo Alto,USA,FALSE
+1993-12-18,United States,Germany,0,3,Friendly,Palo Alto,United States,FALSE
 1993-12-19,Mali,Ivory Coast,0,1,Friendly,Bamako,Mali,FALSE
 1993-12-22,Mexico,Germany,0,0,Friendly,Mexico City,Mexico,FALSE
 1993-12-22,Basque Country,Bolivia,3,1,Friendly,San Sebastián,Spain,FALSE
@@ -18439,36 +18439,36 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-01-05,Mali,Burkina Faso,1,1,Friendly,Bamako,Mali,FALSE
 1994-01-09,Mauritania,Mali,1,3,Friendly,Nouakchott,Mauritania,FALSE
 1994-01-11,Thailand,Nigeria,1,1,Friendly,Bangkok,Thailand,FALSE
-1994-01-15,USA,Norway,2,1,Friendly,Tempe,USA,FALSE
+1994-01-15,United States,Norway,2,1,Friendly,Tempe,United States,FALSE
 1994-01-18,Guinea,Ivory Coast,3,0,Friendly,Conakry,Guinea,FALSE
-1994-01-19,Costa Rica,Norway,0,0,Friendly,San Diego,USA,TRUE
-1994-01-19,Mexico,Bulgaria,1,1,Friendly,San Diego,USA,TRUE
+1994-01-19,Costa Rica,Norway,0,0,Friendly,San Diego,United States,TRUE
+1994-01-19,Mexico,Bulgaria,1,1,Friendly,San Diego,United States,TRUE
 1994-01-19,Spain,Portugal,2,2,Friendly,Vigo,Spain,FALSE
 1994-01-19,Suriname,French Guiana,1,0,CFU Caribbean Cup qualification,Paramaribo,Suriname,FALSE
 1994-01-19,Tunisia,Netherlands,2,2,Friendly,Tunis,Tunisia,FALSE
 1994-01-21,Guyana,French Guiana,1,1,CFU Caribbean Cup qualification,Paramaribo,Suriname,TRUE
-1994-01-22,USA,Switzerland,1,1,Friendly,Fullerton,USA,FALSE
+1994-01-22,United States,Switzerland,1,1,Friendly,Fullerton,United States,FALSE
 1994-01-23,Barbados,Puerto Rico,0,1,CFU Caribbean Cup qualification,Bridgetown,Barbados,FALSE
 1994-01-23,Mali,Senegal,1,0,Friendly,Bamako,Mali,FALSE
 1994-01-23,Saudi Arabia,China PR,1,0,Friendly,Riyadh,Saudi Arabia,FALSE
 1994-01-23,Suriname,Guyana,2,0,CFU Caribbean Cup qualification,Paramaribo,Suriname,FALSE
 1994-01-25,Grenada,Puerto Rico,1,0,CFU Caribbean Cup qualification,Bridgetown,Barbados,TRUE
 1994-01-25,Qatar,Finland,1,0,Friendly,Doha,Qatar,FALSE
-1994-01-26,Mexico,Switzerland,1,5,Friendly,Oakland,USA,TRUE
+1994-01-26,Mexico,Switzerland,1,5,Friendly,Oakland,United States,TRUE
 1994-01-26,Saudi Arabia,China PR,1,1,Friendly,Riyadh,Saudi Arabia,FALSE
 1994-01-27,Barbados,Grenada,3,2,CFU Caribbean Cup qualification,Bridgetown,Barbados,FALSE
 1994-01-27,Qatar,Finland,0,0,Friendly,Doha,Qatar,FALSE
 1994-01-28,Venezuela,Colombia,1,2,Friendly,Barinas,Venezuela,FALSE
 1994-01-29,Burkina Faso,Guinea,1,1,Friendly,Ouagadougou,Burkina Faso,FALSE
 1994-01-29,Ivory Coast,Niger,5,3,Friendly,Ouagadougou,Burkina Faso,TRUE
-1994-01-29,USA,Russia,1,1,Friendly,Seattle,USA,FALSE
+1994-01-29,United States,Russia,1,1,Friendly,Seattle,United States,FALSE
 1994-01-30,Burkina Faso,Ivory Coast,0,1,Friendly,Ouagadougou,Burkina Faso,FALSE
 1994-01-30,Guinea,Niger,1,3,Friendly,Ouagadougou,Burkina Faso,TRUE
 1994-01-30,Oman,Finland,0,2,Friendly,Muscat,Oman,FALSE
 1994-01-30,Senegal,Mali,0,0,Friendly,Dakar,Senegal,FALSE
 1994-02-01,Oman,Finland,1,1,Friendly,Muscat,Oman,FALSE
 1994-02-02,Egypt,Morocco,1,1,United Arab Emirates Friendship Tournament,Sharjah,United Arab Emirates,TRUE
-1994-02-02,Mexico,Russia,1,4,Friendly,Oakland,USA,TRUE
+1994-02-02,Mexico,Russia,1,4,Friendly,Oakland,United States,TRUE
 1994-02-02,United Arab Emirates,Slovakia,0,1,United Arab Emirates Friendship Tournament,Sharjah,United Arab Emirates,FALSE
 1994-02-04,Egypt,Slovakia,1,0,United Arab Emirates Friendship Tournament,Sharjah,United Arab Emirates,TRUE
 1994-02-04,Oman,Kenya,1,0,Friendly,Muscat,Oman,FALSE
@@ -18487,24 +18487,24 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-02-12,Malawi,Zambia,0,3,Friendly,Blantyre,Malawi,FALSE
 1994-02-12,Malta,Slovenia,0,1,Malta International Tournament,Attard,Malta,FALSE
 1994-02-13,Malawi,Zambia,0,2,Friendly,Blantyre,Malawi,FALSE
-1994-02-13,Romania,USA,2,1,Lunar New Year Cup,Kowloon,Hong Kong,TRUE
+1994-02-13,Romania,United States,2,1,Lunar New Year Cup,Kowloon,Hong Kong,TRUE
 1994-02-16,Italy,France,0,1,Friendly,Naples,Italy,FALSE
 1994-02-16,South Korea,Romania,1,2,Friendly,Changwon,South Korea,FALSE
 1994-02-16,Malta,Belgium,1,0,Friendly,Attard,Malta,FALSE
-1994-02-18,Colombia,Sweden,0,0,Friendly,Miami,USA,TRUE
-1994-02-18,USA,Bolivia,1,1,Friendly,Miami,USA,FALSE
-1994-02-20,Bolivia,Colombia,0,2,Friendly,Miami,USA,TRUE
-1994-02-20,USA,Sweden,1,3,Friendly,Miami,USA,FALSE
+1994-02-18,Colombia,Sweden,0,0,Friendly,Miami,United States,TRUE
+1994-02-18,United States,Bolivia,1,1,Friendly,Miami,United States,FALSE
+1994-02-20,Bolivia,Colombia,0,2,Friendly,Miami,United States,TRUE
+1994-02-20,United States,Sweden,1,3,Friendly,Miami,United States,FALSE
 1994-02-23,Dominica,Antigua and Barbuda,3,2,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,TRUE
 1994-02-23,Israel,Georgia,2,0,Friendly,Ashdod,Israel,FALSE
 1994-02-23,Mali,Ghana,0,0,Friendly,Bamako,Mali,FALSE
 1994-02-23,Morocco,Finland,0,0,Friendly,Casablanca,Morocco,FALSE
 1994-02-23,Saint Kitts and Nevis,Montserrat,9,1,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
 1994-02-23,Turkey,Czech Republic,1,4,Friendly,Istanbul,Turkey,FALSE
-1994-02-24,Mexico,Sweden,2,1,Friendly,Fresno,USA,TRUE
+1994-02-24,Mexico,Sweden,2,1,Friendly,Fresno,United States,TRUE
 1994-02-25,Antigua and Barbuda,Montserrat,8,0,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,TRUE
 1994-02-25,Saint Kitts and Nevis,Dominica,2,3,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
-1994-02-26,Colombia,South Korea,2,2,Friendly,Monterey Park,USA,TRUE
+1994-02-26,Colombia,South Korea,2,2,Friendly,Monterey Park,United States,TRUE
 1994-02-26,Zimbabwe,Zambia,2,2,Friendly,Harare,Zimbabwe,FALSE
 1994-02-27,Gabon,Senegal,0,0,Friendly,Moanda,Gabon,FALSE
 1994-03-02,Cayman Islands,British Virgin Islands,5,0,CFU Caribbean Cup qualification,George Town,Cayman Islands,FALSE
@@ -18513,7 +18513,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-03-04,Cayman Islands,Sint Maarten,5,0,CFU Caribbean Cup qualification,George Town,Cayman Islands,FALSE
 1994-03-04,Guadeloupe,Anguilla,9,0,CFU Caribbean Cup qualification,Kingstown,Saint Vincent and the Grenadines,TRUE
 1994-03-04,Jamaica,British Virgin Islands,12,0,CFU Caribbean Cup qualification,George Town,Cayman Islands,TRUE
-1994-03-05,USA,South Korea,1,0,Friendly,Monterey Park,USA,FALSE
+1994-03-05,United States,South Korea,1,0,Friendly,Monterey Park,United States,FALSE
 1994-03-06,Cayman Islands,Jamaica,3,2,CFU Caribbean Cup qualification,West Bay,Cayman Islands,FALSE
 1994-03-06,Sint Maarten,British Virgin Islands,3,0,CFU Caribbean Cup qualification,George Town,Cayman Islands,TRUE
 1994-03-06,Saint Vincent and the Grenadines,Anguilla,2,0,CFU Caribbean Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
@@ -18524,7 +18524,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-03-09,Wales,Norway,1,3,Friendly,Cardiff,Wales,FALSE
 1994-03-10,Dominican Republic,Haiti,0,1,CFU Caribbean Cup qualification,Santo Domingo,Dominican Republic,FALSE
 1994-03-12,Congo,DR Congo,2,1,Friendly,Brazzaville,Congo,FALSE
-1994-03-12,USA,South Korea,1,1,Friendly,Fullerton,USA,FALSE
+1994-03-12,United States,South Korea,1,1,Friendly,Fullerton,United States,FALSE
 1994-03-12,Zambia,Zimbabwe,2,1,Friendly,Lusaka,Zambia,FALSE
 1994-03-15,Gabon,DR Congo,2,1,Friendly,Libreville,Gabon,FALSE
 1994-03-15,Israel,Ukraine,1,0,Friendly,Haifa,Israel,FALSE
@@ -18545,7 +18545,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-03-26,Nigeria,Gabon,3,0,African Cup of Nations,Tunis,Tunisia,TRUE
 1994-03-26,Saudi Arabia,Chile,0,2,Friendly,Riyadh,Saudi Arabia,FALSE
 1994-03-26,Tunisia,Mali,0,2,African Cup of Nations,Tunis,Tunisia,FALSE
-1994-03-26,USA,Bolivia,2,2,Friendly,Dallas,USA,FALSE
+1994-03-26,United States,Bolivia,2,2,Friendly,Dallas,United States,FALSE
 1994-03-27,Ghana,Guinea,1,0,African Cup of Nations,Sousse,Tunisia,TRUE
 1994-03-27,Ivory Coast,Sierra Leone,4,0,African Cup of Nations,Sousse,Tunisia,TRUE
 1994-03-28,Egypt,Gabon,4,0,African Cup of Nations,Tunis,Tunisia,TRUE
@@ -18583,7 +18583,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-04-15,Kazakhstan,Turkmenistan,0,0,Friendly,Tashkent,Uzbekistan,TRUE
 1994-04-15,Kyrgyzstan,Tajikistan,0,1,Friendly,Tashkent,Uzbekistan,TRUE
 1994-04-15,Oman,Bulgaria,1,1,Friendly,Muscat,Oman,FALSE
-1994-04-16,USA,Moldova,1,1,Friendly,Jacksonville,USA,FALSE
+1994-04-16,United States,Moldova,1,1,Friendly,Jacksonville,United States,FALSE
 1994-04-17,Colombia,Nigeria,1,0,Friendly,Armenia,Colombia,FALSE
 1994-04-17,Guadeloupe,Suriname,2,0,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,TRUE
 1994-04-17,Kazakhstan,Kyrgyzstan,0,0,Friendly,Tashkent,Uzbekistan,TRUE
@@ -18605,34 +18605,34 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-04-20,Slovakia,Croatia,4,1,Friendly,Bratislava,Slovakia,FALSE
 1994-04-20,Switzerland,Czech Republic,3,0,Friendly,Zürich,Switzerland,FALSE
 1994-04-20,Turkey,Russia,0,1,Friendly,Bursa,Turkey,FALSE
-1994-04-20,USA,Moldova,3,0,Friendly,Davidson,USA,FALSE
+1994-04-20,United States,Moldova,3,0,Friendly,Davidson,United States,FALSE
 1994-04-20,Wales,Sweden,0,2,Friendly,Wrexham,Wales,FALSE
 1994-04-22,Eswatini,Mozambique,0,1,Friendly,Mbabane,Eswatini,FALSE
 1994-04-24,South Africa,Zimbabwe,1,0,Friendly,Mafikeng,South Africa,FALSE
-1994-04-24,USA,Iceland,1,2,Friendly,Chula Vista,USA,FALSE
+1994-04-24,United States,Iceland,1,2,Friendly,Chula Vista,United States,FALSE
 1994-04-27,Greece,Saudi Arabia,5,1,Friendly,Athens,Greece,FALSE
 1994-04-27,Slovenia,Cyprus,3,0,Friendly,Maribor,Slovenia,FALSE
 1994-04-27,United Arab Emirates,Germany,0,2,Friendly,Abu Dhabi,United Arab Emirates,FALSE
 1994-04-28,Kuwait,Bulgaria,2,2,Friendly,Kuwait City,Kuwait,FALSE
-1994-04-30,USA,Chile,0,2,Friendly,Albuquerque,USA,FALSE
+1994-04-30,United States,Chile,0,2,Friendly,Albuquerque,United States,FALSE
 1994-05-01,South Korea,Cameroon,2,2,Friendly,Seoul,South Korea,FALSE
 1994-05-02,Jersey,Guernsey,3,1,Friendly,St. Helier,Jersey,FALSE
-1994-05-03,Colombia,Peru,1,0,Friendly,Miami,USA,TRUE
-1994-05-03,El Salvador,Honduras,3,1,Friendly,Miami,USA,TRUE
+1994-05-03,Colombia,Peru,1,0,Friendly,Miami,United States,TRUE
+1994-05-03,El Salvador,Honduras,3,1,Friendly,Miami,United States,TRUE
 1994-05-03,South Korea,Cameroon,2,1,Friendly,Changwon,South Korea,FALSE
 1994-05-04,Bolivia,Saudi Arabia,1,0,Friendly,Cannes,France,TRUE
 1994-05-04,Brazil,Iceland,3,0,Friendly,Florianópolis,Brazil,FALSE
 1994-05-04,Poland,Hungary,3,2,Friendly,Kraków,Poland,FALSE
-1994-05-05,Colombia,El Salvador,3,0,Friendly,Miami,USA,TRUE
-1994-05-05,Honduras,Peru,2,1,Friendly,Miami,USA,TRUE
+1994-05-05,Colombia,El Salvador,3,0,Friendly,Miami,United States,TRUE
+1994-05-05,Honduras,Peru,2,1,Friendly,Miami,United States,TRUE
 1994-05-05,Sweden,Nigeria,3,1,Friendly,Solna,Sweden,FALSE
-1994-05-07,USA,Estonia,4,0,Friendly,Fullerton,USA,FALSE
+1994-05-07,United States,Estonia,4,0,Friendly,Fullerton,United States,FALSE
 1994-05-09,Greece,Cameroon,0,3,Friendly,Piraeus,Greece,FALSE
 1994-05-11,Bolivia,Cameroon,1,1,Friendly,Piraeus,Greece,TRUE
 1994-05-13,Greece,Bolivia,0,0,Friendly,Piraeus,Greece,FALSE
 1994-05-14,North Macedonia,Albania,5,1,Friendly,Tetovo,North Macedonia,FALSE
 1994-05-14,Nigeria,Suriname,2,1,Friendly,Amsterdam,Netherlands,TRUE
-1994-05-15,USA,Armenia,1,0,Friendly,Fullerton,USA,FALSE
+1994-05-15,United States,Armenia,1,0,Friendly,Fullerton,United States,FALSE
 1994-05-17,England,Greece,5,0,Friendly,London,England,FALSE
 1994-05-17,Poland,Austria,3,4,Friendly,Katowice,Poland,FALSE
 1994-05-18,Chile,Argentina,3,3,Friendly,Santiago,Chile,FALSE
@@ -18648,13 +18648,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-05-25,Ecuador,Argentina,1,0,Friendly,Guayaquil,Ecuador,FALSE
 1994-05-25,Fiji,Tahiti,2,0,Friendly,Lautoka,Fiji,FALSE
 1994-05-25,Ukraine,Belarus,3,1,Friendly,Kyiv,Ukraine,FALSE
-1994-05-25,USA,Saudi Arabia,0,0,Friendly,Piscataway,USA,FALSE
+1994-05-25,United States,Saudi Arabia,0,0,Friendly,Piscataway,United States,FALSE
 1994-05-26,Australia,France,0,1,Kirin Cup,Kobe,Japan,TRUE
 1994-05-26,Denmark,Sweden,1,0,Friendly,Copenhagen,Denmark,FALSE
 1994-05-27,Italy,Finland,2,0,Friendly,Parma,Italy,FALSE
 1994-05-27,Netherlands,Scotland,3,1,Friendly,Utrecht,Netherlands,FALSE
 1994-05-27,Switzerland,Liechtenstein,2,0,Friendly,Basel,Switzerland,FALSE
-1994-05-28,USA,Greece,1,1,Friendly,New Haven,USA,FALSE
+1994-05-28,United States,Greece,1,1,Friendly,New Haven,United States,FALSE
 1994-05-29,Germany,Republic of Ireland,0,2,Friendly,Hanover,Germany,FALSE
 1994-05-29,Japan,France,1,4,Kirin Cup,Tokyo,Japan,FALSE
 1994-05-29,Russia,Slovakia,2,1,Friendly,Moscow,Russia,FALSE
@@ -18668,14 +18668,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-06-02,Finland,Spain,1,2,Friendly,Tampere,Finland,FALSE
 1994-06-02,Latvia,Malta,2,0,Friendly,Riga,Latvia,FALSE
 1994-06-03,Bulgaria,Ukraine,1,1,Friendly,Sofia,Bulgaria,FALSE
-1994-06-03,Colombia,Northern Ireland,2,0,Friendly,Foxborough,USA,TRUE
+1994-06-03,Colombia,Northern Ireland,2,0,Friendly,Foxborough,United States,TRUE
 1994-06-03,Italy,Switzerland,1,0,Friendly,Rome,Italy,FALSE
 1994-06-04,Croatia,Argentina,0,0,Friendly,Zagreb,Croatia,FALSE
-1994-06-04,Trinidad and Tobago,Saudi Arabia,2,3,Friendly,Pomona,USA,TRUE
-1994-06-04,USA,Mexico,1,0,Friendly,Pasadena,USA,FALSE
+1994-06-04,Trinidad and Tobago,Saudi Arabia,2,3,Friendly,Pomona,United States,TRUE
+1994-06-04,United States,Mexico,1,0,Friendly,Pasadena,United States,FALSE
 1994-06-05,Canada,Brazil,1,1,Friendly,Edmonton,Canada,FALSE
-1994-06-05,Colombia,Greece,2,0,Friendly,East Rutherford,USA,TRUE
-1994-06-05,Ecuador,South Korea,2,1,Friendly,Wakefield,USA,TRUE
+1994-06-05,Colombia,Greece,2,0,Friendly,East Rutherford,United States,TRUE
+1994-06-05,Ecuador,South Korea,2,1,Friendly,Wakefield,United States,TRUE
 1994-06-05,Republic of Ireland,Czech Republic,1,3,Friendly,Dublin,Republic of Ireland,FALSE
 1994-06-05,Ivory Coast,Liberia,4,1,Friendly,Abidjan,Ivory Coast,FALSE
 1994-06-05,Sweden,Norway,2,0,Friendly,Solna,Sweden,FALSE
@@ -18683,65 +18683,65 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-06-08,Belgium,Hungary,3,1,Friendly,Brussels,Belgium,FALSE
 1994-06-08,Bolivia,Peru,0,0,Friendly,Santa Cruz,Bolivia,FALSE
 1994-06-08,Canada,Germany,0,2,Friendly,Toronto,Canada,FALSE
-1994-06-08,Honduras,Brazil,2,8,Friendly,San Diego,USA,TRUE
+1994-06-08,Honduras,Brazil,2,8,Friendly,San Diego,United States,TRUE
 1994-06-10,Canada,Spain,0,2,Friendly,Montréal,Canada,FALSE
 1994-06-11,Bolivia,Switzerland,0,0,Friendly,Montréal,Canada,TRUE
-1994-06-11,Costa Rica,Italy,0,1,Friendly,New Haven,USA,TRUE
-1994-06-11,Honduras,South Korea,0,3,Friendly,Duncanville,USA,TRUE
-1994-06-11,Mexico,Northern Ireland,3,0,Friendly,Miami,USA,TRUE
+1994-06-11,Costa Rica,Italy,0,1,Friendly,New Haven,United States,TRUE
+1994-06-11,Honduras,South Korea,0,3,Friendly,Duncanville,United States,TRUE
+1994-06-11,Mexico,Northern Ireland,3,0,Friendly,Miami,United States,TRUE
 1994-06-11,Nigeria,Georgia,5,1,Friendly,Ibadan,Nigeria,FALSE
 1994-06-12,Australia,South Africa,1,0,Friendly,Sydney,Australia,FALSE
 1994-06-12,Canada,Netherlands,0,3,Friendly,Toronto,Canada,FALSE
-1994-06-12,El Salvador,Brazil,0,4,Friendly,Fresno,USA,TRUE
-1994-06-12,Romania,Sweden,1,1,Friendly,Mission Viejo,USA,TRUE
-1994-06-17,Germany,Bolivia,1,0,FIFA World Cup,Chicago,USA,TRUE
-1994-06-17,Spain,South Korea,2,2,FIFA World Cup,Dallas,USA,TRUE
-1994-06-18,Colombia,Romania,1,3,FIFA World Cup,Pasadena,USA,TRUE
-1994-06-18,Italy,Republic of Ireland,0,1,FIFA World Cup,East Rutherford,USA,TRUE
-1994-06-18,USA,Switzerland,1,1,FIFA World Cup,Pontiac,USA,FALSE
-1994-06-19,Belgium,Morocco,1,0,FIFA World Cup,Orlando,USA,TRUE
-1994-06-19,Cameroon,Sweden,2,2,FIFA World Cup,Pasadena,USA,TRUE
-1994-06-19,Norway,Mexico,1,0,FIFA World Cup,Washington,USA,TRUE
-1994-06-20,Brazil,Russia,2,0,FIFA World Cup,Palo Alto,USA,TRUE
-1994-06-20,Netherlands,Saudi Arabia,2,1,FIFA World Cup,Washington,USA,TRUE
-1994-06-21,Argentina,Greece,4,0,FIFA World Cup,Foxborough,USA,TRUE
-1994-06-21,Germany,Spain,1,1,FIFA World Cup,Chicago,USA,TRUE
-1994-06-21,Nigeria,Bulgaria,3,0,FIFA World Cup,Dallas,USA,TRUE
-1994-06-22,Romania,Switzerland,1,4,FIFA World Cup,Pontiac,USA,TRUE
-1994-06-22,USA,Colombia,2,1,FIFA World Cup,Pasadena,USA,FALSE
-1994-06-23,Italy,Norway,1,0,FIFA World Cup,East Rutherford,USA,TRUE
-1994-06-23,South Korea,Bolivia,0,0,FIFA World Cup,Foxborough,USA,TRUE
-1994-06-24,Brazil,Cameroon,3,0,FIFA World Cup,Palo Alto,USA,TRUE
-1994-06-24,Mexico,Republic of Ireland,2,1,FIFA World Cup,Orlando,USA,TRUE
-1994-06-24,Sweden,Russia,3,1,FIFA World Cup,Pontiac,USA,TRUE
-1994-06-25,Argentina,Nigeria,2,1,FIFA World Cup,Foxborough,USA,TRUE
-1994-06-25,Belgium,Netherlands,1,0,FIFA World Cup,Orlando,USA,TRUE
-1994-06-25,Saudi Arabia,Morocco,2,1,FIFA World Cup,East Rutherford,USA,TRUE
-1994-06-26,Bulgaria,Greece,4,0,FIFA World Cup,Chicago,USA,TRUE
+1994-06-12,El Salvador,Brazil,0,4,Friendly,Fresno,United States,TRUE
+1994-06-12,Romania,Sweden,1,1,Friendly,Mission Viejo,United States,TRUE
+1994-06-17,Germany,Bolivia,1,0,FIFA World Cup,Chicago,United States,TRUE
+1994-06-17,Spain,South Korea,2,2,FIFA World Cup,Dallas,United States,TRUE
+1994-06-18,Colombia,Romania,1,3,FIFA World Cup,Pasadena,United States,TRUE
+1994-06-18,Italy,Republic of Ireland,0,1,FIFA World Cup,East Rutherford,United States,TRUE
+1994-06-18,United States,Switzerland,1,1,FIFA World Cup,Pontiac,United States,FALSE
+1994-06-19,Belgium,Morocco,1,0,FIFA World Cup,Orlando,United States,TRUE
+1994-06-19,Cameroon,Sweden,2,2,FIFA World Cup,Pasadena,United States,TRUE
+1994-06-19,Norway,Mexico,1,0,FIFA World Cup,Washington,United States,TRUE
+1994-06-20,Brazil,Russia,2,0,FIFA World Cup,Palo Alto,United States,TRUE
+1994-06-20,Netherlands,Saudi Arabia,2,1,FIFA World Cup,Washington,United States,TRUE
+1994-06-21,Argentina,Greece,4,0,FIFA World Cup,Foxborough,United States,TRUE
+1994-06-21,Germany,Spain,1,1,FIFA World Cup,Chicago,United States,TRUE
+1994-06-21,Nigeria,Bulgaria,3,0,FIFA World Cup,Dallas,United States,TRUE
+1994-06-22,Romania,Switzerland,1,4,FIFA World Cup,Pontiac,United States,TRUE
+1994-06-22,United States,Colombia,2,1,FIFA World Cup,Pasadena,United States,FALSE
+1994-06-23,Italy,Norway,1,0,FIFA World Cup,East Rutherford,United States,TRUE
+1994-06-23,South Korea,Bolivia,0,0,FIFA World Cup,Foxborough,United States,TRUE
+1994-06-24,Brazil,Cameroon,3,0,FIFA World Cup,Palo Alto,United States,TRUE
+1994-06-24,Mexico,Republic of Ireland,2,1,FIFA World Cup,Orlando,United States,TRUE
+1994-06-24,Sweden,Russia,3,1,FIFA World Cup,Pontiac,United States,TRUE
+1994-06-25,Argentina,Nigeria,2,1,FIFA World Cup,Foxborough,United States,TRUE
+1994-06-25,Belgium,Netherlands,1,0,FIFA World Cup,Orlando,United States,TRUE
+1994-06-25,Saudi Arabia,Morocco,2,1,FIFA World Cup,East Rutherford,United States,TRUE
+1994-06-26,Bulgaria,Greece,4,0,FIFA World Cup,Chicago,United States,TRUE
 1994-06-26,Latvia,Georgia,1,3,Friendly,Riga,Latvia,FALSE
-1994-06-26,Switzerland,Colombia,0,2,FIFA World Cup,Palo Alto,USA,TRUE
-1994-06-26,USA,Romania,0,1,FIFA World Cup,Pasadena,USA,FALSE
-1994-06-27,Bolivia,Spain,1,3,FIFA World Cup,Chicago,USA,TRUE
-1994-06-27,Germany,South Korea,3,2,FIFA World Cup,Dallas,USA,TRUE
-1994-06-28,Brazil,Sweden,1,1,FIFA World Cup,Pontiac,USA,TRUE
-1994-06-28,Republic of Ireland,Norway,0,0,FIFA World Cup,East Rutherford,USA,TRUE
-1994-06-28,Italy,Mexico,1,1,FIFA World Cup,Washington,USA,TRUE
-1994-06-28,Russia,Cameroon,6,1,FIFA World Cup,Palo Alto,USA,TRUE
-1994-06-29,Belgium,Saudi Arabia,0,1,FIFA World Cup,Washington,USA,TRUE
-1994-06-29,Morocco,Netherlands,1,2,FIFA World Cup,Orlando,USA,TRUE
-1994-06-30,Argentina,Bulgaria,0,2,FIFA World Cup,Dallas,USA,TRUE
-1994-06-30,Greece,Nigeria,0,2,FIFA World Cup,Foxborough,USA,TRUE
+1994-06-26,Switzerland,Colombia,0,2,FIFA World Cup,Palo Alto,United States,TRUE
+1994-06-26,United States,Romania,0,1,FIFA World Cup,Pasadena,United States,FALSE
+1994-06-27,Bolivia,Spain,1,3,FIFA World Cup,Chicago,United States,TRUE
+1994-06-27,Germany,South Korea,3,2,FIFA World Cup,Dallas,United States,TRUE
+1994-06-28,Brazil,Sweden,1,1,FIFA World Cup,Pontiac,United States,TRUE
+1994-06-28,Republic of Ireland,Norway,0,0,FIFA World Cup,East Rutherford,United States,TRUE
+1994-06-28,Italy,Mexico,1,1,FIFA World Cup,Washington,United States,TRUE
+1994-06-28,Russia,Cameroon,6,1,FIFA World Cup,Palo Alto,United States,TRUE
+1994-06-29,Belgium,Saudi Arabia,0,1,FIFA World Cup,Washington,United States,TRUE
+1994-06-29,Morocco,Netherlands,1,2,FIFA World Cup,Orlando,United States,TRUE
+1994-06-30,Argentina,Bulgaria,0,2,FIFA World Cup,Dallas,United States,TRUE
+1994-06-30,Greece,Nigeria,0,2,FIFA World Cup,Foxborough,United States,TRUE
 1994-07-01,Botswana,Namibia,0,1,Friendly,Gaborone,Botswana,FALSE
-1994-07-02,Germany,Belgium,3,2,FIFA World Cup,Chicago,USA,TRUE
-1994-07-02,Spain,Switzerland,3,0,FIFA World Cup,Washington,USA,TRUE
+1994-07-02,Germany,Belgium,3,2,FIFA World Cup,Chicago,United States,TRUE
+1994-07-02,Spain,Switzerland,3,0,FIFA World Cup,Washington,United States,TRUE
 1994-07-03,Papua New Guinea,New Caledonia,1,0,Oceania Nations Cup qualification,Honiara,Solomon Islands,TRUE
-1994-07-03,Romania,Argentina,3,2,FIFA World Cup,Pasadena,USA,TRUE
-1994-07-03,Saudi Arabia,Sweden,1,3,FIFA World Cup,Dallas,USA,TRUE
+1994-07-03,Romania,Argentina,3,2,FIFA World Cup,Pasadena,United States,TRUE
+1994-07-03,Saudi Arabia,Sweden,1,3,FIFA World Cup,Dallas,United States,TRUE
 1994-07-04,Fiji,New Caledonia,3,1,Oceania Nations Cup qualification,Honiara,Solomon Islands,TRUE
-1994-07-04,Netherlands,Republic of Ireland,2,0,FIFA World Cup,Orlando,USA,TRUE
-1994-07-04,USA,Brazil,0,1,FIFA World Cup,Palo Alto,USA,FALSE
-1994-07-05,Mexico,Bulgaria,1,1,FIFA World Cup,East Rutherford,USA,TRUE
-1994-07-05,Nigeria,Italy,1,2,FIFA World Cup,Foxborough,USA,TRUE
+1994-07-04,Netherlands,Republic of Ireland,2,0,FIFA World Cup,Orlando,United States,TRUE
+1994-07-04,United States,Brazil,0,1,FIFA World Cup,Palo Alto,United States,FALSE
+1994-07-05,Mexico,Bulgaria,1,1,FIFA World Cup,East Rutherford,United States,TRUE
+1994-07-05,Nigeria,Italy,1,2,FIFA World Cup,Foxborough,United States,TRUE
 1994-07-05,Solomon Islands,Papua New Guinea,2,0,Oceania Nations Cup qualification,Honiara,Solomon Islands,FALSE
 1994-07-05,Vanuatu,New Caledonia,2,3,Oceania Nations Cup qualification,Honiara,Solomon Islands,TRUE
 1994-07-06,Papua New Guinea,Fiji,0,1,Oceania Nations Cup qualification,Honiara,Solomon Islands,TRUE
@@ -18751,16 +18751,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-07-08,Japan,Ghana,3,2,Friendly,Nagoya,Japan,FALSE
 1994-07-08,Solomon Islands,New Caledonia,3,1,Oceania Nations Cup qualification,Honiara,Solomon Islands,FALSE
 1994-07-08,Vanuatu,Fiji,2,4,Oceania Nations Cup qualification,Honiara,Solomon Islands,TRUE
-1994-07-09,Italy,Spain,2,1,FIFA World Cup,Foxborough,USA,TRUE
-1994-07-09,Netherlands,Brazil,2,3,FIFA World Cup,Dallas,USA,TRUE
-1994-07-10,Bulgaria,Germany,2,1,FIFA World Cup,East Rutherford,USA,TRUE
-1994-07-10,Romania,Sweden,2,2,FIFA World Cup,Palo Alto,USA,TRUE
-1994-07-13,Bulgaria,Italy,1,2,FIFA World Cup,East Rutherford,USA,TRUE
-1994-07-13,Sweden,Brazil,0,1,FIFA World Cup,Pasadena,USA,TRUE
+1994-07-09,Italy,Spain,2,1,FIFA World Cup,Foxborough,United States,TRUE
+1994-07-09,Netherlands,Brazil,2,3,FIFA World Cup,Dallas,United States,TRUE
+1994-07-10,Bulgaria,Germany,2,1,FIFA World Cup,East Rutherford,United States,TRUE
+1994-07-10,Romania,Sweden,2,2,FIFA World Cup,Palo Alto,United States,TRUE
+1994-07-13,Bulgaria,Italy,1,2,FIFA World Cup,East Rutherford,United States,TRUE
+1994-07-13,Sweden,Brazil,0,1,FIFA World Cup,Pasadena,United States,TRUE
 1994-07-14,Japan,Ghana,2,1,Friendly,Kobe,Japan,FALSE
 1994-07-16,Armenia,Malta,1,0,Friendly,Yerevan,Armenia,FALSE
-1994-07-16,Sweden,Bulgaria,4,0,FIFA World Cup,Pasadena,USA,TRUE
-1994-07-17,Brazil,Italy,0,0,FIFA World Cup,Pasadena,USA,TRUE
+1994-07-16,Sweden,Bulgaria,4,0,FIFA World Cup,Pasadena,United States,TRUE
+1994-07-17,Brazil,Italy,0,0,FIFA World Cup,Pasadena,United States,TRUE
 1994-07-19,Georgia,Malta,1,1,Friendly,Tbilisi,Georgia,FALSE
 1994-07-29,Lithuania,Estonia,3,0,Baltic Cup,Vilnius,Lithuania,FALSE
 1994-07-30,Estonia,Latvia,0,2,Baltic Cup,Vilnius,Lithuania,TRUE
@@ -18810,7 +18810,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-09-06,Switzerland,United Arab Emirates,1,0,Friendly,Sion,Switzerland,FALSE
 1994-09-07,Belgium,Armenia,2,0,UEFA Euro qualification,Brussels,Belgium,FALSE
 1994-09-07,Cyprus,Spain,1,2,UEFA Euro qualification,Limassol,Cyprus,FALSE
-1994-09-07,England,USA,2,0,Friendly,London,England,FALSE
+1994-09-07,England,United States,2,0,Friendly,London,England,FALSE
 1994-09-07,Faroe Islands,Greece,1,5,UEFA Euro qualification,Toftir,Faroe Islands,FALSE
 1994-09-07,Finland,Scotland,0,2,UEFA Euro qualification,Helsinki,Finland,FALSE
 1994-09-07,Georgia,Moldova,0,1,UEFA Euro qualification,Tbilisi,Georgia,FALSE
@@ -18882,7 +18882,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-10-16,Niger,Ghana,1,5,African Cup of Nations qualification,Niamey,Niger,FALSE
 1994-10-16,Togo,Senegal,2,0,African Cup of Nations qualification,Lomé,Togo,FALSE
 1994-10-19,Peru,Uruguay,0,1,Friendly,Lima,Peru,FALSE
-1994-10-19,Saudi Arabia,USA,2,1,Friendly,Khobar,Saudi Arabia,FALSE
+1994-10-19,Saudi Arabia,United States,2,1,Friendly,Khobar,Saudi Arabia,FALSE
 1994-10-23,Oman,Senegal,0,1,Friendly,Muscat,Oman,FALSE
 1994-10-25,Oman,Senegal,2,1,Friendly,Muscat,Oman,FALSE
 1994-10-26,Estonia,Finland,0,7,Friendly,Tallinn,Estonia,FALSE
@@ -18946,9 +18946,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-11-16,Sweden,Hungary,2,0,UEFA Euro qualification,Solna,Sweden,FALSE
 1994-11-16,Switzerland,Iceland,1,0,UEFA Euro qualification,Lausanne,Switzerland,FALSE
 1994-11-16,United Arab Emirates,Oman,2,0,Gulf Cup,Abu Dhabi,United Arab Emirates,FALSE
-1994-11-19,Trinidad and Tobago,USA,1,0,Friendly,Port of Spain,Trinidad and Tobago,FALSE
+1994-11-19,Trinidad and Tobago,United States,1,0,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 1994-11-20,Gabon,Zambia,2,1,African Cup of Nations qualification,Libreville,Gabon,FALSE
-1994-11-22,Jamaica,USA,0,3,Friendly,Kingston,Jamaica,FALSE
+1994-11-22,Jamaica,United States,0,3,Friendly,Kingston,Jamaica,FALSE
 1994-11-24,Samoa,American Samoa,3,1,Oceania Nations Cup qualification,Apia,Western Samoa,FALSE
 1994-11-24,Tahiti,Tonga,1,0,Oceania Nations Cup qualification,Apia,Western Samoa,TRUE
 1994-11-25,Samoa,Tonga,2,2,Oceania Nations Cup qualification,Apia,Western Samoa,FALSE
@@ -18978,7 +18978,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1994-12-08,Tanzania,Uganda,2,2,Friendly,Nairobi,Kenya,TRUE
 1994-12-10,Namibia,Ivory Coast,2,1,Friendly,Windhoek,Namibia,FALSE
 1994-12-10,Saudi Arabia,Poland,1,2,Friendly,Riyadh,Saudi Arabia,FALSE
-1994-12-11,USA,Honduras,1,1,Friendly,Fullerton,USA,FALSE
+1994-12-11,United States,Honduras,1,1,Friendly,Fullerton,United States,FALSE
 1994-12-14,Albania,Georgia,0,1,UEFA Euro qualification,Tirana,Albania,FALSE
 1994-12-14,Finland,San Marino,4,1,UEFA Euro qualification,Helsinki,Finland,FALSE
 1994-12-14,Israel,Romania,1,1,UEFA Euro qualification,Ramat-Gan,Israel,FALSE
@@ -19044,7 +19044,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-01-26,Canada,Portugal,1,1,Friendly,Toronto,Canada,FALSE
 1995-01-29,Tunisia,Mauritania,1,0,African Cup of Nations qualification,Tunis,Tunisia,FALSE
 1995-01-31,South Korea,Colombia,1,0,Lunar New Year Cup,So Kon Po,Hong Kong,TRUE
-1995-02-01,Mexico,Uruguay,1,0,Friendly,San Diego,USA,TRUE
+1995-02-01,Mexico,Uruguay,1,0,Friendly,San Diego,United States,TRUE
 1995-02-04,South Korea,Serbia,0,1,Lunar New Year Cup,So Kon Po,Hong Kong,TRUE
 1995-02-06,Estonia,Norway,0,7,Friendly,Larnaca,Cyprus,TRUE
 1995-02-08,Cyprus,Norway,0,2,Friendly,Nicosia,Cyprus,FALSE
@@ -19098,7 +19098,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-03-25,Italy,Estonia,4,1,UEFA Euro qualification,Salerno,Italy,FALSE
 1995-03-25,Nepal,Bangladesh,0,2,SAFF Cup,Colombo,Sri Lanka,TRUE
 1995-03-25,Pakistan,Bangladesh,1,0,SAFF Cup,Colombo,Sri Lanka,TRUE
-1995-03-25,USA,Uruguay,2,2,Friendly,Dallas,USA,FALSE
+1995-03-25,United States,Uruguay,2,2,Friendly,Dallas,United States,FALSE
 1995-03-26,Barbados,Guyana,3,0,CFU Caribbean Cup qualification,Bridgetown,Barbados,FALSE
 1995-03-26,Lebanon,Egypt,1,1,Friendly,Beirut,Lebanon,FALSE
 1995-03-26,Montserrat,Anguilla,3,2,CFU Caribbean Cup qualification,Plymouth,Montserrat,FALSE
@@ -19116,7 +19116,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-03-29,Israel,France,0,0,UEFA Euro qualification,Ramat-Gan,Israel,FALSE
 1995-03-29,Lithuania,Croatia,0,0,UEFA Euro qualification,Vilnius,Lithuania,FALSE
 1995-03-29,Luxembourg,Norway,0,2,UEFA Euro qualification,Luxembourg,Luxembourg,FALSE
-1995-03-29,Mexico,Chile,1,2,Friendly,Los Angeles,USA,TRUE
+1995-03-29,Mexico,Chile,1,2,Friendly,Los Angeles,United States,TRUE
 1995-03-29,Nepal,Pakistan,2,0,SAFF Cup,Colombo,Sri Lanka,TRUE
 1995-03-29,Netherlands,Malta,4,0,UEFA Euro qualification,Rotterdam,Netherlands,FALSE
 1995-03-29,Romania,Poland,2,1,UEFA Euro qualification,Bucharest,Romania,FALSE
@@ -19154,7 +19154,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-04-12,North Macedonia,Bulgaria,0,0,Friendly,Strumica,North Macedonia,FALSE
 1995-04-14,Egypt,Tunisia,1,0,Friendly,Port Said,Egypt,FALSE
 1995-04-19,Peru,Chile,6,0,Friendly,Lima,Peru,FALSE
-1995-04-22,Belgium,USA,1,0,Friendly,Brussels,Belgium,FALSE
+1995-04-22,Belgium,United States,1,0,Friendly,Brussels,Belgium,FALSE
 1995-04-22,Chile,Iceland,1,1,Friendly,Temuco,Chile,FALSE
 1995-04-22,Congo,Sierra Leone,0,2,African Cup of Nations qualification,Brazzaville,Congo,FALSE
 1995-04-22,Senegal,Togo,5,1,African Cup of Nations qualification,Dakar,Senegal,FALSE
@@ -19235,7 +19235,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-05-28,Canada,Chile,1,2,Friendly,Edmonton,Canada,FALSE
 1995-05-28,Ivory Coast,Liberia,1,1,Friendly,Abidjan,Ivory Coast,FALSE
 1995-05-28,Japan,Ecuador,3,0,Kirin Cup,Tokyo,Japan,FALSE
-1995-05-28,USA,Costa Rica,1,2,Friendly,Tampa,USA,FALSE
+1995-05-28,United States,Costa Rica,1,2,Friendly,Tampa,United States,FALSE
 1995-05-31,Argentina,Peru,1,0,Friendly,Córdoba,Argentina,FALSE
 1995-05-31,Finland,Denmark,0,1,Friendly,Helsinki,Finland,FALSE
 1995-05-31,Serbia,Russia,1,2,Friendly,Belgrade,Yugoslavia,FALSE
@@ -19289,27 +19289,27 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-06-11,Iceland,Hungary,2,1,UEFA Euro qualification,Reykjavík,Iceland,FALSE
 1995-06-11,Republic of Ireland,Austria,1,3,UEFA Euro qualification,Dublin,Republic of Ireland,FALSE
 1995-06-11,Ukraine,Croatia,1,0,UEFA Euro qualification,Kyiv,Ukraine,FALSE
-1995-06-11,USA,Nigeria,3,2,USA Cup,Foxborough,USA,FALSE
+1995-06-11,United States,Nigeria,3,2,USA Cup,Foxborough,United States,FALSE
 1995-06-12,Ecuador,Zambia,1,0,Korea Cup,Seoul,South Korea,TRUE
 1995-06-14,Argentina,Paraguay,2,1,Friendly,Rosario,Argentina,FALSE
-1995-06-17,Colombia,Nigeria,1,0,USA Cup,Piscataway,USA,TRUE
+1995-06-17,Colombia,Nigeria,1,0,USA Cup,Piscataway,United States,TRUE
 1995-06-18,Australia,Ghana,2,1,Friendly,Sydney,Australia,FALSE
-1995-06-18,USA,Mexico,4,0,USA Cup,Washington,USA,FALSE
+1995-06-18,United States,Mexico,4,0,USA Cup,Washington,United States,FALSE
 1995-06-18,Venezuela,Bolivia,1,3,Friendly,Valera,Venezuela,FALSE
 1995-06-19,Chile,Paraguay,0,1,Friendly,La Serena,Chile,FALSE
 1995-06-19,Switzerland,Italy,0,1,Friendly,Lausanne,Switzerland,FALSE
 1995-06-20,New Zealand,Turkey,1,2,Friendly,Coquimbo,Chile,TRUE
 1995-06-21,Australia,Ghana,1,0,Friendly,Adelaide,Australia,FALSE
 1995-06-21,Germany,Italy,2,0,Friendly,Zürich,Switzerland,TRUE
-1995-06-21,Mexico,Colombia,0,0,USA Cup,Washington,USA,TRUE
+1995-06-21,Mexico,Colombia,0,0,USA Cup,Washington,United States,TRUE
 1995-06-22,Chile,Turkey,0,0,Friendly,Santiago,Chile,FALSE
 1995-06-22,Paraguay,New Zealand,3,2,Friendly,Santiago,Chile,TRUE
 1995-06-23,Switzerland,Germany,1,2,Friendly,Berne,Switzerland,FALSE
 1995-06-24,Australia,Ghana,0,1,Friendly,Perth,Australia,FALSE
-1995-06-24,Mexico,Nigeria,2,1,USA Cup,Dallas,USA,TRUE
+1995-06-24,Mexico,Nigeria,2,1,USA Cup,Dallas,United States,TRUE
 1995-06-25,Mozambique,Zimbabwe,3,1,Friendly,Beira,Mozambique,FALSE
 1995-06-25,Uruguay,New Zealand,7,0,Friendly,Paysandú,Uruguay,FALSE
-1995-06-25,USA,Colombia,0,0,USA Cup,Piscataway,USA,FALSE
+1995-06-25,United States,Colombia,0,0,USA Cup,Piscataway,United States,FALSE
 1995-06-28,Uruguay,New Zealand,2,2,Friendly,Rivera,Uruguay,FALSE
 1995-06-30,Argentina,Australia,2,0,Friendly,Quilmes,Argentina,FALSE
 1995-06-30,Paraguay,Ecuador,1,0,Friendly,Asunción,Paraguay,FALSE
@@ -19321,19 +19321,19 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-07-07,Brazil,Ecuador,1,0,Copa América,Rivera,Uruguay,TRUE
 1995-07-07,Colombia,Peru,1,1,Copa América,Rivera,Uruguay,TRUE
 1995-07-08,Argentina,Bolivia,2,1,Copa América,Paysandú,Uruguay,TRUE
-1995-07-08,USA,Chile,2,1,Copa América,Paysandú,Uruguay,TRUE
+1995-07-08,United States,Chile,2,1,Copa América,Paysandú,Uruguay,TRUE
 1995-07-09,Mexico,Venezuela,3,1,Copa América,Maldonado,Uruguay,TRUE
 1995-07-09,Syria,Egypt,0,0,Friendly,Damascus,Syria,FALSE
 1995-07-09,Uruguay,Paraguay,1,0,Copa América,Montevideo,Uruguay,FALSE
 1995-07-10,Brazil,Peru,2,0,Copa América,Rivera,Uruguay,TRUE
 1995-07-10,Colombia,Ecuador,1,0,Copa América,Rivera,Uruguay,TRUE
 1995-07-11,Argentina,Chile,4,0,Copa América,Paysandú,Uruguay,TRUE
-1995-07-11,USA,Bolivia,0,1,Copa América,Paysandú,Uruguay,TRUE
+1995-07-11,United States,Bolivia,0,1,Copa América,Paysandú,Uruguay,TRUE
 1995-07-12,Paraguay,Venezuela,3,2,Copa América,Maldonado,Uruguay,TRUE
 1995-07-13,Brazil,Colombia,3,0,Copa América,Rivera,Uruguay,TRUE
 1995-07-13,Peru,Ecuador,1,2,Copa América,Rivera,Uruguay,TRUE
 1995-07-13,Uruguay,Mexico,1,1,Copa América,Montevideo,Uruguay,FALSE
-1995-07-14,Argentina,USA,0,3,Copa América,Paysandú,Uruguay,TRUE
+1995-07-14,Argentina,United States,0,3,Copa América,Paysandú,Uruguay,TRUE
 1995-07-14,Chile,Bolivia,2,2,Copa América,Paysandú,Uruguay,TRUE
 1995-07-14,Egypt,Algeria,1,1,African Cup of Nations qualification,Cairo,Egypt,FALSE
 1995-07-14,Mauritania,Togo,2,1,African Cup of Nations qualification,Nouakchott,Mauritania,FALSE
@@ -19351,7 +19351,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-07-16,Jersey,Isle of Wight,2,0,Island Games,Gibraltar,Gibraltar,TRUE
 1995-07-16,Åland Islands,Guernsey,2,2,Island Games,Gibraltar,Gibraltar,TRUE
 1995-07-17,Brazil,Argentina,2,2,Copa América,Rivera,Uruguay,TRUE
-1995-07-17,USA,Mexico,0,0,Copa América,Paysandú,Uruguay,TRUE
+1995-07-17,United States,Mexico,0,0,Copa América,Paysandú,Uruguay,TRUE
 1995-07-17,Gibraltar,Isle of Man,2,1,Island Games,Gibraltar,Gibraltar,FALSE
 1995-07-17,Greenland,Ynys Môn,1,2,Island Games,Gibraltar,Gibraltar,TRUE
 1995-07-17,Åland Islands,Isle of Wight,0,5,Island Games,Gibraltar,Gibraltar,TRUE
@@ -19363,7 +19363,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-07-19,Jamaica,Saint Lucia,2,1,CFU Caribbean Cup,Kingston,Jamaica,FALSE
 1995-07-19,Trinidad and Tobago,Cuba,2,0,CFU Caribbean Cup,Kingston,Jamaica,TRUE
 1995-07-19,Uruguay,Colombia,2,0,Copa América,Montevideo,Uruguay,FALSE
-1995-07-20,USA,Brazil,0,1,Copa América,Maldonado,Uruguay,TRUE
+1995-07-20,United States,Brazil,0,1,Copa América,Maldonado,Uruguay,TRUE
 1995-07-20,Greenland,Isle of Wight,1,2,Island Games,Gibraltar,Gibraltar,TRUE
 1995-07-20,Gibraltar,Jersey,1,0,Island Games,Gibraltar,Gibraltar,FALSE
 1995-07-21,Cayman Islands,Antigua and Barbuda,2,0,CFU Caribbean Cup,George Town,Cayman Islands,FALSE
@@ -19375,7 +19375,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-07-21,Guernsey,Ynys Môn,4,2,Island Games,Gibraltar,Gibraltar,TRUE
 1995-07-21,Gibraltar,Jersey,1,0,Island Games,Gibraltar,Gibraltar,FALSE
 1995-07-22,Algeria,Tunisia,2,1,Friendly,Algiers,Algeria,FALSE
-1995-07-22,Colombia,USA,4,1,Copa América,Maldonado,Uruguay,TRUE
+1995-07-22,Colombia,United States,4,1,Copa América,Maldonado,Uruguay,TRUE
 1995-07-22,Norway,France,0,0,Friendly,Oslo,Norway,FALSE
 1995-07-22,Gibraltar,Isle of Wight,0,1,Island Games,Gibraltar,Gibraltar,FALSE
 1995-07-23,Cayman Islands,French Guiana,1,0,CFU Caribbean Cup,George Town,Cayman Islands,FALSE
@@ -19422,7 +19422,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-08-16,Norway,Czech Republic,1,1,UEFA Euro qualification,Oslo,Norway,FALSE
 1995-08-16,Scotland,Greece,1,0,UEFA Euro qualification,Glasgow,Scotland,FALSE
 1995-08-16,Solomon Islands,Wallis Islands and Futuna,12,1,South Pacific Games,Papeete,French Polynesia,TRUE
-1995-08-16,Sweden,USA,1,0,Friendly,Norrköping,Sweden,FALSE
+1995-08-16,Sweden,United States,1,0,Friendly,Norrköping,Sweden,FALSE
 1995-08-17,Tahiti,Wallis Islands and Futuna,13,0,South Pacific Games,Papeete,French Polynesia,TRUE
 1995-08-18,Jamaica,Zambia,1,1,Friendly,Montego Bay,Jamaica,FALSE
 1995-08-18,New Caledonia,Solomon Islands,0,1,South Pacific Games,Papeete,French Polynesia,TRUE
@@ -19480,7 +19480,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-10-07,Bulgaria,Albania,3,0,UEFA Euro qualification,Sofia,Bulgaria,FALSE
 1995-10-08,Croatia,Italy,1,1,UEFA Euro qualification,Split,Croatia,FALSE
 1995-10-08,Germany,Moldova,6,1,UEFA Euro qualification,Leverkusen,Germany,FALSE
-1995-10-08,USA,Saudi Arabia,4,3,Friendly,Washington,USA,FALSE
+1995-10-08,United States,Saudi Arabia,4,3,Friendly,Washington,United States,FALSE
 1995-10-11,Argentina,Colombia,0,0,Friendly,Buenos Aires,Argentina,FALSE
 1995-10-11,Austria,Portugal,1,1,UEFA Euro qualification,Vienna,Austria,FALSE
 1995-10-11,Brazil,Uruguay,2,0,Friendly,Salvador,Brazil,FALSE
@@ -19495,7 +19495,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-10-11,Lithuania,Estonia,5,0,UEFA Euro qualification,Vilnius,Lithuania,FALSE
 1995-10-11,Luxembourg,Belarus,0,0,UEFA Euro qualification,Luxembourg,Luxembourg,FALSE
 1995-10-11,Malta,Netherlands,0,4,UEFA Euro qualification,Attard,Malta,FALSE
-1995-10-11,Mexico,Saudi Arabia,2,1,Friendly,Los Angeles,USA,TRUE
+1995-10-11,Mexico,Saudi Arabia,2,1,Friendly,Los Angeles,United States,TRUE
 1995-10-11,Norway,England,0,0,Friendly,Oslo,Norway,FALSE
 1995-10-11,Romania,France,1,3,UEFA Euro qualification,Bucharest,Romania,FALSE
 1995-10-11,Russia,Greece,2,1,UEFA Euro qualification,Moscow,Russia,FALSE
@@ -19594,7 +19594,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1995-11-28,Mauritania,Sierra Leone,0,0,Amílcar Cabral Cup,Nouakchott,Mauritania,FALSE
 1995-11-29,El Salvador,Belize,3,0,UNCAF Cup,San Salvador,El Salvador,FALSE
 1995-11-29,Honduras,Panama,2,0,UNCAF Cup,Santa Ana,El Salvador,TRUE
-1995-11-29,Mexico,Colombia,2,2,Friendly,Los Angeles,USA,TRUE
+1995-11-29,Mexico,Colombia,2,2,Friendly,Los Angeles,United States,TRUE
 1995-11-29,Trinidad and Tobago,Norway,3,2,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 1995-11-29,Tunisia,Burkina Faso,3,0,Friendly,Tunis,Tunisia,FALSE
 1995-11-29,Zanzibar,Rwanda,2,1,CECAFA Cup,Kampala,Uganda,TRUE
@@ -19649,37 +19649,37 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-01-07,Zimbabwe,Gabon,1,2,Friendly,Harare,Zimbabwe,FALSE
 1996-01-08,Egypt,Tunisia,2,1,Friendly,Ismaila,Egypt,FALSE
 1996-01-09,Zimbabwe,Ghana,1,1,Friendly,Harare,Zimbabwe,FALSE
-1996-01-10,Canada,Honduras,3,1,Gold Cup,Anaheim,USA,TRUE
-1996-01-10,Trinidad and Tobago,El Salvador,2,3,Gold Cup,Anaheim,USA,TRUE
-1996-01-11,Mexico,Saint Vincent and the Grenadines,5,0,Gold Cup,San Diego,USA,TRUE
+1996-01-10,Canada,Honduras,3,1,Gold Cup,Anaheim,United States,TRUE
+1996-01-10,Trinidad and Tobago,El Salvador,2,3,Gold Cup,Anaheim,United States,TRUE
+1996-01-11,Mexico,Saint Vincent and the Grenadines,5,0,Gold Cup,San Diego,United States,TRUE
 1996-01-11,Mozambique,Gabon,1,0,Friendly,Maputo,Mozambique,FALSE
-1996-01-12,Brazil,Canada,4,1,Gold Cup,Los Angeles,USA,TRUE
+1996-01-12,Brazil,Canada,4,1,Gold Cup,Los Angeles,United States,TRUE
 1996-01-13,South Africa,Cameroon,3,0,African Cup of Nations,Johannesburg,South Africa,FALSE
-1996-01-13,USA,Trinidad and Tobago,3,2,Gold Cup,Anaheim,USA,FALSE
-1996-01-14,Guatemala,Mexico,0,1,Gold Cup,San Diego,USA,TRUE
-1996-01-14,Honduras,Brazil,0,5,Gold Cup,Los Angeles,USA,TRUE
+1996-01-13,United States,Trinidad and Tobago,3,2,Gold Cup,Anaheim,United States,FALSE
+1996-01-14,Guatemala,Mexico,0,1,Gold Cup,San Diego,United States,TRUE
+1996-01-14,Honduras,Brazil,0,5,Gold Cup,Los Angeles,United States,TRUE
 1996-01-14,Ivory Coast,Ghana,0,2,African Cup of Nations,Port Elizabeth,South Africa,TRUE
 1996-01-14,Jamaica,Cuba,1,1,Friendly,Kingston,Jamaica,FALSE
 1996-01-14,Zambia,Algeria,0,0,African Cup of Nations,Bloemfontein,South Africa,TRUE
 1996-01-15,Egypt,Angola,2,1,African Cup of Nations,Johannesburg,South Africa,TRUE
 1996-01-15,Sierra Leone,Burkina Faso,2,1,African Cup of Nations,Bloemfontein,South Africa,TRUE
 1996-01-16,Gabon,Liberia,1,2,African Cup of Nations,Durban,South Africa,TRUE
-1996-01-16,Guatemala,Saint Vincent and the Grenadines,3,0,Gold Cup,Anaheim,USA,TRUE
+1996-01-16,Guatemala,Saint Vincent and the Grenadines,3,0,Gold Cup,Anaheim,United States,TRUE
 1996-01-16,Lebanon,Cyprus,1,0,Friendly,Beirut,Lebanon,FALSE
 1996-01-16,Tunisia,Mozambique,1,1,African Cup of Nations,Port Elizabeth,South Africa,TRUE
-1996-01-16,USA,El Salvador,2,0,Gold Cup,Anaheim,USA,FALSE
+1996-01-16,United States,El Salvador,2,0,Gold Cup,Anaheim,United States,FALSE
 1996-01-17,Armenia,Morocco,0,6,Friendly,Vitrolles,France,TRUE
 1996-01-18,Algeria,Sierra Leone,2,0,African Cup of Nations,Bloemfontein,South Africa,TRUE
 1996-01-18,Cameroon,Egypt,2,1,African Cup of Nations,Johannesburg,South Africa,TRUE
-1996-01-18,USA,Brazil,0,1,Gold Cup,Los Angeles,USA,FALSE
+1996-01-18,United States,Brazil,0,1,Gold Cup,Los Angeles,United States,FALSE
 1996-01-19,DR Congo,Gabon,0,2,African Cup of Nations,Durban,South Africa,TRUE
 1996-01-19,Ghana,Tunisia,2,1,African Cup of Nations,Port Elizabeth,South Africa,TRUE
-1996-01-19,Mexico,Guatemala,1,0,Gold Cup,San Diego,USA,TRUE
+1996-01-19,Mexico,Guatemala,1,0,Gold Cup,San Diego,United States,TRUE
 1996-01-20,Burkina Faso,Zambia,1,5,African Cup of Nations,Bloemfontein,South Africa,TRUE
 1996-01-20,South Africa,Angola,1,0,African Cup of Nations,Johannesburg,South Africa,FALSE
-1996-01-21,Mexico,Brazil,2,0,Gold Cup,Los Angeles,USA,TRUE
+1996-01-21,Mexico,Brazil,2,0,Gold Cup,Los Angeles,United States,TRUE
 1996-01-21,Mozambique,Ivory Coast,0,1,African Cup of Nations,Port Elizabeth,South Africa,TRUE
-1996-01-21,USA,Guatemala,3,0,Gold Cup,Los Angeles,USA,FALSE
+1996-01-21,United States,Guatemala,3,0,Gold Cup,Los Angeles,United States,FALSE
 1996-01-24,Angola,Cameroon,3,3,African Cup of Nations,Durban,South Africa,TRUE
 1996-01-24,Burkina Faso,Algeria,1,2,African Cup of Nations,Port Elizabeth,South Africa,TRUE
 1996-01-24,Greece,Israel,2,1,Friendly,Chalcis,Greece,FALSE
@@ -19752,9 +19752,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-03-03,Jamaica,Guatemala,2,0,Friendly,Kingston,Jamaica,FALSE
 1996-03-04,Indonesia,India,7,1,AFC Asian Cup qualification,Kuala Lumpur,Malaysia,TRUE
 1996-03-05,Syria,Kuwait,0,2,Friendly,Damascus,Syria,FALSE
-1996-03-06,Colombia,Honduras,2,1,Friendly,Miami,USA,TRUE
+1996-03-06,Colombia,Honduras,2,1,Friendly,Miami,United States,TRUE
 1996-03-06,Malaysia,India,5,2,AFC Asian Cup qualification,Kuala Lumpur,Malaysia,FALSE
-1996-03-06,Trinidad and Tobago,Haiti,2,0,Friendly,Miami,USA,TRUE
+1996-03-06,Trinidad and Tobago,Haiti,2,0,Friendly,Miami,United States,TRUE
 1996-03-07,Bolivia,Peru,2,0,Friendly,Santa Cruz,Bolivia,FALSE
 1996-03-10,Dominica,Antigua and Barbuda,3,3,FIFA World Cup qualification,Roseau,Dominica,FALSE
 1996-03-10,Turkmenistan,Kuwait,2,2,AFC Asian Cup qualification,Ashgabat,Turkmenistan,FALSE
@@ -19848,7 +19848,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-05-01,Poland,Belarus,1,1,Friendly,Mielec,Poland,FALSE
 1996-05-01,Turkey,Ukraine,3,2,Friendly,Samsun,Turkey,FALSE
 1996-05-04,Dominican Republic,Curaçao,2,1,FIFA World Cup qualification,Santo Domingo,Dominican Republic,FALSE
-1996-05-05,El Salvador,Bolivia,1,1,Friendly,Washington,USA,TRUE
+1996-05-05,El Salvador,Bolivia,1,1,Friendly,Washington,United States,TRUE
 1996-05-05,Guyana,Suriname,2,1,CFU Caribbean Cup qualification,Georgetown,Guyana,FALSE
 1996-05-05,Nicaragua,Guatemala,0,1,FIFA World Cup qualification,Diriamba,Nicaragua,FALSE
 1996-05-05,Saint Kitts and Nevis,Saint Lucia,5,1,FIFA World Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
@@ -19873,7 +19873,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-05-17,Mauritania,Senegal,0,0,Friendly,Nouakchott,Mauritania,FALSE
 1996-05-18,England,Hungary,3,0,Friendly,London,England,FALSE
 1996-05-18,Grenada,Haiti,0,1,FIFA World Cup qualification,St. George's,Grenada,FALSE
-1996-05-18,Mexico,Slovakia,5,2,Friendly,Chicago,USA,TRUE
+1996-05-18,Mexico,Slovakia,5,2,Friendly,Chicago,United States,TRUE
 1996-05-19,Barbados,Dominica,1,0,FIFA World Cup qualification,Bridgetown,Barbados,FALSE
 1996-05-19,Gambia,Guinea,1,1,Friendly,Banjul,Gambia,FALSE
 1996-05-19,Guernsey,Jersey,0,1,Friendly,St. Sampson,Guernsey,FALSE
@@ -19900,14 +19900,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-05-26,Tunisia,Senegal,2,0,Friendly,Tunis,Tunisia,FALSE
 1996-05-26,Turkmenistan,Lebanon,0,1,AFC Asian Cup qualification,Ashgabat,Turkmenistan,FALSE
 1996-05-26,Uganda,Kenya,1,2,Friendly,Kampala,Uganda,FALSE
-1996-05-26,USA,Scotland,2,1,Friendly,New Britain,USA,FALSE
+1996-05-26,United States,Scotland,2,1,Friendly,New Britain,United States,FALSE
 1996-05-27,Belarus,Azerbaijan,2,2,Friendly,Maladzečna,Belarus,FALSE
 1996-05-27,Cuba,Martinique,1,0,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,TRUE
 1996-05-28,Bulgaria,North Macedonia,3,0,Friendly,Sofia,Bulgaria,FALSE
 1996-05-28,Suriname,Jamaica,3,1,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,TRUE
 1996-05-28,Trinidad and Tobago,Saint Kitts and Nevis,5,1,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,FALSE
 1996-05-29,Austria,Czech Republic,1,0,Friendly,Salzburg,Austria,FALSE
-1996-05-29,Colombia,Scotland,1,0,Friendly,Miami,USA,TRUE
+1996-05-29,Colombia,Scotland,1,0,Friendly,Miami,United States,TRUE
 1996-05-29,Cuba,Haiti,0,0,CFU Caribbean Cup,Arima,Trinidad and Tobago,TRUE
 1996-05-29,Estonia,Turkey,0,0,Friendly,Tallinn,Estonia,FALSE
 1996-05-29,France,Finland,2,0,Friendly,Strasbourg,France,FALSE
@@ -19964,7 +19964,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-06-05,Martinique,Suriname,1,1,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,TRUE
 1996-06-07,Trinidad and Tobago,Cuba,2,0,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,FALSE
 1996-06-08,England,Switzerland,1,1,UEFA Euro,London,England,FALSE
-1996-06-08,Mexico,Bolivia,1,0,USA Cup,Dallas,USA,TRUE
+1996-06-08,Mexico,Bolivia,1,0,USA Cup,Dallas,United States,TRUE
 1996-06-08,Tanzania,Ghana,0,0,FIFA World Cup qualification,Dar es Salaam,Tanzania,FALSE
 1996-06-09,Denmark,Portugal,1,1,UEFA Euro,Sheffield,England,TRUE
 1996-06-09,Germany,Czech Republic,2,0,UEFA Euro,Manchester,England,TRUE
@@ -19973,7 +19973,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-06-09,Nigeria,Togo,1,3,Friendly,Lagos,Nigeria,FALSE
 1996-06-09,Panama,Belize,4,1,FIFA World Cup qualification,Panama City,Panama,FALSE
 1996-06-09,Spain,Bulgaria,1,1,UEFA Euro,Leeds,England,TRUE
-1996-06-09,USA,Republic of Ireland,2,1,USA Cup,Foxborough,USA,FALSE
+1996-06-09,United States,Republic of Ireland,2,1,USA Cup,Foxborough,United States,FALSE
 1996-06-10,Cuba,Haiti,6,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,TRUE
 1996-06-10,Iran,Nepal,8,0,AFC Asian Cup qualification,Tehran,Iran,FALSE
 1996-06-10,Netherlands,Scotland,0,0,UEFA Euro,Birmingham,England,TRUE
@@ -19982,10 +19982,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-06-11,Italy,Russia,2,1,UEFA Euro,Liverpool,England,TRUE
 1996-06-11,Turkey,Croatia,0,1,UEFA Euro,Nottingham,England,TRUE
 1996-06-12,Iran,Sri Lanka,7,0,AFC Asian Cup qualification,Tehran,Iran,FALSE
-1996-06-12,Mexico,Republic of Ireland,2,2,USA Cup,East Rutherford,USA,TRUE
+1996-06-12,Mexico,Republic of Ireland,2,2,USA Cup,East Rutherford,United States,TRUE
 1996-06-12,Nepal,Oman,0,7,AFC Asian Cup qualification,Tehran,Iran,TRUE
 1996-06-12,Tanzania,Sudan,0,0,Friendly,Dar es Salaam,Tanzania,FALSE
-1996-06-12,USA,Bolivia,0,2,USA Cup,Washington,USA,FALSE
+1996-06-12,United States,Bolivia,0,2,USA Cup,Washington,United States,FALSE
 1996-06-13,Barbados,Trinidad and Tobago,0,4,Friendly,Bridgetown,Barbados,FALSE
 1996-06-13,Bulgaria,Romania,1,0,UEFA Euro,Newcastle,England,TRUE
 1996-06-13,Switzerland,Netherlands,0,2,UEFA Euro,Birmingham,England,TRUE
@@ -19995,7 +19995,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-06-14,Kazakhstan,Qatar,1,0,AFC Asian Cup qualification,Almaty,Kazakhstan,FALSE
 1996-06-14,Portugal,Turkey,1,0,UEFA Euro,Nottingham,England,TRUE
 1996-06-14,Sri Lanka,Nepal,3,1,AFC Asian Cup qualification,Tehran,Iran,TRUE
-1996-06-15,Bolivia,Republic of Ireland,0,3,USA Cup,East Rutherford,USA,TRUE
+1996-06-15,Bolivia,Republic of Ireland,0,3,USA Cup,East Rutherford,United States,TRUE
 1996-06-15,Dominican Republic,Trinidad and Tobago,1,4,FIFA World Cup qualification,Santo Domingo,Dominican Republic,FALSE
 1996-06-15,England,Scotland,2,0,UEFA Euro,London,England,FALSE
 1996-06-15,France,Spain,1,1,UEFA Euro,Leeds,England,TRUE
@@ -20012,7 +20012,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-06-16,Russia,Germany,0,3,UEFA Euro,Manchester,England,TRUE
 1996-06-16,Sierra Leone,Burundi,0,1,FIFA World Cup qualification,Freetown,Sierra Leone,FALSE
 1996-06-16,Tunisia,Rwanda,2,0,FIFA World Cup qualification,Tunis,Tunisia,FALSE
-1996-06-16,USA,Mexico,2,2,USA Cup,Pasadena,USA,FALSE
+1996-06-16,United States,Mexico,2,2,USA Cup,Pasadena,United States,FALSE
 1996-06-16,Zambia,Sudan,3,0,FIFA World Cup qualification,Lusaka,Zambia,FALSE
 1996-06-16,Zimbabwe,Madagascar,2,2,FIFA World Cup qualification,Harare,Zimbabwe,FALSE
 1996-06-17,Ghana,Tanzania,2,1,FIFA World Cup qualification,Kumasi,Ghana,FALSE
@@ -20117,7 +20117,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-08-14,Turkey,Moldova,2,0,Friendly,Istanbul,Turkey,FALSE
 1996-08-16,Ecuador,Costa Rica,1,1,Friendly,Cuenca,Ecuador,FALSE
 1996-08-17,Rwanda,Uganda,0,0,Friendly,Kigali,Rwanda,FALSE
-1996-08-18,Guatemala,Honduras,1,1,Friendly,Monterey Park,USA,TRUE
+1996-08-18,Guatemala,Honduras,1,1,Friendly,Monterey Park,United States,TRUE
 1996-08-20,Belarus,United Arab Emirates,0,1,Friendly,Fürth,Germany,TRUE
 1996-08-20,Oman,Mali,1,0,Friendly,Muscat,Oman,FALSE
 1996-08-20,Togo,Benin,2,0,Friendly,Lomé,Togo,FALSE
@@ -20139,7 +20139,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-08-30,Canada,Panama,3,1,FIFA World Cup qualification,Edmonton,Canada,FALSE
 1996-08-30,Guatemala,Cuba,1,1,Friendly,Guatemala,Guatemala,FALSE
 1996-08-30,Mauritania,Benin,0,0,African Cup of Nations qualification,Nouakchott,Mauritania,FALSE
-1996-08-30,USA,El Salvador,3,1,Friendly,Los Angeles,USA,FALSE
+1996-08-30,United States,El Salvador,3,1,Friendly,Los Angeles,United States,FALSE
 1996-08-31,Armenia,Portugal,0,0,FIFA World Cup qualification,Yerevan,Armenia,FALSE
 1996-08-31,Austria,Scotland,0,0,FIFA World Cup qualification,Vienna,Austria,FALSE
 1996-08-31,Azerbaijan,Switzerland,1,0,FIFA World Cup qualification,Baku,Azerbaijan,FALSE
@@ -20222,7 +20222,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-09-23,Mali,Guinea,0,0,Friendly,Bamako,Mali,FALSE
 1996-09-23,Qatar,Philippines,5,0,FIFA World Cup qualification,Doha,Qatar,FALSE
 1996-09-24,Sri Lanka,India,1,1,FIFA World Cup qualification,Doha,Qatar,TRUE
-1996-09-25,El Salvador,Guatemala,2,1,Friendly,Los Angeles,USA,TRUE
+1996-09-25,El Salvador,Guatemala,2,1,Friendly,Los Angeles,United States,TRUE
 1996-09-25,South Korea,China PR,3,1,Friendly,Seoul,South Korea,FALSE
 1996-09-25,Oman,Mozambique,0,2,Friendly,Muscat,Oman,FALSE
 1996-09-25,Poland,United Arab Emirates,1,0,Friendly,Wodzisław Śląski,Poland,FALSE
@@ -20296,7 +20296,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-10-16,Brazil,Lithuania,3,1,Friendly,Teresina,Brazil,FALSE
 1996-10-16,Kuwait,Bahrain,1,0,Gulf Cup,Muscat,Oman,TRUE
 1996-10-16,Mexico,Jamaica,2,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
-1996-10-16,Peru,USA,4,1,Friendly,Lima,Peru,FALSE
+1996-10-16,Peru,United States,4,1,Friendly,Lima,Peru,FALSE
 1996-10-16,United Arab Emirates,Qatar,0,1,Gulf Cup,Muscat,Oman,TRUE
 1996-10-18,Oman,Kuwait,1,2,Gulf Cup,Muscat,Oman,FALSE
 1996-10-18,United Arab Emirates,Bahrain,1,1,Gulf Cup,Muscat,Oman,TRUE
@@ -20306,7 +20306,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-10-21,Oman,Qatar,0,3,Gulf Cup,Muscat,Oman,FALSE
 1996-10-21,Saudi Arabia,Bahrain,3,1,Gulf Cup,Muscat,Oman,TRUE
 1996-10-22,Kuwait,United Arab Emirates,1,2,Gulf Cup,Muscat,Oman,TRUE
-1996-10-23,Mexico,Ecuador,0,1,Friendly,Oakland,USA,TRUE
+1996-10-23,Mexico,Ecuador,0,1,Friendly,Oakland,United States,TRUE
 1996-10-23,Slovakia,Faroe Islands,3,0,FIFA World Cup qualification,Bratislava,Slovakia,FALSE
 1996-10-24,Kuwait,Saudi Arabia,1,0,Gulf Cup,Muscat,Oman,TRUE
 1996-10-24,Oman,United Arab Emirates,0,0,Gulf Cup,Muscat,Oman,FALSE
@@ -20320,11 +20320,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-10-30,Finland,Estonia,2,2,Friendly,Kotka,Finland,FALSE
 1996-10-30,Indonesia,Moldova,1,2,Friendly,Genoa,Italy,TRUE
 1996-11-01,Australia,Tahiti,5,0,Oceania Nations Cup,Canberra,Australia,FALSE
-1996-11-01,Honduras,Colombia,1,2,Friendly,New York,USA,TRUE
+1996-11-01,Honduras,Colombia,1,2,Friendly,New York,United States,TRUE
 1996-11-03,Canada,El Salvador,1,0,FIFA World Cup qualification,Burnaby,Canada,FALSE
 1996-11-03,Lithuania,Indonesia,4,0,Friendly,Vilnius,Lithuania,FALSE
 1996-11-03,Togo,Gabon,0,1,Friendly,Lomé,Togo,FALSE
-1996-11-03,USA,Guatemala,2,0,FIFA World Cup qualification,Washington,USA,FALSE
+1996-11-03,United States,Guatemala,2,0,FIFA World Cup qualification,Washington,United States,FALSE
 1996-11-06,Bosnia and Herzegovina,Italy,2,1,Friendly,Sarajevo,Bosnia and Herzegovina,FALSE
 1996-11-06,Mexico,Honduras,3,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1996-11-06,Saudi Arabia,Bulgaria,1,0,Friendly,Riyadh,Saudi Arabia,FALSE
@@ -20365,7 +20365,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-11-10,Switzerland,Norway,0,1,FIFA World Cup qualification,Berne,Switzerland,FALSE
 1996-11-10,Togo,Cameroon,2,4,FIFA World Cup qualification,Lomé,Togo,FALSE
 1996-11-10,Turkey,San Marino,7,0,FIFA World Cup qualification,Istanbul,Turkey,FALSE
-1996-11-10,USA,Trinidad and Tobago,2,0,FIFA World Cup qualification,Richmond,USA,FALSE
+1996-11-10,United States,Trinidad and Tobago,2,0,FIFA World Cup qualification,Richmond,United States,FALSE
 1996-11-11,Tonga,Cook Islands,2,0,FIFA World Cup qualification,Nuku'alofa,Tonga,FALSE
 1996-11-12,Chile,Uruguay,1,0,FIFA World Cup qualification,Santiago,Chile,FALSE
 1996-11-13,Andorra,Estonia,1,6,Friendly,Sant Julià de Lòria,Andorra,FALSE
@@ -20384,18 +20384,18 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-11-19,Kuwait,Syria,2,2,Friendly,Kuwait City,Kuwait,FALSE
 1996-11-19,Saudi Arabia,Mali,1,3,Friendly,Riyadh,Saudi Arabia,FALSE
 1996-11-19,United Arab Emirates,Uzbekistan,4,2,Friendly,Abu Dhabi,United Arab Emirates,FALSE
-1996-11-20,El Salvador,Mexico,1,3,Friendly,Los Angeles,USA,TRUE
+1996-11-20,El Salvador,Mexico,1,3,Friendly,Los Angeles,United States,TRUE
 1996-11-22,Kuwait,Mali,4,2,Friendly,Kuwait City,Kuwait,FALSE
 1996-11-22,Rwanda,Zanzibar,1,1,CECAFA Cup,Kassala,Sudan,TRUE
 1996-11-22,Tanzania,Uganda,0,1,CECAFA Cup,Khartoum,Sudan,TRUE
 1996-11-22,United Arab Emirates,Uzbekistan,2,0,Friendly,Abu Dhabi,United Arab Emirates,FALSE
 1996-11-23,South Korea,Colombia,4,1,Friendly,Suwon,South Korea,FALSE
-1996-11-24,Guatemala,Costa Rica,1,0,FIFA World Cup qualification,Los Angeles,USA,TRUE
+1996-11-24,Guatemala,Costa Rica,1,0,FIFA World Cup qualification,Los Angeles,United States,TRUE
 1996-11-24,Indonesia,Iraq,0,4,Friendly,Genoa,Italy,TRUE
 1996-11-24,Kenya,Zanzibar,1,0,CECAFA Cup,Kassala,Sudan,TRUE
 1996-11-24,Mali,Burkina Faso,2,0,Friendly,Bamako,Mali,FALSE
 1996-11-24,Sudan,Tanzania,3,2,CECAFA Cup,Khartoum,Sudan,FALSE
-1996-11-24,Trinidad and Tobago,USA,0,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
+1996-11-24,Trinidad and Tobago,United States,0,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 1996-11-25,Iran,Turkmenistan,0,1,Friendly,Tehran,Iran,FALSE
 1996-11-26,China PR,South Korea,2,3,Friendly,Guangzhou,China PR,FALSE
 1996-11-26,United Arab Emirates,Syria,1,1,Friendly,Abu Dhabi,United Arab Emirates,FALSE
@@ -20404,7 +20404,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-11-28,United Arab Emirates,Syria,1,0,Friendly,Abu Dhabi,United Arab Emirates,FALSE
 1996-11-29,Saudi Arabia,Indonesia,4,1,Friendly,Dammam,Saudi Arabia,FALSE
 1996-11-29,Sudan,Kenya,1,1,Friendly,Khartoum,Sudan,FALSE
-1996-12-01,Costa Rica,USA,2,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
+1996-12-01,Costa Rica,United States,2,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 1996-12-01,El Salvador,Cuba,3,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 1996-12-04,Indonesia,Kuwait,2,2,AFC Asian Cup,Abu Dhabi,United Arab Emirates,TRUE
 1996-12-04,United Arab Emirates,South Korea,1,1,AFC Asian Cup,Abu Dhabi,United Arab Emirates,FALSE
@@ -20415,7 +20415,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-12-06,Japan,Syria,2,1,AFC Asian Cup,Al Ain,United Arab Emirates,TRUE
 1996-12-07,South Korea,Indonesia,4,2,AFC Asian Cup,Abu Dhabi,United Arab Emirates,TRUE
 1996-12-07,United Arab Emirates,Kuwait,3,2,AFC Asian Cup,Abu Dhabi,United Arab Emirates,FALSE
-1996-12-08,Guatemala,Trinidad and Tobago,2,1,FIFA World Cup qualification,Los Angeles,USA,TRUE
+1996-12-08,Guatemala,Trinidad and Tobago,2,1,FIFA World Cup qualification,Los Angeles,United States,TRUE
 1996-12-08,Lebanon,Georgia,3,2,Friendly,Beirut,Lebanon,FALSE
 1996-12-08,Saudi Arabia,Iraq,1,0,AFC Asian Cup,Dubai,United Arab Emirates,TRUE
 1996-12-08,Thailand,Iran,1,3,AFC Asian Cup,Dubai,United Arab Emirates,TRUE
@@ -20438,7 +20438,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-12-14,Northern Ireland,Albania,2,0,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
 1996-12-14,Portugal,Germany,0,0,FIFA World Cup qualification,Lisbon,Portugal,FALSE
 1996-12-14,Spain,Serbia,2,0,FIFA World Cup qualification,Valencia,Spain,FALSE
-1996-12-14,USA,Costa Rica,2,1,FIFA World Cup qualification,Palo Alto,USA,FALSE
+1996-12-14,United States,Costa Rica,2,1,FIFA World Cup qualification,Palo Alto,United States,FALSE
 1996-12-14,Wales,Turkey,0,0,FIFA World Cup qualification,Cardiff,Wales,FALSE
 1996-12-15,Argentina,Chile,1,1,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
 1996-12-15,Bolivia,Paraguay,0,0,FIFA World Cup qualification,La Paz,Bolivia,FALSE
@@ -20458,7 +20458,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1996-12-19,United Arab Emirates,Kuwait,1,0,AFC Asian Cup,Abu Dhabi,United Arab Emirates,FALSE
 1996-12-20,Burkina Faso,Gabon,1,1,Friendly,Cotonou,Benin,TRUE
 1996-12-21,Costa Rica,Trinidad and Tobago,2,1,FIFA World Cup qualification,Cartago,Costa Rica,FALSE
-1996-12-21,Guatemala,USA,2,2,FIFA World Cup qualification,San Salvador,El Salvador,TRUE
+1996-12-21,Guatemala,United States,2,2,FIFA World Cup qualification,San Salvador,El Salvador,TRUE
 1996-12-21,Iran,Kuwait,1,1,AFC Asian Cup,Abu Dhabi,United Arab Emirates,TRUE
 1996-12-21,United Arab Emirates,Saudi Arabia,0,0,AFC Asian Cup,Abu Dhabi,United Arab Emirates,FALSE
 1996-12-21,Zimbabwe,Tanzania,2,2,Friendly,Harare,Zimbabwe,FALSE
@@ -20491,16 +20491,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-01-12,Uruguay,Argentina,0,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 1997-01-12,Venezuela,Paraguay,0,2,FIFA World Cup qualification,Mérida,Venezuela,FALSE
 1997-01-12,Zimbabwe,Togo,3,0,FIFA World Cup qualification,Harare,Zimbabwe,FALSE
-1997-01-17,USA,Peru,0,1,USA Cup,San Diego,USA,FALSE
+1997-01-17,United States,Peru,0,1,USA Cup,San Diego,United States,FALSE
 1997-01-18,Australia,New Zealand,1,0,Friendly,Melbourne,Australia,FALSE
 1997-01-18,South Korea,Norway,1,0,Friendly,Melbourne,Australia,TRUE
 1997-01-19,Benin,Togo,1,1,Friendly,Cotonou,Benin,FALSE
 1997-01-19,Mozambique,Zimbabwe,1,2,Friendly,Maputo,Mozambique,FALSE
-1997-01-19,USA,Mexico,0,2,USA Cup,Pasadena,USA,FALSE
+1997-01-19,United States,Mexico,0,2,USA Cup,Pasadena,United States,FALSE
 1997-01-22,Australia,South Korea,2,1,Friendly,Brisbane,Australia,FALSE
 1997-01-22,Israel,Greece,1,1,Friendly,Jerusalem,Israel,FALSE
 1997-01-22,Italy,Northern Ireland,2,0,Friendly,Palermo,Italy,FALSE
-1997-01-22,Mexico,Peru,0,0,USA Cup,Pasadena,USA,TRUE
+1997-01-22,Mexico,Peru,0,0,USA Cup,Pasadena,United States,TRUE
 1997-01-22,New Zealand,Norway,0,3,Friendly,Brisbane,Australia,TRUE
 1997-01-22,Portugal,France,0,2,Friendly,Braga,Portugal,FALSE
 1997-01-25,Australia,Norway,1,0,Friendly,Sydney,Australia,FALSE
@@ -20517,8 +20517,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-01-26,Eswatini,Lesotho,3,1,Friendly,Lobamba,Eswatini,FALSE
 1997-01-26,Tanzania,DR Congo,1,2,African Cup of Nations qualification,Dar es Salaam,Tanzania,FALSE
 1997-01-26,Zimbabwe,Ghana,0,0,African Cup of Nations qualification,Harare,Zimbabwe,FALSE
-1997-01-29,China PR,USA,2,1,Friendly,Kunming,China PR,FALSE
-1997-02-01,China PR,USA,1,1,Friendly,Guangzhou,China PR,FALSE
+1997-01-29,China PR,United States,2,1,Friendly,Kunming,China PR,FALSE
+1997-02-01,China PR,United States,1,1,Friendly,Guangzhou,China PR,FALSE
 1997-02-02,Bolivia,Slovakia,0,1,Friendly,Cochabamba,Bolivia,FALSE
 1997-02-02,Lebanon,Jordan,1,0,Friendly,Beirut,Lebanon,FALSE
 1997-02-05,Costa Rica,Slovakia,2,2,Friendly,Alajuela,Costa Rica,FALSE
@@ -20592,7 +20592,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-03-01,Botswana,Malawi,1,4,COSAFA Cup qualification,Gaborone,Botswana,FALSE
 1997-03-01,Solomon Islands,Tonga,9,0,FIFA World Cup qualification,Honiara,Solomon Islands,FALSE
 1997-03-02,Bosnia and Herzegovina,China PR,0,3,Dunhill Cup,Kuala Lumpur,Malaysia,TRUE
-1997-03-02,Jamaica,USA,0,0,FIFA World Cup qualification,Kingston,Jamaica,FALSE
+1997-03-02,Jamaica,United States,0,0,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 1997-03-02,Lesotho,Zambia,0,2,COSAFA Cup qualification,Maseru,Lesotho,FALSE
 1997-03-02,Mexico,Canada,4,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1997-03-02,Saudi Arabia,Syria,3,0,Friendly,Riyadh,Saudi Arabia,FALSE
@@ -20616,7 +20616,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-03-16,Costa Rica,Mexico,0,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 1997-03-16,Malaysia,Bangladesh,2,0,FIFA World Cup qualification,Kuala Lumpur,Malaysia,FALSE
 1997-03-16,Namibia,Zimbabwe,2,1,COSAFA Cup qualification,Windhoek,Namibia,FALSE
-1997-03-16,USA,Canada,3,0,FIFA World Cup qualification,Palo Alto,USA,FALSE
+1997-03-16,United States,Canada,3,0,FIFA World Cup qualification,Palo Alto,United States,FALSE
 1997-03-18,Austria,Slovenia,0,2,Friendly,Linz,Austria,FALSE
 1997-03-18,Bangladesh,Taiwan,1,3,FIFA World Cup qualification,Kuala Lumpur,Malaysia,TRUE
 1997-03-18,Kuwait,Bahrain,3,1,Friendly,Kuwait City,Kuwait,FALSE
@@ -20627,7 +20627,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-03-20,Malaysia,Taiwan,2,0,FIFA World Cup qualification,Kuala Lumpur,Malaysia,FALSE
 1997-03-22,Azerbaijan,Turkmenistan,3,0,Friendly,Baku,Azerbaijan,FALSE
 1997-03-23,Bolivia,Jamaica,6,0,Friendly,Oruro,Bolivia,FALSE
-1997-03-23,Costa Rica,USA,3,2,FIFA World Cup qualification,San José,Costa Rica,FALSE
+1997-03-23,Costa Rica,United States,3,2,FIFA World Cup qualification,San José,Costa Rica,FALSE
 1997-03-23,Nepal,Macau,1,1,FIFA World Cup qualification,Muscat,Oman,TRUE
 1997-03-23,Oman,Japan,0,1,FIFA World Cup qualification,Muscat,Oman,FALSE
 1997-03-23,Panama,Belize,1,1,UNCAF Cup,Panama City,Panama,FALSE
@@ -20714,7 +20714,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-04-11,India,China PR,1,2,Nehru Cup,Kochi,India,FALSE
 1997-04-11,Kuwait,Iran,0,2,Friendly,Kuwait City,Kuwait,FALSE
 1997-04-12,Malawi,Mozambique,2,2,COSAFA Cup,Lilongwe,Malawi,FALSE
-1997-04-13,El Salvador,Guatemala,1,1,Friendly,Washington,USA,TRUE
+1997-04-13,El Salvador,Guatemala,1,1,Friendly,Washington,United States,TRUE
 1997-04-13,Indonesia,Yemen,0,0,FIFA World Cup qualification,Jakarta,Indonesia,FALSE
 1997-04-13,Lebanon,Singapore,1,1,FIFA World Cup qualification,Beirut,Lebanon,FALSE
 1997-04-13,Mexico,Jamaica,6,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
@@ -20730,7 +20730,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-04-20,Cameroon,Congo,2,0,Friendly,Yaoundé,Cameroon,FALSE
 1997-04-20,El Salvador,Panama,2,0,UNCAF Cup,Guatemala,Guatemala,TRUE
 1997-04-20,Guatemala,Nicaragua,6,1,UNCAF Cup,Guatemala,Guatemala,FALSE
-1997-04-20,USA,Mexico,2,2,FIFA World Cup qualification,Foxborough,USA,FALSE
+1997-04-20,United States,Mexico,2,2,FIFA World Cup qualification,Foxborough,United States,FALSE
 1997-04-21,China PR,Myanmar,5,0,Friendly,Beijing,China PR,FALSE
 1997-04-21,Iran,Kenya,3,0,Friendly,Tabriz,Iran,FALSE
 1997-04-22,United Arab Emirates,Bahrain,3,0,FIFA World Cup qualification,Sharjah,United Arab Emirates,FALSE
@@ -20765,7 +20765,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-04-30,Argentina,Ecuador,2,1,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
 1997-04-30,Armenia,Northern Ireland,0,0,FIFA World Cup qualification,Yerevan,Armenia,FALSE
 1997-04-30,Austria,Estonia,2,0,FIFA World Cup qualification,Vienna,Austria,FALSE
-1997-04-30,Brazil,Mexico,4,0,Friendly,Miami,USA,TRUE
+1997-04-30,Brazil,Mexico,4,0,Friendly,Miami,United States,TRUE
 1997-04-30,Colombia,Peru,0,1,FIFA World Cup qualification,Barranquilla,Colombia,FALSE
 1997-04-30,Denmark,Slovenia,4,0,FIFA World Cup qualification,Copenhagen,Denmark,FALSE
 1997-04-30,England,Georgia,2,0,FIFA World Cup qualification,London,England,FALSE
@@ -20841,7 +20841,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-06-04,South Africa,Netherlands,0,2,Friendly,Johannesburg,South Africa,FALSE
 1997-06-04,Syria,Maldives,12,0,FIFA World Cup qualification,Damascus,Syria,FALSE
 1997-06-04,Togo,Burkina Faso,0,0,Friendly,Lomé,Togo,FALSE
-1997-06-04,USA,Paraguay,0,0,Friendly,St. Louis,USA,FALSE
+1997-06-04,United States,Paraguay,0,0,Friendly,St. Louis,United States,FALSE
 1997-06-05,Kuwait,Singapore,4,0,FIFA World Cup qualification,Kuwait City,Kuwait,FALSE
 1997-06-05,Senegal,Algeria,0,0,Friendly,Dakar,Senegal,FALSE
 1997-06-06,Iraq,Kazakhstan,1,2,FIFA World Cup qualification,Baghdad,Iraq,FALSE
@@ -20925,7 +20925,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-06-17,Argentina,Paraguay,1,1,Copa América,Cochabamba,Bolivia,TRUE
 1997-06-17,Australia,Solomon Islands,6,2,FIFA World Cup qualification,Sydney,Australia,FALSE
 1997-06-17,Chile,Ecuador,1,2,Copa América,Cochabamba,Bolivia,TRUE
-1997-06-17,USA,Israel,2,1,Friendly,Jacksonville,USA,FALSE
+1997-06-17,United States,Israel,2,1,Friendly,Jacksonville,United States,FALSE
 1997-06-18,Bolivia,Uruguay,1,0,Copa América,La Paz,Bolivia,FALSE
 1997-06-18,New Zealand,Fiji,5,0,FIFA World Cup qualification,Auckland,New Zealand,FALSE
 1997-06-18,Peru,Venezuela,2,0,Copa América,Sucre,Bolivia,TRUE
@@ -20970,7 +20970,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-06-28,New Zealand,Australia,0,3,FIFA World Cup qualification,Auckland,New Zealand,FALSE
 1997-06-29,Bolivia,Brazil,1,3,Copa América,La Paz,Bolivia,FALSE
 1997-06-29,Cambodia,Uzbekistan,1,4,FIFA World Cup qualification,Phnom Penh,Cambodia,FALSE
-1997-06-29,El Salvador,USA,1,1,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
+1997-06-29,El Salvador,United States,1,1,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 1997-06-29,Jamaica,Cuba,3,0,Friendly,Kingston,Jamaica,FALSE
 1997-06-29,Kazakhstan,Iraq,3,1,FIFA World Cup qualification,Almaty,Kazakhstan,FALSE
 1997-06-29,Jersey,Frøya,4,1,Island Games,St. Clement,Jersey,FALSE
@@ -21051,7 +21051,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-08-06,Sweden,Lithuania,1,0,Friendly,Malmö,Sweden,FALSE
 1997-08-07,Cameroon,Nigeria,0,1,Friendly,Tunis,Tunisia,TRUE
 1997-08-07,Tunisia,Zambia,3,1,Friendly,Tunis,Tunisia,FALSE
-1997-08-07,USA,Ecuador,0,1,Friendly,Baltimore,USA,FALSE
+1997-08-07,United States,Ecuador,0,1,Friendly,Baltimore,United States,FALSE
 1997-08-09,Cameroon,Zambia,3,3,Friendly,Tunis,Tunisia,TRUE
 1997-08-09,Malawi,Tanzania,2,2,COSAFA Cup,Lilongwe,Malawi,FALSE
 1997-08-09,Tunisia,Nigeria,2,0,Friendly,Tunis,Tunisia,FALSE
@@ -21106,7 +21106,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-09-06,Austria,Sweden,1,0,FIFA World Cup qualification,Vienna,Austria,FALSE
 1997-09-06,Azerbaijan,Norway,0,1,FIFA World Cup qualification,Baku,Azerbaijan,FALSE
 1997-09-06,Croatia,Bosnia and Herzegovina,3,2,FIFA World Cup qualification,Zagreb,Croatia,FALSE
-1997-09-06,El Salvador,Colombia,2,2,Friendly,East Rutherford,USA,TRUE
+1997-09-06,El Salvador,Colombia,2,2,Friendly,East Rutherford,United States,TRUE
 1997-09-06,Faroe Islands,Czech Republic,0,2,FIFA World Cup qualification,Toftir,Faroe Islands,FALSE
 1997-09-06,Germany,Portugal,1,1,FIFA World Cup qualification,Berlin,Germany,FALSE
 1997-09-06,Iceland,Republic of Ireland,2,2,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
@@ -21124,7 +21124,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-09-07,Japan,Uzbekistan,6,3,FIFA World Cup qualification,Tokyo,Japan,FALSE
 1997-09-07,Luxembourg,Cyprus,1,3,FIFA World Cup qualification,Luxembourg,Luxembourg,FALSE
 1997-09-07,Scotland,Belarus,4,1,FIFA World Cup qualification,Aberdeen,Scotland,FALSE
-1997-09-07,USA,Costa Rica,1,0,FIFA World Cup qualification,Portland,USA,FALSE
+1997-09-07,United States,Costa Rica,1,0,FIFA World Cup qualification,Portland,United States,FALSE
 1997-09-08,Nepal,Sri Lanka,1,3,SAFF Cup,Kathmandu,Nepal,FALSE
 1997-09-09,Maldives,India,2,2,SAFF Cup,Kathmandu,Nepal,TRUE
 1997-09-10,Albania,Northern Ireland,1,0,FIFA World Cup qualification,Zürich,Switzerland,TRUE
@@ -21164,7 +21164,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-09-20,Kazakhstan,Uzbekistan,1,1,FIFA World Cup qualification,Almaty,Kazakhstan,FALSE
 1997-09-20,Libya,Bahrain,2,1,Friendly,Tripoli,Libya,FALSE
 1997-09-21,Indonesia,New Zealand,5,0,Friendly,Jakarta,Indonesia,FALSE
-1997-09-24,El Salvador,Guatemala,0,1,Friendly,Los Angeles,USA,TRUE
+1997-09-24,El Salvador,Guatemala,0,1,Friendly,Los Angeles,United States,TRUE
 1997-09-24,Malta,Czech Republic,0,1,FIFA World Cup qualification,Attard,Malta,FALSE
 1997-09-24,Moldova,Georgia,0,1,FIFA World Cup qualification,Chișinău,Moldova,FALSE
 1997-09-24,Poland,Lithuania,2,0,Friendly,Olsztyn,Poland,FALSE
@@ -21183,7 +21183,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-10-03,China PR,Saudi Arabia,1,0,FIFA World Cup qualification,Dalian,China PR,FALSE
 1997-10-03,Iran,Qatar,3,0,FIFA World Cup qualification,Tehran,Iran,FALSE
 1997-10-03,Kenya,Zambia,0,0,Friendly,Dar es Salaam,Tanzania,TRUE
-1997-10-03,USA,Jamaica,1,1,FIFA World Cup qualification,Washington,USA,FALSE
+1997-10-03,United States,Jamaica,1,1,FIFA World Cup qualification,Washington,United States,FALSE
 1997-10-04,Kazakhstan,Japan,1,1,FIFA World Cup qualification,Almaty,Kazakhstan,FALSE
 1997-10-04,South Korea,United Arab Emirates,3,0,FIFA World Cup qualification,Seoul,South Korea,FALSE
 1997-10-04,Saint Kitts and Nevis,Cuba,0,2,Gold Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
@@ -21248,7 +21248,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-10-31,Iran,Kuwait,0,0,FIFA World Cup qualification,Tehran,Iran,FALSE
 1997-11-01,South Korea,Japan,0,2,FIFA World Cup qualification,Seoul,South Korea,FALSE
 1997-11-02,Ivory Coast,Burkina Faso,0,0,Friendly,Bouaké,Ivory Coast,FALSE
-1997-11-02,Mexico,USA,0,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+1997-11-02,Mexico,United States,0,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1997-11-02,Eswatini,Mauritius,0,1,Friendly,Mbabane,Eswatini,FALSE
 1997-11-02,United Arab Emirates,Uzbekistan,0,0,FIFA World Cup qualification,Abu Dhabi,United Arab Emirates,FALSE
 1997-11-05,Tunisia,Bosnia and Herzegovina,2,1,Friendly,Tunis,Tunisia,FALSE
@@ -21256,7 +21256,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-11-07,Chile,Guatemala,4,1,Friendly,Antofagasta,Chile,FALSE
 1997-11-07,Qatar,Iran,2,0,FIFA World Cup qualification,Doha,Qatar,FALSE
 1997-11-08,Japan,Kazakhstan,5,1,FIFA World Cup qualification,Tokyo,Japan,FALSE
-1997-11-09,Canada,USA,0,3,FIFA World Cup qualification,Burnaby,Canada,FALSE
+1997-11-09,Canada,United States,0,3,FIFA World Cup qualification,Burnaby,Canada,FALSE
 1997-11-09,El Salvador,Jamaica,2,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 1997-11-09,Mexico,Costa Rica,3,3,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 1997-11-09,United Arab Emirates,South Korea,1,3,FIFA World Cup qualification,Abu Dhabi,United Arab Emirates,FALSE
@@ -21278,7 +21278,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1997-11-16,Japan,Iran,3,2,FIFA World Cup qualification,Johor Bahru,Malaysia,TRUE
 1997-11-16,Peru,Paraguay,1,0,FIFA World Cup qualification,Lima,Peru,FALSE
 1997-11-16,Uruguay,Ecuador,5,3,FIFA World Cup qualification,Maldonado,Uruguay,FALSE
-1997-11-16,USA,El Salvador,4,2,FIFA World Cup qualification,Foxborough,USA,FALSE
+1997-11-16,United States,El Salvador,4,2,FIFA World Cup qualification,Foxborough,United States,FALSE
 1997-11-19,Senegal,Mali,1,2,Friendly,Dakar,Senegal,FALSE
 1997-11-19,Spain,Romania,1,1,Friendly,Palma de Mallorca,Spain,FALSE
 1997-11-22,Iran,Australia,1,1,FIFA World Cup qualification,Tehran,Iran,FALSE
@@ -21356,7 +21356,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-01-21,El Salvador,Trinidad and Tobago,2,0,Friendly,San Salvador,El Salvador,FALSE
 1998-01-21,Turkey,Albania,1,4,Friendly,Antalya,Turkey,FALSE
 1998-01-24,Namibia,South Africa,3,2,COSAFA Cup qualification,Windhoek,Namibia,FALSE
-1998-01-24,USA,Sweden,1,0,Friendly,Orlando,USA,FALSE
+1998-01-24,United States,Sweden,1,0,Friendly,Orlando,United States,FALSE
 1998-01-25,Botswana,Mozambique,1,2,COSAFA Cup qualification,Gaborone,Botswana,FALSE
 1998-01-25,Thailand,Egypt,1,1,King's Cup,Bangkok,Thailand,FALSE
 1998-01-27,Egypt,South Korea,0,2,King's Cup,Bangkok,Thailand,TRUE
@@ -21375,17 +21375,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-01-31,Iran,Chile,1,1,Lunar New Year Cup,So Kon Po,Hong Kong,TRUE
 1998-01-31,Tunisia,Guinea,4,1,Friendly,Tunis,Tunisia,FALSE
 1998-02-01,Burkina Faso,Namibia,3,1,Friendly,Niamey,Niger,TRUE
-1998-02-01,Guatemala,El Salvador,0,0,Gold Cup,Los Angeles,USA,TRUE
-1998-02-01,Honduras,Trinidad and Tobago,1,3,Gold Cup,Oakland,USA,TRUE
+1998-02-01,Guatemala,El Salvador,0,0,Gold Cup,Los Angeles,United States,TRUE
+1998-02-01,Honduras,Trinidad and Tobago,1,3,Gold Cup,Oakland,United States,TRUE
 1998-02-01,Ivory Coast,Cameroon,1,0,Friendly,Bouaké,Ivory Coast,FALSE
 1998-02-01,Togo,Mali,0,4,Friendly,Lomé,Togo,FALSE
-1998-02-01,USA,Cuba,3,0,Gold Cup,Oakland,USA,FALSE
-1998-02-03,Brazil,Jamaica,0,0,Gold Cup,Miami,USA,TRUE
-1998-02-04,Cuba,Costa Rica,2,7,Gold Cup,Oakland,USA,TRUE
+1998-02-01,United States,Cuba,3,0,Gold Cup,Oakland,United States,FALSE
+1998-02-03,Brazil,Jamaica,0,0,Gold Cup,Miami,United States,TRUE
+1998-02-04,Cuba,Costa Rica,2,7,Gold Cup,Oakland,United States,TRUE
 1998-02-04,Mali,Tunisia,0,1,Friendly,Bamako,Mali,FALSE
 1998-02-04,New Zealand,Chile,0,0,Friendly,Auckland,New Zealand,FALSE
-1998-02-04,Trinidad and Tobago,Mexico,2,4,Gold Cup,Oakland,USA,TRUE
-1998-02-05,Brazil,Guatemala,1,1,Gold Cup,Miami,USA,TRUE
+1998-02-04,Trinidad and Tobago,Mexico,2,4,Gold Cup,Oakland,United States,TRUE
+1998-02-05,Brazil,Guatemala,1,1,Gold Cup,Miami,United States,TRUE
 1998-02-05,Cyprus,Finland,1,1,Cyprus International Tournament,Limassol,Cyprus,FALSE
 1998-02-05,Iceland,Slovenia,2,3,Cyprus International Tournament,Limassol,Cyprus,TRUE
 1998-02-05,Morocco,Niger,3,0,Friendly,Marrakech,Morocco,FALSE
@@ -21395,13 +21395,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-02-07,Australia,Chile,0,1,Friendly,Melbourne,Australia,FALSE
 1998-02-07,Burkina Faso,Cameroon,0,1,African Cup of Nations,Ouagadougou,Burkina Faso,FALSE
 1998-02-07,Iceland,Slovakia,1,2,Cyprus International Tournament,Limassol,Cyprus,TRUE
-1998-02-07,Mexico,Honduras,2,0,Gold Cup,Oakland,USA,TRUE
+1998-02-07,Mexico,Honduras,2,0,Gold Cup,Oakland,United States,TRUE
 1998-02-07,New Zealand,South Korea,0,1,Friendly,Auckland,New Zealand,FALSE
-1998-02-07,USA,Costa Rica,2,1,Gold Cup,Oakland,USA,FALSE
+1998-02-07,United States,Costa Rica,2,1,Gold Cup,Oakland,United States,FALSE
 1998-02-08,Albania,Georgia,0,3,Malta International Tournament,Attard,Malta,TRUE
 1998-02-08,Algeria,Guinea,0,1,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
-1998-02-08,El Salvador,Brazil,0,4,Gold Cup,Los Angeles,USA,TRUE
-1998-02-08,Guatemala,Jamaica,2,3,Gold Cup,Los Angeles,USA,TRUE
+1998-02-08,El Salvador,Brazil,0,4,Gold Cup,Los Angeles,United States,TRUE
+1998-02-08,Guatemala,Jamaica,2,3,Gold Cup,Los Angeles,United States,TRUE
 1998-02-08,Ivory Coast,Namibia,4,3,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
 1998-02-08,Malta,Latvia,2,1,Malta International Tournament,Attard,Malta,FALSE
 1998-02-08,Paraguay,Poland,4,0,Friendly,Asunción,Paraguay,FALSE
@@ -21410,12 +21410,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-02-09,Cyprus,Slovenia,1,0,Cyprus International Tournament,Limassol,Cyprus,FALSE
 1998-02-09,Finland,Slovakia,0,2,Cyprus International Tournament,Larnaca,Cyprus,TRUE
 1998-02-09,Ghana,Tunisia,2,0,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
-1998-02-09,Jamaica,El Salvador,2,0,Gold Cup,Los Angeles,USA,TRUE
+1998-02-09,Jamaica,El Salvador,2,0,Gold Cup,Los Angeles,United States,TRUE
 1998-02-09,Zambia,Morocco,1,1,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
 1998-02-10,Albania,Latvia,2,2,Malta International Tournament,Attard,Malta,TRUE
 1998-02-10,Egypt,Mozambique,2,0,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
 1998-02-10,Malta,Georgia,1,3,Malta International Tournament,Attard,Malta,FALSE
-1998-02-10,USA,Brazil,1,0,Gold Cup,Los Angeles,USA,FALSE
+1998-02-10,United States,Brazil,1,0,Gold Cup,Los Angeles,United States,FALSE
 1998-02-11,Australia,South Korea,1,0,Friendly,Sydney,Australia,FALSE
 1998-02-11,Burkina Faso,Algeria,2,1,African Cup of Nations,Ouagadougou,Burkina Faso,FALSE
 1998-02-11,Cameroon,Guinea,2,2,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
@@ -21423,15 +21423,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-02-11,South Africa,Ivory Coast,1,1,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
 1998-02-12,Angola,Namibia,3,3,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
 1998-02-12,Ghana,Togo,1,2,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
-1998-02-12,Jamaica,Mexico,0,1,Gold Cup,Los Angeles,USA,TRUE
+1998-02-12,Jamaica,Mexico,0,1,Gold Cup,Los Angeles,United States,TRUE
 1998-02-12,Tunisia,DR Congo,2,1,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
 1998-02-13,Morocco,Mozambique,3,0,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
 1998-02-13,Zambia,Egypt,0,4,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
 1998-02-15,Australia,Japan,0,3,Friendly,Adelaide,Australia,FALSE
-1998-02-15,Brazil,Jamaica,1,0,Gold Cup,Los Angeles,USA,TRUE
+1998-02-15,Brazil,Jamaica,1,0,Gold Cup,Los Angeles,United States,TRUE
 1998-02-15,Burkina Faso,Guinea,1,0,African Cup of Nations,Ouagadougou,Burkina Faso,FALSE
 1998-02-15,Cameroon,Algeria,2,1,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
-1998-02-15,USA,Mexico,0,1,Gold Cup,Los Angeles,USA,FALSE
+1998-02-15,United States,Mexico,0,1,Gold Cup,Los Angeles,United States,FALSE
 1998-02-16,Ghana,DR Congo,0,1,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
 1998-02-16,Ivory Coast,Angola,5,2,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
 1998-02-16,South Africa,Namibia,4,1,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
@@ -21444,14 +21444,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-02-20,Cameroon,DR Congo,0,1,African Cup of Nations,Bobo Dioulasso,Burkina Faso,TRUE
 1998-02-21,Burkina Faso,Tunisia,1,1,African Cup of Nations,Ouagadougou,Burkina Faso,FALSE
 1998-02-21,Ivory Coast,Egypt,0,0,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
-1998-02-21,USA,Netherlands,0,2,Friendly,Miami Gardens,USA,FALSE
+1998-02-21,United States,Netherlands,0,2,Friendly,Miami Gardens,United States,FALSE
 1998-02-22,Antigua and Barbuda,Dominica,1,1,Friendly,St. John's,Antigua and Barbuda,FALSE
 1998-02-22,Jamaica,Nigeria,2,2,Friendly,Kingston,Jamaica,FALSE
 1998-02-22,Morocco,South Africa,1,2,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
 1998-02-22,Saudi Arabia,Germany,0,3,Friendly,Riyadh,Saudi Arabia,FALSE
 1998-02-24,Argentina,Serbia,3,1,Friendly,Mar del Plata,Argentina,FALSE
-1998-02-24,Mexico,Netherlands,2,3,Friendly,Miami Gardens,USA,TRUE
-1998-02-25,Belgium,USA,2,0,Friendly,Brussels,Belgium,FALSE
+1998-02-24,Mexico,Netherlands,2,3,Friendly,Miami Gardens,United States,TRUE
+1998-02-25,Belgium,United States,2,0,Friendly,Brussels,Belgium,FALSE
 1998-02-25,Burkina Faso,Egypt,0,2,African Cup of Nations,Bobo Dioulasso,Burkina Faso,FALSE
 1998-02-25,DR Congo,South Africa,1,2,African Cup of Nations,Ouagadougou,Burkina Faso,TRUE
 1998-02-25,France,Norway,3,3,Friendly,Marseille,France,FALSE
@@ -21478,7 +21478,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-03-11,Haiti,Puerto Rico,4,0,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
 1998-03-13,Dominican Republic,Puerto Rico,3,1,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,TRUE
 1998-03-14,Myanmar,Brunei,4,1,AFF Championship,Yangon,Myanmar,FALSE
-1998-03-14,USA,Paraguay,2,2,Friendly,San Diego,USA,FALSE
+1998-03-14,United States,Paraguay,2,2,Friendly,San Diego,United States,FALSE
 1998-03-15,Haiti,Dominican Republic,5,0,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
 1998-03-16,Laos,Brunei,2,1,AFF Championship,Yangon,Myanmar,TRUE
 1998-03-18,Myanmar,Laos,3,0,AFF Championship,Yangon,Myanmar,FALSE
@@ -21489,7 +21489,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-03-20,Saint Lucia,Saint Vincent and the Grenadines,3,2,CFU Caribbean Cup qualification,Castries,Saint Lucia,FALSE
 1998-03-22,Azerbaijan,Moldova,1,0,Friendly,Baku,Azerbaijan,FALSE
 1998-03-22,Saint Lucia,Martinique,1,2,CFU Caribbean Cup qualification,Castries,Saint Lucia,FALSE
-1998-03-22,USA Virgin Islands,British Virgin Islands,1,0,Friendly,Saint Croix,USA Virgin Islands,FALSE
+1998-03-22,United States Virgin Islands,British Virgin Islands,1,0,Friendly,Saint Croix,United States Virgin Islands,FALSE
 1998-03-24,Singapore,Philippines,1,0,AFF Championship,Singapore,Singapore,FALSE
 1998-03-25,Austria,Hungary,2,3,Friendly,Vienna,Austria,FALSE
 1998-03-25,Belgium,Norway,2,2,Friendly,Brussels,Belgium,FALSE
@@ -21507,7 +21507,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-03-25,Wales,Jamaica,0,0,Friendly,Cardiff,Wales,FALSE
 1998-03-26,Cambodia,Philippines,1,1,AFF Championship,Singapore,Singapore,TRUE
 1998-03-28,Singapore,Cambodia,3,0,AFF Championship,Singapore,Singapore,FALSE
-1998-03-29,Colombia,Paraguay,1,1,Friendly,New Haven,USA,TRUE
+1998-03-29,Colombia,Paraguay,1,1,Friendly,New Haven,United States,TRUE
 1998-04-01,Antigua and Barbuda,Saint Lucia,1,1,Friendly,St. John's,Antigua and Barbuda,FALSE
 1998-04-01,Dominica,Guadeloupe,1,1,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,TRUE
 1998-04-01,South Korea,Japan,2,1,Friendly,Seoul,South Korea,FALSE
@@ -21520,7 +21520,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-04-14,Iran,Kuwait,1,1,Friendly,Tehran,Iran,FALSE
 1998-04-15,Grenada,Anguilla,14,1,CFU Caribbean Cup qualification,St. John's,Antigua and Barbuda,TRUE
 1998-04-15,Israel,Argentina,2,1,Friendly,Jerusalem,Israel,FALSE
-1998-04-15,Mexico,Peru,1,0,Friendly,Los Angeles,USA,TRUE
+1998-04-15,Mexico,Peru,1,0,Friendly,Los Angeles,United States,TRUE
 1998-04-15,Slovakia,South Korea,0,0,Friendly,Bratislava,Slovakia,FALSE
 1998-04-18,North Macedonia,South Korea,2,2,Friendly,Skopje,North Macedonia,FALSE
 1998-04-19,Antigua and Barbuda,Grenada,2,1,CFU Caribbean Cup qualification,St. John's,Antigua and Barbuda,FALSE
@@ -21529,7 +21529,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-04-20,Iran,Hungary,0,2,Friendly,Tehran,Iran,FALSE
 1998-04-20,Jamaica,North Macedonia,1,2,Friendly,Tehran,Iran,TRUE
 1998-04-21,Latvia,Lithuania,1,2,Baltic Cup,Liepāja,Latvia,FALSE
-1998-04-22,Austria,USA,0,3,Friendly,Vienna,Austria,FALSE
+1998-04-22,Austria,United States,0,3,Friendly,Vienna,Austria,FALSE
 1998-04-22,Belgium,Romania,1,1,Friendly,Brussels,Belgium,FALSE
 1998-04-22,Bulgaria,Morocco,2,1,Friendly,Sofia,Bulgaria,FALSE
 1998-04-22,Chile,Colombia,2,2,Friendly,Santiago,Chile,FALSE
@@ -21564,7 +21564,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-05-14,Corsica,Cameroon,0,1,Friendly,Bastia,France,FALSE
 1998-05-16,Estonia,Azerbaijan,0,0,Friendly,Viljandi,Estonia,FALSE
 1998-05-16,South Korea,Jamaica,2,1,Friendly,Seoul,South Korea,FALSE
-1998-05-16,USA,North Macedonia,0,0,Friendly,San Jose,USA,FALSE
+1998-05-16,United States,North Macedonia,0,0,Friendly,San Jose,United States,FALSE
 1998-05-16,Zambia,Mozambique,1,0,COSAFA Cup,Lusaka,Zambia,FALSE
 1998-05-17,Japan,Paraguay,1,1,Kirin Cup,Tokyo,Japan,FALSE
 1998-05-17,Latvia,Israel,1,5,Friendly,Riga,Latvia,FALSE
@@ -21582,7 +21582,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-05-24,Chile,Uruguay,2,2,Friendly,Santiago,Chile,FALSE
 1998-05-24,Japan,Czech Republic,0,0,Kirin Cup,Yokohama,Japan,FALSE
 1998-05-24,Mozambique,Zimbabwe,0,2,COSAFA Cup,Maputo,Mozambique,FALSE
-1998-05-24,USA,Kuwait,2,0,Friendly,Portland,USA,FALSE
+1998-05-24,United States,Kuwait,2,0,Friendly,Portland,United States,FALSE
 1998-05-25,Argentina,South Africa,2,0,Friendly,Buenos Aires,Argentina,FALSE
 1998-05-27,Austria,Tunisia,2,1,Friendly,Vienna,Austria,FALSE
 1998-05-27,Belgium,France,0,1,King Hassan II Tournament,Casablanca,Morocco,TRUE
@@ -21601,7 +21601,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-05-30,Georgia,Russia,1,1,Friendly,Tbilisi,Georgia,FALSE
 1998-05-30,Germany,Colombia,3,1,Friendly,Frankfurt am Main,Germany,FALSE
 1998-05-30,Namibia,Angola,1,1,COSAFA Cup,Windhoek,Namibia,FALSE
-1998-05-30,USA,Scotland,0,0,Friendly,Washington,USA,FALSE
+1998-05-30,United States,Scotland,0,0,Friendly,Washington,United States,FALSE
 1998-05-31,Chile,Tunisia,3,2,Friendly,Montélimar,France,TRUE
 1998-05-31,Japan,Mexico,1,2,Friendly,Lausanne,Switzerland,TRUE
 1998-05-31,Luxembourg,Cameroon,0,2,Friendly,Luxembourg,Luxembourg,FALSE
@@ -21648,7 +21648,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-06-14,Jamaica,Croatia,1,3,FIFA World Cup,Lens,France,TRUE
 1998-06-14,Serbia,Iran,1,0,FIFA World Cup,Saint-Étienne,France,TRUE
 1998-06-15,England,Tunisia,2,0,FIFA World Cup,Marseille,France,TRUE
-1998-06-15,Germany,USA,2,0,FIFA World Cup,Paris,France,TRUE
+1998-06-15,Germany,United States,2,0,FIFA World Cup,Paris,France,TRUE
 1998-06-15,Romania,Colombia,1,0,FIFA World Cup,Lyon,France,TRUE
 1998-06-16,Brazil,Morocco,3,0,FIFA World Cup,Nantes,France,TRUE
 1998-06-16,Scotland,Norway,1,1,FIFA World Cup,Bordeaux,France,TRUE
@@ -21663,7 +21663,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-06-20,Netherlands,South Korea,5,0,FIFA World Cup,Marseille,France,TRUE
 1998-06-21,Argentina,Jamaica,5,0,FIFA World Cup,Paris,France,TRUE
 1998-06-21,Germany,Serbia,2,2,FIFA World Cup,Lens,France,TRUE
-1998-06-21,USA,Iran,1,2,FIFA World Cup,Lyon,France,TRUE
+1998-06-21,United States,Iran,1,2,FIFA World Cup,Lyon,France,TRUE
 1998-06-22,Colombia,Tunisia,1,0,FIFA World Cup,Montpellier,France,TRUE
 1998-06-22,Estonia,Andorra,2,1,Friendly,Kuressaare,Estonia,FALSE
 1998-06-22,Romania,England,2,1,FIFA World Cup,Toulouse,France,TRUE
@@ -21680,7 +21680,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-06-25,Estonia,Latvia,0,2,Baltic Cup,Valga,Estonia,FALSE
 1998-06-25,Germany,Iran,2,0,FIFA World Cup,Montpellier,France,TRUE
 1998-06-25,Netherlands,Mexico,2,2,FIFA World Cup,Saint-Étienne,France,TRUE
-1998-06-25,USA,Serbia,0,1,FIFA World Cup,Nantes,France,TRUE
+1998-06-25,United States,Serbia,0,1,FIFA World Cup,Nantes,France,TRUE
 1998-06-26,Argentina,Croatia,1,0,FIFA World Cup,Bordeaux,France,TRUE
 1998-06-26,Azerbaijan,Lithuania,2,1,Friendly,Viljandi,Estonia,TRUE
 1998-06-26,Colombia,England,0,2,FIFA World Cup,Lens,France,TRUE
@@ -21941,7 +21941,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-10-10,Turkey,Germany,1,0,UEFA Euro qualification,Bursa,Turkey,FALSE
 1998-10-13,Kuwait,Iran,3,0,Friendly,Kuwait City,Kuwait,FALSE
 1998-10-13,Netherlands,Ghana,0,0,Friendly,Arnhem,Netherlands,FALSE
-1998-10-14,Brazil,Ecuador,5,1,Friendly,Washington,USA,TRUE
+1998-10-14,Brazil,Ecuador,5,1,Friendly,Washington,United States,TRUE
 1998-10-14,Bulgaria,Sweden,0,1,UEFA Euro qualification,Burgas,Bulgaria,FALSE
 1998-10-14,Croatia,North Macedonia,3,2,UEFA Euro qualification,Zagreb,Croatia,FALSE
 1998-10-14,Czech Republic,Estonia,4,1,UEFA Euro qualification,Teplice,Czech Republic,FALSE
@@ -21985,7 +21985,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-11-05,Oman,Saudi Arabia,0,1,Gulf Cup,Manama,Bahrain,TRUE
 1998-11-05,Qatar,United Arab Emirates,0,0,Gulf Cup,Manama,Bahrain,TRUE
 1998-11-06,Bahrain,Kuwait,0,2,Gulf Cup,Manama,Bahrain,FALSE
-1998-11-06,USA,Australia,0,0,Friendly,San Jose,USA,FALSE
+1998-11-06,United States,Australia,0,0,Friendly,San Jose,United States,FALSE
 1998-11-07,Tunisia,Zimbabwe,1,1,Friendly,Tunis,Tunisia,FALSE
 1998-11-08,Bahrain,Qatar,0,0,Gulf Cup,Manama,Bahrain,FALSE
 1998-11-08,Saudi Arabia,United Arab Emirates,1,0,Gulf Cup,Manama,Bahrain,TRUE
@@ -21997,16 +21997,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1998-11-12,United Arab Emirates,Kuwait,1,4,Gulf Cup,Manama,Bahrain,TRUE
 1998-11-15,Sri Lanka,Maldives,2,2,Friendly,Colombo,Sri Lanka,FALSE
 1998-11-16,India,Uzbekistan,0,0,Friendly,New Delhi,India,FALSE
-1998-11-17,El Salvador,Mexico,0,2,Friendly,Los Angeles,USA,TRUE
-1998-11-17,Guatemala,Honduras,3,3,Friendly,Los Angeles,USA,TRUE
+1998-11-17,El Salvador,Mexico,0,2,Friendly,Los Angeles,United States,TRUE
+1998-11-17,Guatemala,Honduras,3,3,Friendly,Los Angeles,United States,TRUE
 1998-11-18,Albania,Greece,0,0,UEFA Euro qualification,Tirana,Albania,FALSE
 1998-11-18,Brazil,Russia,5,1,Friendly,Fortaleza,Brazil,FALSE
 1998-11-18,Egypt,Norway,1,1,Friendly,Cairo,Egypt,FALSE
-1998-11-18,El Salvador,Honduras,1,2,Friendly,Los Angeles,USA,TRUE
+1998-11-18,El Salvador,Honduras,1,2,Friendly,Los Angeles,United States,TRUE
 1998-11-18,England,Czech Republic,2,0,Friendly,London,England,FALSE
 1998-11-18,Georgia,Estonia,3,1,Friendly,Tbilisi,Georgia,FALSE
 1998-11-18,Germany,Netherlands,1,1,Friendly,Gelsenkirchen,Germany,FALSE
-1998-11-18,Guatemala,Mexico,2,2,Friendly,Los Angeles,USA,TRUE
+1998-11-18,Guatemala,Mexico,2,2,Friendly,Los Angeles,United States,TRUE
 1998-11-18,Hungary,Switzerland,2,0,Friendly,Budapest,Hungary,FALSE
 1998-11-18,Italy,Spain,2,2,Friendly,Salerno,Italy,FALSE
 1998-11-18,Luxembourg,Belgium,0,0,Friendly,Luxembourg,Luxembourg,FALSE
@@ -22052,7 +22052,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-01-23,Senegal,Burkina Faso,1,1,African Cup of Nations qualification,Dakar,Senegal,FALSE
 1999-01-23,Zimbabwe,Malawi,3,0,Friendly,Bulawayo,Zimbabwe,FALSE
 1999-01-24,Angola,Gabon,3,1,African Cup of Nations qualification,Luanda,Angola,FALSE
-1999-01-24,Bolivia,USA,0,0,Friendly,Santa Cruz,Bolivia,FALSE
+1999-01-24,Bolivia,United States,0,0,Friendly,Santa Cruz,Bolivia,FALSE
 1999-01-24,Congo,Mali,0,0,African Cup of Nations qualification,Pointe-Noire,Congo,FALSE
 1999-01-24,DR Congo,Kenya,2,1,African Cup of Nations qualification,Kinshasa,DR Congo,FALSE
 1999-01-24,Ghana,Mozambique,1,0,African Cup of Nations qualification,Accra,Ghana,FALSE
@@ -22074,12 +22074,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-02-05,Cyprus,Finland,2,1,Cyprus International Tournament,Paralímni,Cyprus,FALSE
 1999-02-05,Greece,Belgium,1,0,Cyprus International Tournament,Larnaca,Cyprus,TRUE
 1999-02-06,Slovenia,Switzerland,0,2,Friendly,Muscat,Oman,TRUE
-1999-02-06,USA,Germany,3,0,Friendly,Jacksonville,USA,FALSE
+1999-02-06,United States,Germany,3,0,Friendly,Jacksonville,United States,FALSE
 1999-02-07,British Virgin Islands,Montserrat,3,0,CFU Caribbean Cup qualification,Road Town,British Virgin Islands,FALSE
 1999-02-07,Lesotho,Namibia,1,0,COSAFA Cup qualification,Maseru,Lesotho,FALSE
 1999-02-08,Oman,Slovenia,0,7,Friendly,Muscat,Oman,FALSE
 1999-02-09,Belgium,Czech Republic,0,1,Friendly,Brussels,Belgium,FALSE
-1999-02-09,Colombia,Germany,3,3,Friendly,Miami,USA,TRUE
+1999-02-09,Colombia,Germany,3,3,Friendly,Miami,United States,TRUE
 1999-02-09,Israel,Belarus,2,1,Friendly,Haifa,Israel,FALSE
 1999-02-10,Albania,North Macedonia,2,0,Friendly,Tirana,Albania,FALSE
 1999-02-10,Croatia,Denmark,0,1,Friendly,Split,Croatia,FALSE
@@ -22090,7 +22090,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-02-10,Italy,Norway,0,0,Friendly,Pisa,Italy,FALSE
 1999-02-10,Jamaica,Costa Rica,1,1,Friendly,Kingston,Jamaica,FALSE
 1999-02-10,Malta,Serbia,0,3,UEFA Euro qualification,Attard,Malta,FALSE
-1999-02-10,Mexico,Argentina,0,1,Friendly,Los Angeles,USA,TRUE
+1999-02-10,Mexico,Argentina,0,1,Friendly,Los Angeles,United States,TRUE
 1999-02-10,Oman,Switzerland,1,2,Friendly,Muscat,Oman,FALSE
 1999-02-10,Peru,Ecuador,1,2,Friendly,Lima,Peru,FALSE
 1999-02-10,Portugal,Netherlands,0,0,Friendly,Paris,France,TRUE
@@ -22104,17 +22104,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-02-20,Botswana,South Africa,1,2,COSAFA Cup qualification,Gaborone,Botswana,FALSE
 1999-02-20,Gabon,Burkina Faso,1,1,Friendly,Libreville,Gabon,FALSE
 1999-02-20,Zimbabwe,Zambia,1,1,Friendly,Bulawayo,Zimbabwe,FALSE
-1999-02-21,USA,Chile,2,1,Friendly,Fort Lauderdale,USA,FALSE
+1999-02-21,United States,Chile,2,1,Friendly,Fort Lauderdale,United States,FALSE
 1999-02-22,Suriname,Guyana,2,1,Friendly,Paramaribo,Suriname,FALSE
 1999-02-23,Thailand,North Korea,2,2,King's Cup,Bangkok,Thailand,FALSE
 1999-02-24,Bahamas,Turks and Caicos Islands,3,0,CFU Caribbean Cup qualification,Nassau,Bahamas,FALSE
 1999-02-24,Costa Rica,Jamaica,9,0,Friendly,San José,Costa Rica,FALSE
 1999-02-24,Israel,Latvia,2,0,Friendly,Jerusalem,Israel,FALSE
 1999-02-24,Saint Lucia,Grenada,1,2,Friendly,Castries,Saint Lucia,FALSE
-1999-02-26,USA Virgin Islands,Turks and Caicos Islands,2,2,CFU Caribbean Cup qualification,Nassau,Bahamas,TRUE
+1999-02-26,United States Virgin Islands,Turks and Caicos Islands,2,2,CFU Caribbean Cup qualification,Nassau,Bahamas,TRUE
 1999-02-27,South Africa,Gabon,4,1,African Cup of Nations qualification,Mabopane,South Africa,FALSE
 1999-02-28,Angola,Mauritius,0,2,African Cup of Nations qualification,Luanda,Angola,FALSE
-1999-02-28,Bahamas,USA Virgin Islands,0,0,CFU Caribbean Cup qualification,Nassau,Bahamas,FALSE
+1999-02-28,Bahamas,United States Virgin Islands,0,0,CFU Caribbean Cup qualification,Nassau,Bahamas,FALSE
 1999-02-28,British Virgin Islands,Antigua and Barbuda,0,2,Friendly,Road Town,British Virgin Islands,FALSE
 1999-02-28,Burundi,Burkina Faso,1,2,African Cup of Nations qualification,Bujumbura,Burundi,FALSE
 1999-02-28,Cameroon,Mozambique,1,0,African Cup of Nations qualification,Yaoundé,Cameroon,FALSE
@@ -22145,12 +22145,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-03-10,Malta,Moldova,0,2,Friendly,Attard,Malta,FALSE
 1999-03-10,Romania,Israel,0,2,Friendly,Bucharest,Romania,FALSE
 1999-03-10,Switzerland,Austria,2,4,Friendly,St. Gallen,Switzerland,FALSE
-1999-03-11,Mexico,Bolivia,2,1,USA Cup,Los Angeles,USA,TRUE
-1999-03-11,USA,Guatemala,3,1,USA Cup,Los Angeles,USA,FALSE
+1999-03-11,Mexico,Bolivia,2,1,USA Cup,Los Angeles,United States,TRUE
+1999-03-11,United States,Guatemala,3,1,USA Cup,Los Angeles,United States,FALSE
 1999-03-12,Barbados,Dominica,3,1,CFU Caribbean Cup qualification,Pointe-à-Pitre,Guadeloupe,TRUE
 1999-03-12,Guadeloupe,Antigua and Barbuda,2,1,CFU Caribbean Cup qualification,Pointe-à-Pitre,Guadeloupe,FALSE
-1999-03-13,Guatemala,Bolivia,2,1,USA Cup,San Diego,USA,TRUE
-1999-03-13,USA,Mexico,1,2,USA Cup,San Diego,USA,FALSE
+1999-03-13,Guatemala,Bolivia,2,1,USA Cup,San Diego,United States,TRUE
+1999-03-13,United States,Mexico,1,2,USA Cup,San Diego,United States,FALSE
 1999-03-14,Antigua and Barbuda,Dominica,1,1,CFU Caribbean Cup qualification,Pointe-à-Pitre,Guadeloupe,TRUE
 1999-03-14,Guadeloupe,Barbados,1,0,CFU Caribbean Cup qualification,Pointe-à-Pitre,Guadeloupe,FALSE
 1999-03-16,Cyprus,Estonia,1,2,Friendly,Larnaca,Cyprus,FALSE
@@ -22284,14 +22284,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-05-19,Russia,Belarus,1,1,Friendly,Tula,Russia,FALSE
 1999-05-19,Slovakia,Bulgaria,2,0,Friendly,Dubnica nad Váhom,Slovakia,FALSE
 1999-05-20,Norway,Jamaica,6,0,Friendly,Oslo,Norway,FALSE
-1999-05-21,Haiti,Honduras,0,2,Friendly,Miami,USA,TRUE
+1999-05-21,Haiti,Honduras,0,2,Friendly,Miami,United States,TRUE
 1999-05-22,Malawi,Namibia,1,1,COSAFA Cup qualification,Blantyre,Malawi,FALSE
 1999-05-22,Uganda,Zambia,0,1,Friendly,Kampala,Uganda,FALSE
 1999-05-27,Sweden,Jamaica,2,1,Friendly,Solna,Sweden,FALSE
 1999-05-28,Botswana,Mozambique,0,2,COSAFA Cup qualification,Gaborone,Botswana,FALSE
 1999-05-29,Canada,Guatemala,1,0,Friendly,Toronto,Canada,FALSE
 1999-05-29,Chile,Costa Rica,3,0,Friendly,Concepción,Chile,FALSE
-1999-05-29,El Salvador,Colombia,2,1,Friendly,East Rutherford,USA,TRUE
+1999-05-29,El Salvador,Colombia,2,1,Friendly,East Rutherford,United States,TRUE
 1999-05-29,Republic of Ireland,Northern Ireland,0,1,Friendly,Dublin,Republic of Ireland,FALSE
 1999-05-29,Saint Kitts and Nevis,Antigua and Barbuda,4,1,Friendly,Basseterre,Saint Kitts and Nevis,FALSE
 1999-05-30,Belgium,Peru,1,1,Kirin Cup,Kyoto,Japan,TRUE
@@ -22362,7 +22362,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-06-09,Hungary,Slovakia,0,1,UEFA Euro qualification,Győr,Hungary,FALSE
 1999-06-09,Republic of Ireland,North Macedonia,1,0,UEFA Euro qualification,Dublin,Republic of Ireland,FALSE
 1999-06-09,Luxembourg,Poland,2,3,UEFA Euro qualification,Luxembourg,Luxembourg,FALSE
-1999-06-09,Mexico,Argentina,2,2,Friendly,Chicago,USA,TRUE
+1999-06-09,Mexico,Argentina,2,2,Friendly,Chicago,United States,TRUE
 1999-06-09,Moldova,Finland,0,0,UEFA Euro qualification,Chișinău,Moldova,FALSE
 1999-06-09,Portugal,Liechtenstein,8,0,UEFA Euro qualification,Coimbra,Portugal,FALSE
 1999-06-09,Romania,Azerbaijan,4,0,UEFA Euro qualification,Bucharest,Romania,FALSE
@@ -22376,7 +22376,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-06-13,Croatia,Egypt,2,2,Korea Cup,Seoul,South Korea,TRUE
 1999-06-13,Kenya,Zanzibar,0,1,Friendly,Mombasa,Kenya,FALSE
 1999-06-13,Trinidad and Tobago,Cuba,2,1,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,FALSE
-1999-06-13,USA,Argentina,1,0,Friendly,Washington,USA,FALSE
+1999-06-13,United States,Argentina,1,0,Friendly,Washington,United States,FALSE
 1999-06-15,Venezuela,Ecuador,3,2,Friendly,San Cristóbal,Venezuela,FALSE
 1999-06-16,Brazil,Poland,2,0,Friendly,Bangkok,Thailand,TRUE
 1999-06-16,Croatia,Mexico,2,1,Korea Cup,Seoul,South Korea,TRUE
@@ -22469,7 +22469,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-07-06,Mexico,Venezuela,3,1,Copa América,Ciudad del Este,Paraguay,TRUE
 1999-07-07,Colombia,Ecuador,2,1,Copa América,Luque,Paraguay,TRUE
 1999-07-07,Uruguay,Argentina,0,2,Copa América,Luque,Paraguay,TRUE
-1999-07-09,Canada,Saudi Arabia,0,2,Friendly,Fullerton,USA,TRUE
+1999-07-09,Canada,Saudi Arabia,0,2,Friendly,Fullerton,United States,TRUE
 1999-07-10,Egypt,New Zealand,1,1,Friendly,Mexico City,Mexico,TRUE
 1999-07-10,Mexico,Peru,3,3,Copa América,Asunción,Paraguay,TRUE
 1999-07-10,Paraguay,Uruguay,1,1,Copa América,Asunción,Paraguay,FALSE
@@ -22477,21 +22477,21 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-07-11,Chile,Colombia,3,2,Copa América,Luque,Paraguay,TRUE
 1999-07-11,Uzbekistan,Malaysia,3,0,Friendly,Samarqand,Uzbekistan,FALSE
 1999-07-12,Micronesia,Northern Mariana Islands,7,0,Friendly,Colonia,Micronesia,FALSE
-1999-07-13,Jamaica,Saudi Arabia,2,1,Friendly,San Bernardino,USA,TRUE
+1999-07-13,Jamaica,Saudi Arabia,2,1,Friendly,San Bernardino,United States,TRUE
 1999-07-13,Uruguay,Chile,1,1,Copa América,Asunción,Paraguay,TRUE
 1999-07-14,Mexico,Brazil,0,2,Copa América,Ciudad del Este,Paraguay,TRUE
 1999-07-15,Egypt,New Zealand,1,0,Friendly,Guadalajara,Mexico,TRUE
-1999-07-15,Jamaica,Saudi Arabia,0,4,Friendly,Fullerton,USA,TRUE
+1999-07-15,Jamaica,Saudi Arabia,0,4,Friendly,Fullerton,United States,TRUE
 1999-07-16,Jordan,Syria,1,0,Friendly,Amman,Jordan,FALSE
 1999-07-17,Chile,Mexico,1,2,Copa América,Asunción,Paraguay,TRUE
-1999-07-17,Costa Rica,Saudi Arabia,1,0,Friendly,Fullerton,USA,TRUE
+1999-07-17,Costa Rica,Saudi Arabia,1,0,Friendly,Fullerton,United States,TRUE
 1999-07-18,Brazil,Uruguay,3,0,Copa América,Asunción,Paraguay,TRUE
 1999-07-18,Jordan,Syria,4,0,Friendly,Amman,Jordan,FALSE
 1999-07-18,Senegal,Eritrea,6,2,African Cup of Nations qualification,Dakar,Senegal,FALSE
 1999-07-18,Eswatini,Zimbabwe,1,1,COSAFA Cup,Lobamba,Eswatini,FALSE
 1999-07-21,Oman,Kenya,2,2,Friendly,Muscat,Oman,FALSE
 1999-07-24,Brazil,Germany,4,0,Confederations Cup,Guadalajara,Mexico,TRUE
-1999-07-24,New Zealand,USA,1,2,Confederations Cup,Guadalajara,Mexico,TRUE
+1999-07-24,New Zealand,United States,1,2,Confederations Cup,Guadalajara,Mexico,TRUE
 1999-07-24,Rwanda,Djibouti,4,1,CECAFA Cup,Kigali,Rwanda,FALSE
 1999-07-24,Thailand,Uzbekistan,1,0,Friendly,Bangkok,Thailand,FALSE
 1999-07-25,Bolivia,Egypt,2,2,Confederations Cup,Mexico City,Mexico,TRUE
@@ -22503,8 +22503,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-07-27,Ethiopia,Sudan,0,0,CECAFA Cup,Kigali,Rwanda,TRUE
 1999-07-27,Mexico,Egypt,2,2,Confederations Cup,Mexico City,Mexico,FALSE
 1999-07-27,Saudi Arabia,Bolivia,0,0,Confederations Cup,Mexico City,Mexico,TRUE
-1999-07-28,Brazil,USA,1,0,Confederations Cup,Guadalajara,Mexico,TRUE
-1999-07-28,El Salvador,Guatemala,0,2,Friendly,Los Angeles,USA,TRUE
+1999-07-28,Brazil,United States,1,0,Confederations Cup,Guadalajara,Mexico,TRUE
+1999-07-28,El Salvador,Guatemala,0,2,Friendly,Los Angeles,United States,TRUE
 1999-07-28,Germany,New Zealand,2,0,Confederations Cup,Guadalajara,Mexico,TRUE
 1999-07-28,Kenya,Eritrea,1,0,CECAFA Cup,Kigali,Rwanda,TRUE
 1999-07-28,Rwanda,Tanzania,0,0,CECAFA Cup,Kigali,Rwanda,FALSE
@@ -22513,17 +22513,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-07-29,Somalia,Uganda,0,2,CECAFA Cup,Kigali,Rwanda,TRUE
 1999-07-29,Sudan,Zanzibar,1,1,CECAFA Cup,Kigali,Rwanda,TRUE
 1999-07-30,New Zealand,Brazil,0,2,Confederations Cup,Guadalajara,Mexico,TRUE
-1999-07-30,USA,Germany,2,0,Confederations Cup,Guadalajara,Mexico,TRUE
+1999-07-30,United States,Germany,2,0,Confederations Cup,Guadalajara,Mexico,TRUE
 1999-07-31,Burundi,Tanzania,1,0,CECAFA Cup,Kigali,Rwanda,TRUE
 1999-07-31,Namibia,South Africa,1,1,COSAFA Cup,Windhoek,Namibia,FALSE
 1999-07-31,Rwanda,Uganda,1,0,CECAFA Cup,Kigali,Rwanda,FALSE
 1999-08-01,Brazil,Saudi Arabia,8,2,Confederations Cup,Guadalajara,Mexico,TRUE
 1999-08-01,Kenya,Sudan,3,0,CECAFA Cup,Kigali,Rwanda,TRUE
-1999-08-01,Mexico,USA,1,0,Confederations Cup,Mexico City,Mexico,FALSE
+1999-08-01,Mexico,United States,1,0,Confederations Cup,Mexico City,Mexico,FALSE
 1999-08-03,Oman,Kyrgyzstan,3,0,AFC Asian Cup qualification,Dushanbe,Tajikistan,TRUE
 1999-08-03,Rwanda,Kenya,0,0,Friendly,Kigali,Rwanda,FALSE
 1999-08-03,Tajikistan,Iraq,1,2,AFC Asian Cup qualification,Dushanbe,Tajikistan,FALSE
-1999-08-03,USA,Saudi Arabia,2,0,Confederations Cup,Guadalajara,Mexico,TRUE
+1999-08-03,United States,Saudi Arabia,2,0,Confederations Cup,Guadalajara,Mexico,TRUE
 1999-08-04,Mexico,Brazil,4,3,Confederations Cup,Mexico City,Mexico,FALSE
 1999-08-05,Iraq,Oman,2,0,AFC Asian Cup qualification,Dushanbe,Tajikistan,TRUE
 1999-08-05,Tajikistan,Kyrgyzstan,3,2,AFC Asian Cup qualification,Dushanbe,Tajikistan,FALSE
@@ -22601,7 +22601,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-09-08,Iceland,Ukraine,0,1,UEFA Euro qualification,Reykjavík,Iceland,FALSE
 1999-09-08,Israel,San Marino,8,0,UEFA Euro qualification,Ramat-Gan,Israel,FALSE
 1999-09-08,Italy,Denmark,2,3,UEFA Euro qualification,Naples,Italy,FALSE
-1999-09-08,Jamaica,USA,2,2,Friendly,Kingston,Jamaica,FALSE
+1999-09-08,Jamaica,United States,2,2,Friendly,Kingston,Jamaica,FALSE
 1999-09-08,Japan,Iran,1,1,Friendly,Yokohama,Japan,FALSE
 1999-09-08,Luxembourg,Sweden,0,1,UEFA Euro qualification,Luxembourg,Luxembourg,FALSE
 1999-09-08,North Macedonia,Serbia,2,4,UEFA Euro qualification,Skopje,North Macedonia,FALSE
@@ -22613,7 +22613,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-09-08,Slovakia,Liechtenstein,2,0,UEFA Euro qualification,Dubnica nad Váhom,Slovakia,FALSE
 1999-09-08,Spain,Cyprus,8,0,UEFA Euro qualification,Badajoz,Spain,FALSE
 1999-09-08,Switzerland,Belarus,2,0,UEFA Euro qualification,Lausanne,Switzerland,FALSE
-1999-09-08,Trinidad and Tobago,Colombia,4,3,Friendly,Miami,USA,TRUE
+1999-09-08,Trinidad and Tobago,Colombia,4,3,Friendly,Miami,United States,TRUE
 1999-09-08,Uruguay,Venezuela,2,0,Friendly,Montevideo,Uruguay,FALSE
 1999-09-08,Zambia,Saudi Arabia,0,0,Friendly,Harare,Zimbabwe,TRUE
 1999-09-09,Bermuda,Cayman Islands,3,1,Friendly,Hamilton,Bermuda,FALSE
@@ -22627,11 +22627,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-09-30,Saudi Arabia,South Africa,0,0,Friendly,Riyadh,Saudi Arabia,FALSE
 1999-10-02,Namibia,Angola,1,1,COSAFA Cup,Windhoek,Namibia,FALSE
 1999-10-05,Scotland,Bosnia and Herzegovina,1,0,UEFA Euro qualification,Glasgow,Scotland,FALSE
-1999-10-06,Canada,Cuba,0,0,Gold Cup qualification,Los Angeles,USA,TRUE
-1999-10-06,El Salvador,Haiti,1,1,Gold Cup qualification,Los Angeles,USA,TRUE
+1999-10-06,Canada,Cuba,0,0,Gold Cup qualification,Los Angeles,United States,TRUE
+1999-10-06,El Salvador,Haiti,1,1,Gold Cup qualification,Los Angeles,United States,TRUE
 1999-10-06,Greece,Albania,2,0,UEFA Euro qualification,Athens,Greece,FALSE
-1999-10-08,Canada,El Salvador,2,1,Gold Cup qualification,Los Angeles,USA,TRUE
-1999-10-08,Cuba,Haiti,0,1,Gold Cup qualification,Los Angeles,USA,TRUE
+1999-10-08,Canada,El Salvador,2,1,Gold Cup qualification,Los Angeles,United States,TRUE
+1999-10-08,Cuba,Haiti,0,1,Gold Cup qualification,Los Angeles,United States,TRUE
 1999-10-09,Albania,Georgia,2,1,UEFA Euro qualification,Tirana,Albania,FALSE
 1999-10-09,Andorra,Armenia,0,3,UEFA Euro qualification,Sant Julià de Lòria,Andorra,FALSE
 1999-10-09,Azerbaijan,Slovakia,0,1,UEFA Euro qualification,Baku,Azerbaijan,FALSE
@@ -22654,8 +22654,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-10-09,Wales,Switzerland,0,2,UEFA Euro qualification,Wrexham,Wales,FALSE
 1999-10-10,Austria,Cyprus,3,1,UEFA Euro qualification,Vienna,Austria,FALSE
 1999-10-10,Bulgaria,Luxembourg,3,0,UEFA Euro qualification,Sofia,Bulgaria,FALSE
-1999-10-10,Canada,Haiti,2,1,Gold Cup qualification,Los Angeles,USA,TRUE
-1999-10-10,Cuba,El Salvador,3,1,Gold Cup qualification,Los Angeles,USA,TRUE
+1999-10-10,Canada,Haiti,2,1,Gold Cup qualification,Los Angeles,United States,TRUE
+1999-10-10,Cuba,El Salvador,3,1,Gold Cup qualification,Los Angeles,United States,TRUE
 1999-10-10,Denmark,Iran,0,0,Friendly,Copenhagen,Denmark,FALSE
 1999-10-10,England,Belgium,2,1,Friendly,Sunderland,England,FALSE
 1999-10-10,Spain,Israel,3,0,UEFA Euro qualification,Albacete,Spain,FALSE
@@ -22663,14 +22663,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-10-12,Panama,Trinidad and Tobago,2,2,Friendly,Panama City,Panama,FALSE
 1999-10-12,Uruguay,Ecuador,0,0,Friendly,Montevideo,Uruguay,FALSE
 1999-10-13,Argentina,Colombia,2,1,Friendly,Córdoba,Argentina,FALSE
-1999-10-13,Mexico,Paraguay,0,1,Friendly,Chicago,USA,TRUE
+1999-10-13,Mexico,Paraguay,0,1,Friendly,Chicago,United States,TRUE
 1999-10-15,Guatemala,Paraguay,0,0,Friendly,Guatemala,Guatemala,FALSE
 1999-10-16,Tunisia,United Arab Emirates,1,0,Friendly,Tunis,Tunisia,FALSE
 1999-10-18,Hong Kong,Cambodia,4,1,AFC Asian Cup qualification,Victoria,Hong Kong,FALSE
-1999-10-20,Mexico,Colombia,0,0,Friendly,San Diego,USA,TRUE
+1999-10-20,Mexico,Colombia,0,0,Friendly,San Diego,United States,TRUE
 1999-10-24,Cayman Islands,Jamaica,1,4,Friendly,George Town,Cayman Islands,FALSE
 1999-10-24,Hong Kong,Indonesia,1,1,AFC Asian Cup qualification,Victoria,Hong Kong,FALSE
-1999-10-27,Mexico,Ecuador,0,0,Friendly,Houston,USA,TRUE
+1999-10-27,Mexico,Ecuador,0,0,Friendly,Houston,United States,TRUE
 1999-10-30,Cambodia,Indonesia,1,5,AFC Asian Cup qualification,Phnom Penh,Cambodia,FALSE
 1999-10-30,DR Congo,Congo,1,1,Friendly,Kinshasa,DR Congo,FALSE
 1999-10-30,Iraq,Estonia,1,1,United Arab Emirates Friendship Tournament,Abu Dhabi,United Arab Emirates,TRUE
@@ -22718,7 +22718,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 1999-11-17,England,Scotland,0,1,UEFA Euro qualification,London,England,FALSE
 1999-11-17,Greece,Bulgaria,1,0,Friendly,Kozáni,Greece,FALSE
 1999-11-17,Honduras,Trinidad and Tobago,3,2,Friendly,San Pedro Sula,Honduras,FALSE
-1999-11-17,Morocco,USA,2,1,Friendly,Marrakech,Morocco,FALSE
+1999-11-17,Morocco,United States,2,1,Friendly,Marrakech,Morocco,FALSE
 1999-11-17,Peru,Slovakia,2,1,Friendly,Lima,Peru,FALSE
 1999-11-17,Spain,Argentina,0,2,Friendly,Seville,Spain,FALSE
 1999-11-17,Turkey,Republic of Ireland,0,0,UEFA Euro qualification,Bursa,Turkey,FALSE
@@ -22779,15 +22779,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-01-07,Tunisia,Togo,7,0,Friendly,Tunis,Tunisia,FALSE
 2000-01-08,Trinidad and Tobago,Canada,0,0,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 2000-01-09,Burkina Faso,Gabon,1,1,Friendly,Ouagadougou,Burkina Faso,FALSE
-2000-01-09,Guatemala,Armenia,1,1,Friendly,Los Angeles,USA,TRUE
+2000-01-09,Guatemala,Armenia,1,1,Friendly,Los Angeles,United States,TRUE
 2000-01-09,Ivory Coast,Egypt,2,0,Friendly,Abidjan,Ivory Coast,FALSE
-2000-01-09,Mexico,Iran,2,1,Friendly,Oakland,USA,TRUE
+2000-01-09,Mexico,Iran,2,1,Friendly,Oakland,United States,TRUE
 2000-01-11,Bermuda,Canada,0,2,Friendly,Hamilton,Bermuda,FALSE
 2000-01-11,Burkina Faso,Cameroon,2,2,Friendly,Ouagadougou,Burkina Faso,FALSE
 2000-01-13,Senegal,Cameroon,0,0,Friendly,Dakar,Senegal,FALSE
 2000-01-14,China PR,New Zealand,1,0,Friendly,Guangzhou,China PR,FALSE
 2000-01-16,Jamaica,New Zealand,2,1,Friendly,Guangzhou,China PR,TRUE
-2000-01-16,USA,Iran,1,1,Friendly,Pasadena,USA,FALSE
+2000-01-16,United States,Iran,1,1,Friendly,Pasadena,United States,FALSE
 2000-01-18,Ghana,Tunisia,2,0,Friendly,Accra,Ghana,FALSE
 2000-01-18,Morocco,Trinidad and Tobago,1,0,Friendly,El Jadida,Morocco,FALSE
 2000-01-19,Panama,Guatemala,2,0,Friendly,Panama City,Panama,FALSE
@@ -22818,14 +22818,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-01-28,Cameroon,Ivory Coast,3,0,African Cup of Nations,Accra,Ghana,TRUE
 2000-01-28,Egypt,Senegal,1,0,African Cup of Nations,Kano,Nigeria,TRUE
 2000-01-28,Nigeria,Congo,0,0,African Cup of Nations,Lagos,Nigeria,FALSE
-2000-01-28,USA Virgin Islands,Saint Lucia,0,9,Friendly,Saint Croix,USA Virgin Islands,FALSE
+2000-01-28,United States Virgin Islands,Saint Lucia,0,9,Friendly,Saint Croix,United States Virgin Islands,FALSE
 2000-01-29,Algeria,Gabon,3,1,African Cup of Nations,Kumasi,Ghana,TRUE
-2000-01-29,Chile,USA,1,2,Friendly,Coquimbo,Chile,FALSE
+2000-01-29,Chile,United States,1,2,Friendly,Coquimbo,Chile,FALSE
 2000-01-29,Philippines,Guam,2,0,AFC Asian Cup qualification,Hanoi,Vietnam,TRUE
 2000-01-29,Tunisia,Morocco,0,0,African Cup of Nations,Lagos,Nigeria,TRUE
 2000-01-29,Vietnam,China PR,0,2,AFC Asian Cup qualification,Hanoi,Vietnam,FALSE
 2000-01-29,Zambia,Burkina Faso,1,1,African Cup of Nations,Kano,Nigeria,TRUE
-2000-01-30,USA Virgin Islands,Saint Lucia,0,2,Friendly,Saint Croix,USA Virgin Islands,FALSE
+2000-01-30,United States Virgin Islands,Saint Lucia,0,2,Friendly,Saint Croix,United States Virgin Islands,FALSE
 2000-01-31,Cameroon,Togo,0,1,African Cup of Nations,Kumasi,Ghana,TRUE
 2000-01-31,Faroe Islands,Finland,0,1,Nordic Championship,Cartagena,Spain,TRUE
 2000-01-31,Ghana,Ivory Coast,0,2,African Cup of Nations,Accra,Ghana,FALSE
@@ -22880,56 +22880,56 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-02-10,Nigeria,South Africa,2,0,African Cup of Nations,Lagos,Nigeria,FALSE
 2000-02-12,Australia,Slovakia,0,0,Friendly,Valparaíso,Chile,TRUE
 2000-02-12,Chile,Bulgaria,3,2,Friendly,Valparaíso,Chile,FALSE
-2000-02-12,Colombia,Jamaica,1,0,Gold Cup,Miami,USA,TRUE
+2000-02-12,Colombia,Jamaica,1,0,Gold Cup,Miami,United States,TRUE
 2000-02-12,Nepal,Bhutan,3,0,AFC Asian Cup qualification,Kuwait City,Kuwait,TRUE
 2000-02-12,South Africa,Tunisia,2,2,African Cup of Nations,Accra,Ghana,TRUE
-2000-02-12,USA,Haiti,3,0,Gold Cup,Miami,USA,FALSE
+2000-02-12,United States,Haiti,3,0,Gold Cup,Miami,United States,FALSE
 2000-02-12,Yemen,Turkmenistan,0,1,AFC Asian Cup qualification,Kuwait City,Kuwait,TRUE
-2000-02-13,Costa Rica,Canada,2,2,Gold Cup,San Diego,USA,TRUE
+2000-02-13,Costa Rica,Canada,2,2,Gold Cup,San Diego,United States,TRUE
 2000-02-13,Dominican Republic,British Virgin Islands,1,0,Friendly,Santo Domingo,Dominican Republic,FALSE
 2000-02-13,Macau,Brunei,1,0,AFC Asian Cup qualification,Macau,Macau,FALSE
-2000-02-13,Mexico,Trinidad and Tobago,4,0,Gold Cup,San Diego,USA,TRUE
+2000-02-13,Mexico,Trinidad and Tobago,4,0,Gold Cup,San Diego,United States,TRUE
 2000-02-13,Nigeria,Cameroon,2,2,African Cup of Nations,Lagos,Nigeria,FALSE
 2000-02-13,Singapore,Japan,0,3,AFC Asian Cup qualification,Macau,Macau,TRUE
 2000-02-13,Syria,North Korea,0,0,Friendly,Damascus,Syria,FALSE
-2000-02-14,Haiti,Peru,1,1,Gold Cup,Miami,USA,TRUE
-2000-02-14,Jamaica,Honduras,0,2,Gold Cup,Miami,USA,TRUE
+2000-02-14,Haiti,Peru,1,1,Gold Cup,Miami,United States,TRUE
+2000-02-14,Jamaica,Honduras,0,2,Gold Cup,Miami,United States,TRUE
 2000-02-14,Kuwait,Bhutan,20,0,AFC Asian Cup qualification,Kuwait City,Kuwait,FALSE
 2000-02-14,Turkmenistan,Nepal,5,0,AFC Asian Cup qualification,Kuwait City,Kuwait,TRUE
 2000-02-15,Australia,Bulgaria,1,1,Friendly,Valparaíso,Chile,TRUE
-2000-02-15,Canada,South Korea,0,0,Gold Cup,Los Angeles,USA,TRUE
+2000-02-15,Canada,South Korea,0,0,Gold Cup,Los Angeles,United States,TRUE
 2000-02-15,Chile,Slovakia,0,2,Friendly,Valparaíso,Chile,FALSE
 2000-02-15,Malaysia,Maldives,2,0,Friendly,Kuala Lumpur,Malaysia,FALSE
-2000-02-15,Trinidad and Tobago,Guatemala,4,2,Gold Cup,Los Angeles,USA,TRUE
+2000-02-15,Trinidad and Tobago,Guatemala,4,2,Gold Cup,Los Angeles,United States,TRUE
 2000-02-16,Bhutan,Turkmenistan,0,8,AFC Asian Cup qualification,Kuwait City,Kuwait,TRUE
-2000-02-16,Honduras,Colombia,2,0,Gold Cup,Miami,USA,TRUE
+2000-02-16,Honduras,Colombia,2,0,Gold Cup,Miami,United States,TRUE
 2000-02-16,Japan,Brunei,9,0,AFC Asian Cup qualification,Macau,Macau,TRUE
 2000-02-16,Kuwait,Yemen,2,0,AFC Asian Cup qualification,Kuwait City,Kuwait,FALSE
 2000-02-16,Lebanon,North Korea,1,0,Friendly,Beirut,Lebanon,FALSE
 2000-02-16,Macau,Singapore,0,1,AFC Asian Cup qualification,Macau,Macau,FALSE
 2000-02-16,Panama,El Salvador,4,1,Friendly,Panama City,Panama,FALSE
-2000-02-16,USA,Peru,1,0,Gold Cup,Miami,USA,FALSE
+2000-02-16,United States,Peru,1,0,Gold Cup,Miami,United States,FALSE
 2000-02-17,Barbados,Saint Kitts and Nevis,1,0,Friendly,Bridgetown,Barbados,FALSE
-2000-02-17,South Korea,Costa Rica,2,2,Gold Cup,Los Angeles,USA,TRUE
+2000-02-17,South Korea,Costa Rica,2,2,Gold Cup,Los Angeles,United States,TRUE
 2000-02-17,Malaysia,Maldives,3,0,Friendly,Kuala Lumpur,Malaysia,FALSE
-2000-02-17,Mexico,Guatemala,1,1,Gold Cup,Los Angeles,USA,TRUE
+2000-02-17,Mexico,Guatemala,1,1,Gold Cup,Los Angeles,United States,TRUE
 2000-02-18,Kuwait,Nepal,5,0,AFC Asian Cup qualification,Kuwait City,Kuwait,FALSE
 2000-02-18,Yemen,Bhutan,11,2,AFC Asian Cup qualification,Kuwait City,Kuwait,TRUE
 2000-02-19,Dominica,Antigua and Barbuda,2,0,Friendly,Roseau,Dominica,FALSE
-2000-02-19,Honduras,Peru,3,5,Gold Cup,Miami,USA,TRUE
+2000-02-19,Honduras,Peru,3,5,Gold Cup,Miami,United States,TRUE
 2000-02-19,Oman,Switzerland,1,4,Friendly,Muscat,Oman,FALSE
 2000-02-19,United Arab Emirates,Slovenia,1,1,Friendly,Muscat,Oman,TRUE
-2000-02-19,USA,Colombia,2,2,Gold Cup,Miami,USA,FALSE
-2000-02-20,Costa Rica,Trinidad and Tobago,1,2,Gold Cup,San Diego,USA,TRUE
+2000-02-19,United States,Colombia,2,2,Gold Cup,Miami,United States,FALSE
+2000-02-20,Costa Rica,Trinidad and Tobago,1,2,Gold Cup,San Diego,United States,TRUE
 2000-02-20,Lesotho,Eswatini,1,0,Friendly,Maseru,Lesotho,FALSE
 2000-02-20,Macau,Japan,0,3,AFC Asian Cup qualification,Macau,Macau,FALSE
-2000-02-20,Mexico,Canada,1,2,Gold Cup,San Diego,USA,TRUE
+2000-02-20,Mexico,Canada,1,2,Gold Cup,San Diego,United States,TRUE
 2000-02-20,Singapore,Brunei,1,0,AFC Asian Cup qualification,Macau,Macau,TRUE
 2000-02-20,Thailand,Finland,0,0,King's Cup,Bangkok,Thailand,FALSE
 2000-02-20,Kernow,Guernsey,1,2,Friendly,Cornwall,England,FALSE
 2000-02-21,Oman,United Arab Emirates,0,1,Friendly,Muscat,Oman,FALSE
 2000-02-23,Belgium,Portugal,1,1,Friendly,Charleroi,Belgium,FALSE
-2000-02-23,Colombia,Peru,2,1,Gold Cup,San Diego,USA,TRUE
+2000-02-23,Colombia,Peru,2,1,Gold Cup,San Diego,United States,TRUE
 2000-02-23,Croatia,Spain,0,0,Friendly,Split,Croatia,FALSE
 2000-02-23,England,Argentina,0,0,Friendly,London,England,FALSE
 2000-02-23,Estonia,Finland,2,4,King's Cup,Bangkok,Thailand,TRUE
@@ -22948,12 +22948,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-02-23,Thailand,Brazil,0,7,King's Cup,Bangkok,Thailand,FALSE
 2000-02-23,Turkey,Norway,0,2,Friendly,Istanbul,Turkey,FALSE
 2000-02-23,United Arab Emirates,Switzerland,1,0,Friendly,Muscat,Oman,TRUE
-2000-02-24,Trinidad and Tobago,Canada,0,1,Gold Cup,Los Angeles,USA,TRUE
+2000-02-24,Trinidad and Tobago,Canada,0,1,Gold Cup,Los Angeles,United States,TRUE
 2000-02-25,British Virgin Islands,Anguilla,3,4,Friendly,Road Town,British Virgin Islands,FALSE
 2000-02-25,Thailand,Estonia,2,1,King's Cup,Bangkok,Thailand,FALSE
 2000-02-27,Botswana,Lesotho,1,0,Friendly,Gaborone,Botswana,FALSE
 2000-02-27,British Virgin Islands,Anguilla,5,0,Friendly,Road Town,British Virgin Islands,FALSE
-2000-02-27,Canada,Colombia,2,0,Gold Cup,Los Angeles,USA,TRUE
+2000-02-27,Canada,Colombia,2,0,Gold Cup,Los Angeles,United States,TRUE
 2000-02-27,Thailand,Finland,5,1,King's Cup,Bangkok,Thailand,FALSE
 2000-02-29,Barbados,Antigua and Barbuda,2,2,Friendly,Bridgetown,Barbados,FALSE
 2000-02-29,El Salvador,Panama,3,1,Friendly,San Salvador,El Salvador,FALSE
@@ -22970,7 +22970,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-03-05,El Salvador,Belize,5,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2000-03-05,Ethiopia,Sudan,1,0,Friendly,Addis Ababa,Ethiopia,FALSE
 2000-03-05,Saint Lucia,Suriname,1,0,FIFA World Cup qualification,Castries,Saint Lucia,FALSE
-2000-03-05,Saint Vincent and the Grenadines,USA Virgin Islands,9,0,FIFA World Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
+2000-03-05,Saint Vincent and the Grenadines,United States Virgin Islands,9,0,FIFA World Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
 2000-03-05,Zimbabwe,Lesotho,2,1,COSAFA Cup,Harare,Zimbabwe,FALSE
 2000-03-06,Syria,Jordan,0,0,Friendly,Damascus,Syria,FALSE
 2000-03-08,Ecuador,Honduras,1,3,Friendly,Quito,Ecuador,FALSE
@@ -22980,7 +22980,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-03-11,Aruba,Puerto Rico,4,2,FIFA World Cup qualification,Oranjestad,Aruba,FALSE
 2000-03-11,Haiti,Dominica,4,0,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
 2000-03-11,Jordan,Bosnia and Herzegovina,0,0,Friendly,Zarqa,Jordan,FALSE
-2000-03-12,USA,Tunisia,1,1,Friendly,Birmingham,USA,FALSE
+2000-03-12,United States,Tunisia,1,1,Friendly,Birmingham,United States,FALSE
 2000-03-12,Zambia,Malawi,1,1,Friendly,Kitwe,Zambia,FALSE
 2000-03-13,Jordan,Syria,0,0,Friendly,Amman,Jordan,FALSE
 2000-03-13,Zambia,Malawi,0,1,Friendly,Lusaka,Zambia,FALSE
@@ -23001,7 +23001,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-03-19,Montserrat,Dominican Republic,1,3,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,TRUE
 2000-03-19,Nicaragua,Panama,0,2,FIFA World Cup qualification,Diriamba,Nicaragua,FALSE
 2000-03-19,Suriname,Saint Lucia,1,0,FIFA World Cup qualification,Paramaribo,Suriname,FALSE
-2000-03-19,USA Virgin Islands,Saint Vincent and the Grenadines,1,5,FIFA World Cup qualification,Frederiksted,USA Virgin Islands,FALSE
+2000-03-19,United States Virgin Islands,Saint Vincent and the Grenadines,1,5,FIFA World Cup qualification,Frederiksted,United States Virgin Islands,FALSE
 2000-03-20,Bahrain,Kazakhstan,0,1,Friendly,Manama,Bahrain,FALSE
 2000-03-21,Namibia,Zimbabwe,2,1,Friendly,Windhoek,Namibia,FALSE
 2000-03-21,Saint Kitts and Nevis,Turks and Caicos Islands,6,0,FIFA World Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
@@ -23180,7 +23180,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-04-26,Paraguay,Uruguay,1,0,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 2000-04-26,Poland,Finland,0,0,Friendly,Poznań,Poland,FALSE
 2000-04-26,Romania,Cyprus,2,0,Friendly,Constanţa,Romania,FALSE
-2000-04-26,Russia,USA,2,0,Friendly,Moscow,Russia,FALSE
+2000-04-26,Russia,United States,2,0,Friendly,Moscow,Russia,FALSE
 2000-04-26,San Marino,Moldova,0,1,Friendly,Serravalle,San Marino,FALSE
 2000-04-26,Venezuela,Argentina,0,4,FIFA World Cup qualification,Maracaibo,Venezuela,FALSE
 2000-04-29,Antigua and Barbuda,Dominica,3,2,Friendly,Road Town,British Virgin Islands,TRUE
@@ -23241,7 +23241,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-05-27,Cuba,Haiti,0,1,Friendly,Havana,Cuba,FALSE
 2000-05-27,England,Brazil,1,1,Friendly,London,England,FALSE
 2000-05-27,Iraq,Kyrgyzstan,4,0,WAFF Championship,Amman,Jordan,TRUE
-2000-05-27,Jamaica,Colombia,0,3,Friendly,East Rutherford,USA,TRUE
+2000-05-27,Jamaica,Colombia,0,3,Friendly,East Rutherford,United States,TRUE
 2000-05-27,Jordan,Lebanon,0,0,WAFF Championship,Amman,Jordan,FALSE
 2000-05-27,Netherlands,Romania,2,1,Friendly,Amsterdam,Netherlands,FALSE
 2000-05-27,Norway,Slovakia,2,0,Friendly,Oslo,Norway,FALSE
@@ -23282,7 +23282,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-06-03,Slovenia,Saudi Arabia,2,0,Friendly,Ljubljana,Slovenia,FALSE
 2000-06-03,Sweden,Spain,1,1,Friendly,Gothenburg,Sweden,FALSE
 2000-06-03,Uruguay,Chile,2,1,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2000-06-03,USA,South Africa,4,0,USA Cup,Washington,USA,FALSE
+2000-06-03,United States,South Africa,4,0,USA Cup,Washington,United States,FALSE
 2000-06-04,Argentina,Bolivia,1,0,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
 2000-06-04,Azerbaijan,Georgia,0,0,Friendly,Baku,Azerbaijan,FALSE
 2000-06-04,Benin,Togo,1,2,Friendly,Cotonou,Benin,FALSE
@@ -23291,7 +23291,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-06-04,Cuba,Canada,0,1,FIFA World Cup qualification,Havana,Cuba,FALSE
 2000-06-04,Estonia,Belarus,2,0,Friendly,Tallinn,Estonia,FALSE
 2000-06-04,France,Japan,2,2,King Hassan II Tournament,Casablanca,Morocco,TRUE
-2000-06-04,Mexico,Republic of Ireland,2,2,USA Cup,Chicago,USA,TRUE
+2000-06-04,Mexico,Republic of Ireland,2,2,USA Cup,Chicago,United States,TRUE
 2000-06-04,Moldova,Russia,0,1,Friendly,Chișinău,Moldova,FALSE
 2000-06-04,Morocco,Jamaica,1,0,King Hassan II Tournament,Casablanca,Morocco,FALSE
 2000-06-04,Netherlands,Poland,3,1,Friendly,Lausanne,Switzerland,TRUE
@@ -23303,12 +23303,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-06-06,Morocco,France,1,5,King Hassan II Tournament,Casablanca,Morocco,FALSE
 2000-06-06,Nigeria,Malawi,4,1,Friendly,Port Harcourt,Nigeria,FALSE
 2000-06-06,Senegal,Zambia,0,0,Friendly,Dakar,Senegal,FALSE
-2000-06-06,USA,Republic of Ireland,1,1,USA Cup,Foxborough,USA,FALSE
+2000-06-06,United States,Republic of Ireland,1,1,USA Cup,Foxborough,United States,FALSE
 2000-06-07,Germany,Liechtenstein,8,2,Friendly,Freiburg,Germany,FALSE
 2000-06-07,Iran,Egypt,1,1,Friendly,Tehran,Iran,FALSE
 2000-06-07,South Korea,North Macedonia,2,1,Friendly,Tehran,Iran,TRUE
 2000-06-07,Luxembourg,Spain,0,1,Friendly,Luxembourg,Luxembourg,FALSE
-2000-06-07,Mexico,South Africa,4,2,USA Cup,Dallas,USA,TRUE
+2000-06-07,Mexico,South Africa,4,2,USA Cup,Dallas,United States,TRUE
 2000-06-08,Tonga,Cook Islands,1,2,Oceania Nations Cup qualification,Papeete,French Polynesia,TRUE
 2000-06-09,Australia,Paraguay,0,0,Friendly,Sydney,Australia,FALSE
 2000-06-09,Egypt,South Korea,0,1,Friendly,Tehran,Iran,TRUE
@@ -23320,13 +23320,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-06-11,Canada,Cuba,0,0,FIFA World Cup qualification,Winnipeg,Canada,FALSE
 2000-06-11,Estonia,Georgia,1,0,Friendly,Tallinn,Estonia,FALSE
 2000-06-11,France,Denmark,3,0,UEFA Euro,Bruges,Belgium,TRUE
-2000-06-11,Republic of Ireland,South Africa,2,1,USA Cup,East Rutherford,USA,TRUE
+2000-06-11,Republic of Ireland,South Africa,2,1,USA Cup,East Rutherford,United States,TRUE
 2000-06-11,Japan,Slovakia,1,1,Kirin Cup,Rifu,Japan,FALSE
 2000-06-11,Lesotho,Zambia,0,0,COSAFA Cup,Maseru,Lesotho,FALSE
 2000-06-11,Netherlands,Czech Republic,1,0,UEFA Euro,Amsterdam,Netherlands,FALSE
 2000-06-11,Tunisia,Senegal,4,1,Friendly,Tunis,Tunisia,FALSE
 2000-06-11,Turkey,Italy,1,2,UEFA Euro,Arnhem,Netherlands,TRUE
-2000-06-11,USA,Mexico,3,0,USA Cup,East Rutherford,USA,FALSE
+2000-06-11,United States,Mexico,3,0,USA Cup,East Rutherford,United States,FALSE
 2000-06-12,Australia,Paraguay,0,0,Friendly,Brisbane,Australia,FALSE
 2000-06-12,Germany,Romania,1,1,UEFA Euro,Liège,Belgium,TRUE
 2000-06-12,New Caledonia,Vanuatu,3,1,Friendly,Nouméa,New Caledonia,FALSE
@@ -23403,7 +23403,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-06-30,Djibouti,Burundi,1,3,African Cup of Nations qualification,Djibouti,Djibouti,FALSE
 2000-07-01,Botswana,Madagascar,1,0,African Cup of Nations qualification,Gaborone,Botswana,FALSE
 2000-07-01,Costa Rica,Panama,5,1,Friendly,Alajuela,Costa Rica,FALSE
-2000-07-01,El Salvador,Mexico,0,3,Friendly,San Francisco,USA,TRUE
+2000-07-01,El Salvador,Mexico,0,3,Friendly,San Francisco,United States,TRUE
 2000-07-01,Seychelles,Zimbabwe,0,1,African Cup of Nations qualification,Victoria,Seychelles,FALSE
 2000-07-01,Tanzania,Mauritius,0,1,African Cup of Nations qualification,Dar es Salaam,Tanzania,FALSE
 2000-07-01,Uganda,Malawi,3,1,African Cup of Nations qualification,Kampala,Uganda,FALSE
@@ -23426,7 +23426,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-07-05,Mexico,Venezuela,2,1,Friendly,Monterrey,Mexico,FALSE
 2000-07-06,Cape Verde,Angola,1,1,Friendly,Praia,Cape Verde,FALSE
 2000-07-06,Malawi,Namibia,1,2,Friendly,Lilongwe,Malawi,FALSE
-2000-07-07,El Salvador,Guatemala,0,1,Friendly,Los Angeles,USA,TRUE
+2000-07-07,El Salvador,Guatemala,0,1,Friendly,Los Angeles,United States,TRUE
 2000-07-08,Trinidad and Tobago,Jamaica,2,4,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 2000-07-08,Tunisia,Madagascar,1,0,FIFA World Cup qualification,Tunis,Tunisia,FALSE
 2000-07-08,Zambia,Togo,2,0,FIFA World Cup qualification,Lusaka,Zambia,FALSE
@@ -23451,7 +23451,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-07-16,Canada,Trinidad and Tobago,0,2,FIFA World Cup qualification,Edmonton,Canada,FALSE
 2000-07-16,DR Congo,Central African Republic,2,0,African Cup of Nations qualification,Kinshasa,DR Congo,FALSE
 2000-07-16,El Salvador,Honduras,2,5,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
-2000-07-16,Guatemala,USA,1,1,FIFA World Cup qualification,Mazatenango,Guatemala,FALSE
+2000-07-16,Guatemala,United States,1,1,FIFA World Cup qualification,Mazatenango,Guatemala,FALSE
 2000-07-16,Guinea,Gambia,2,0,African Cup of Nations qualification,Conakry,Guinea,FALSE
 2000-07-16,Ivory Coast,Niger,6,0,African Cup of Nations qualification,Abidjan,Ivory Coast,FALSE
 2000-07-16,Mauritius,Tanzania,3,2,African Cup of Nations qualification,Curepipe,Mauritius,FALSE
@@ -23463,7 +23463,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-07-19,Bolivia,Chile,1,0,FIFA World Cup qualification,La Paz,Bolivia,FALSE
 2000-07-19,Peru,Colombia,0,1,FIFA World Cup qualification,Lima,Peru,FALSE
 2000-07-22,Guatemala,Barbados,2,0,FIFA World Cup qualification,Quetzaltenango,Guatemala,FALSE
-2000-07-23,Costa Rica,USA,2,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
+2000-07-23,Costa Rica,United States,2,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2000-07-23,Jamaica,Honduras,3,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2000-07-23,Lesotho,Angola,2,1,COSAFA Cup,Maseru,Lesotho,FALSE
 2000-07-23,Panama,Canada,0,0,FIFA World Cup qualification,Panama City,Panama,FALSE
@@ -23479,7 +23479,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-07-28,China PR,South Korea,0,1,Friendly,Beijing,China PR,FALSE
 2000-07-29,Bangladesh,India,0,1,Friendly,Leicester,England,TRUE
 2000-07-29,South Africa,Zimbabwe,0,1,COSAFA Cup,Port Elizabeth,South Africa,FALSE
-2000-08-05,El Salvador,Haiti,1,2,Friendly,Foxborough,USA,TRUE
+2000-08-05,El Salvador,Haiti,1,2,Friendly,Foxborough,United States,TRUE
 2000-08-05,Lebanon,Oman,3,1,Friendly,Zahlé,Lebanon,FALSE
 2000-08-06,Guyana,Trinidad and Tobago,0,0,Friendly,Georgetown,Guyana,FALSE
 2000-08-06,Malaysia,Myanmar,6,0,Friendly,Kuala Lumpur,Malaysia,FALSE
@@ -23522,10 +23522,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-08-16,Slovakia,Croatia,1,1,Friendly,Bratislava,Slovakia,FALSE
 2000-08-16,Switzerland,Greece,2,2,Friendly,St. Gallen,Switzerland,FALSE
 2000-08-16,Trinidad and Tobago,Panama,6,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
-2000-08-16,USA,Barbados,7,0,FIFA World Cup qualification,Foxborough,USA,FALSE
+2000-08-16,United States,Barbados,7,0,FIFA World Cup qualification,Foxborough,United States,FALSE
 2000-08-17,New Zealand,Oman,1,0,Merdeka Tournament,Kuala Lumpur,Malaysia,TRUE
 2000-08-19,Malaysia,New Zealand,0,2,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
-2000-08-20,Haiti,Honduras,0,4,Friendly,New York,USA,TRUE
+2000-08-20,Haiti,Honduras,0,4,Friendly,New York,United States,TRUE
 2000-08-20,Sierra Leone,Togo,2,0,African Cup of Nations qualification,Freetown,Sierra Leone,FALSE
 2000-08-25,Egypt,Kenya,2,1,Friendly,Port Said,Egypt,FALSE
 2000-08-25,Vietnam,Sri Lanka,2,2,Friendly,Ho Chi Minh City,Vietnam,FALSE
@@ -23587,19 +23587,19 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-09-03,Togo,Sierra Leone,2,0,African Cup of Nations qualification,Lomé,Togo,FALSE
 2000-09-03,Trinidad and Tobago,Canada,4,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2000-09-03,Uruguay,Ecuador,4,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2000-09-03,USA,Guatemala,1,0,FIFA World Cup qualification,Washington,USA,FALSE
+2000-09-03,United States,Guatemala,1,0,FIFA World Cup qualification,Washington,United States,FALSE
 2000-09-03,Zimbabwe,DR Congo,3,2,African Cup of Nations qualification,Harare,Zimbabwe,FALSE
 2000-09-07,Lebanon,United Arab Emirates,0,1,Friendly,Beirut,Lebanon,FALSE
 2000-09-10,Lebanon,United Arab Emirates,2,2,Friendly,Beirut,Lebanon,FALSE
 2000-09-10,Libya,Sudan,1,0,African Cup of Nations qualification,Tripoli,Libya,FALSE
-2000-09-20,Mexico,Ecuador,2,0,Friendly,San Diego,USA,TRUE
+2000-09-20,Mexico,Ecuador,2,0,Friendly,San Diego,United States,TRUE
 2000-09-24,Qatar,Kuwait,0,0,Friendly,Doha,Qatar,FALSE
 2000-09-24,Saudi Arabia,Syria,2,1,Friendly,Abha,Saudi Arabia,FALSE
 2000-09-24,Senegal,Togo,0,0,African Cup of Nations qualification,Dakar,Senegal,FALSE
 2000-09-24,Zanzibar,Tanzania,0,1,Friendly,Zanzibar,Zanzibar,FALSE
 2000-09-26,Saudi Arabia,Syria,3,0,Friendly,Abha,Saudi Arabia,FALSE
 2000-09-27,Cayman Islands,Turks and Caicos Islands,3,0,Friendly,George Town,Cayman Islands,FALSE
-2000-09-27,Mexico,Bolivia,1,0,Friendly,San Diego,USA,TRUE
+2000-09-27,Mexico,Bolivia,1,0,Friendly,San Diego,United States,TRUE
 2000-09-27,Qatar,Iran,1,2,Friendly,Doha,Qatar,FALSE
 2000-09-28,Saudi Arabia,United Arab Emirates,6,1,Friendly,Abha,Saudi Arabia,FALSE
 2000-09-30,Kenya,Burundi,1,0,Friendly,Nairobi,Kenya,FALSE
@@ -23682,7 +23682,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-10-11,Russia,Luxembourg,3,0,FIFA World Cup qualification,Moscow,Russia,FALSE
 2000-10-11,Slovakia,Sweden,0,0,FIFA World Cup qualification,Bratislava,Slovakia,FALSE
 2000-10-11,Slovenia,Switzerland,2,2,FIFA World Cup qualification,Ljubljana,Slovenia,FALSE
-2000-10-11,USA,Costa Rica,0,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2000-10-11,United States,Costa Rica,0,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2000-10-12,Iraq,Thailand,2,0,AFC Asian Cup,Tripoli,Lebanon,TRUE
 2000-10-12,Lebanon,Iran,0,4,AFC Asian Cup,Beirut,Lebanon,FALSE
 2000-10-13,South Korea,China PR,2,2,AFC Asian Cup,Tripoli,Lebanon,TRUE
@@ -23711,7 +23711,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-10-24,Kuwait,Saudi Arabia,2,3,AFC Asian Cup,Beirut,Lebanon,TRUE
 2000-10-25,Ghana,Uganda,1,2,Friendly,Nairobi,Kenya,TRUE
 2000-10-25,Malaysia,Sri Lanka,3,1,Friendly,Kuala Lumpur,Malaysia,FALSE
-2000-10-25,USA,Mexico,2,0,Friendly,Los Angeles,USA,FALSE
+2000-10-25,United States,Mexico,2,0,Friendly,Los Angeles,United States,FALSE
 2000-10-26,China PR,Japan,2,3,AFC Asian Cup,Beirut,Lebanon,TRUE
 2000-10-26,South Korea,Saudi Arabia,1,2,AFC Asian Cup,Beirut,Lebanon,TRUE
 2000-10-28,Eritrea,Rwanda,0,1,Friendly,Lusaka,Zambia,TRUE
@@ -23743,7 +23743,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-11-13,Malaysia,Singapore,1,0,AFF Championship,Songkhla,Thailand,TRUE
 2000-11-14,Algeria,Bulgaria,1,2,Friendly,Algiers,Algeria,FALSE
 2000-11-15,Albania,Malta,3,0,Friendly,Tirana,Albania,FALSE
-2000-11-15,Barbados,USA,0,4,FIFA World Cup qualification,Bridgetown,Barbados,FALSE
+2000-11-15,Barbados,United States,0,4,FIFA World Cup qualification,Bridgetown,Barbados,FALSE
 2000-11-15,Bolivia,Uruguay,0,0,FIFA World Cup qualification,La Paz,Bolivia,FALSE
 2000-11-15,Brazil,Colombia,1,0,FIFA World Cup qualification,São Paulo,Brazil,FALSE
 2000-11-15,Canada,Mexico,0,0,FIFA World Cup qualification,Toronto,Canada,FALSE
@@ -23797,12 +23797,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2000-12-13,Greece,Serbia,1,1,Friendly,Xánthi,Greece,FALSE
 2000-12-16,South Africa,Liberia,2,1,African Cup of Nations qualification,Johannesburg,South Africa,FALSE
 2000-12-20,Japan,South Korea,1,1,Friendly,Tokyo,Japan,FALSE
-2000-12-20,Mexico,Argentina,0,2,Friendly,Los Angeles,USA,TRUE
+2000-12-20,Mexico,Argentina,0,2,Friendly,Los Angeles,United States,TRUE
 2000-12-22,Catalonia,Lithuania,5,0,Friendly,Barcelona,Spain,FALSE
 2000-12-22,Andalusia,Morocco,2,0,Friendly,Córdoba,Spain,FALSE
 2000-12-29,Basque Country,Morocco,3,2,Friendly,Bilbao,Spain,FALSE
 2001-01-04,Kenya,Zambia,2,1,Friendly,Nairobi,Kenya,FALSE
-2001-01-06,Costa Rica,Guatemala,5,2,FIFA World Cup qualification,Miami,USA,TRUE
+2001-01-06,Costa Rica,Guatemala,5,2,FIFA World Cup qualification,Miami,United States,TRUE
 2001-01-06,Egypt,United Arab Emirates,2,1,Friendly,Cairo,Egypt,FALSE
 2001-01-06,Eswatini,Angola,1,0,Friendly,Manzini,Eswatini,FALSE
 2001-01-07,Angola,Lesotho,2,0,Friendly,Manzini,Eswatini,TRUE
@@ -23857,7 +23857,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-01-27,Nigeria,Sudan,3,0,FIFA World Cup qualification,Port Harcourt,Nigeria,FALSE
 2001-01-27,Singapore,Thailand,1,1,Friendly,Singapore,Singapore,FALSE
 2001-01-27,South Africa,Burkina Faso,1,0,FIFA World Cup qualification,Rustenburg,South Africa,FALSE
-2001-01-27,USA,China PR,2,1,Friendly,Oakland,USA,FALSE
+2001-01-27,United States,China PR,2,1,Friendly,Oakland,United States,FALSE
 2001-01-28,Angola,Libya,3,1,FIFA World Cup qualification,Luanda,Angola,FALSE
 2001-01-28,Antigua and Barbuda,British Virgin Islands,1,1,Friendly,St. John's,Antigua and Barbuda,FALSE
 2001-01-28,Botswana,Lesotho,2,1,Friendly,Gaborone,Botswana,FALSE
@@ -23874,14 +23874,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-01-30,Saudi Arabia,Syria,1,0,Friendly,Dammam,Saudi Arabia,FALSE
 2001-01-30,Thailand,Kyrgyzstan,3,1,Friendly,Bangkok,Thailand,FALSE
 2001-01-31,Lebanon,Iraq,0,0,Friendly,Beirut,Lebanon,FALSE
-2001-01-31,Mexico,Colombia,2,3,Friendly,Los Angeles,USA,TRUE
+2001-01-31,Mexico,Colombia,2,3,Friendly,Los Angeles,United States,TRUE
 2001-01-31,Sweden,Faroe Islands,0,0,Nordic Championship,Växjö,Sweden,FALSE
 2001-02-01,Sweden,Finland,0,1,Nordic Championship,Jönköping,Sweden,FALSE
 2001-02-03,Bahrain,Kuwait,1,2,FIFA World Cup qualification,Singapore,Singapore,TRUE
 2001-02-03,Puerto Rico,British Virgin Islands,1,2,CFU Caribbean Cup qualification,San Juan,Puerto Rico,FALSE
 2001-02-03,Saudi Arabia,Uganda,3,1,Friendly,Dammam,Saudi Arabia,FALSE
 2001-02-03,Singapore,Kyrgyzstan,0,1,FIFA World Cup qualification,Singapore,Singapore,FALSE
-2001-02-03,USA,Colombia,0,1,Friendly,Miami,USA,FALSE
+2001-02-03,United States,Colombia,0,1,Friendly,Miami,United States,FALSE
 2001-02-04,Senegal,Mali,1,0,Friendly,Dakar,Senegal,FALSE
 2001-02-05,Fiji,Malaysia,4,1,Friendly,Lautoka,Fiji,FALSE
 2001-02-06,Bahrain,Kyrgyzstan,1,0,FIFA World Cup qualification,Singapore,Singapore,TRUE
@@ -23972,15 +23972,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-02-28,Portugal,Andorra,3,0,FIFA World Cup qualification,Funchal,Portugal,FALSE
 2001-02-28,Slovenia,Uruguay,0,2,Friendly,Koper,Slovenia,FALSE
 2001-02-28,Switzerland,Poland,0,4,Friendly,Larnaca,Cyprus,TRUE
-2001-02-28,USA,Mexico,2,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2001-02-28,United States,Mexico,2,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2001-03-01,Saint Kitts and Nevis,Dominican Republic,2,1,CFU Caribbean Cup qualification,St. John's,Antigua and Barbuda,TRUE
 2001-03-03,Antigua and Barbuda,Dominican Republic,2,3,CFU Caribbean Cup qualification,St. John's,Antigua and Barbuda,FALSE
-2001-03-03,USA,Brazil,1,2,Friendly,Pasadena,USA,FALSE
+2001-03-03,United States,Brazil,1,2,Friendly,Pasadena,United States,FALSE
 2001-03-04,Antigua and Barbuda,Saint Kitts and Nevis,2,2,CFU Caribbean Cup qualification,St. John's,Antigua and Barbuda,FALSE
 2001-03-04,Hong Kong,Palestine,1,1,FIFA World Cup qualification,So Kon Po,Hong Kong,FALSE
 2001-03-04,Qatar,Malaysia,5,1,FIFA World Cup qualification,So Kon Po,Hong Kong,TRUE
 2001-03-06,Guatemala,El Salvador,1,1,Friendly,Mazatenango,Guatemala,FALSE
-2001-03-07,Honduras,Peru,0,0,Friendly,Miami,USA,TRUE
+2001-03-07,Honduras,Peru,0,0,Friendly,Miami,United States,TRUE
 2001-03-07,Jordan,Hungary,1,1,Friendly,Amman,Jordan,FALSE
 2001-03-07,Lebanon,Syria,2,2,Friendly,Tripoli,Lebanon,FALSE
 2001-03-07,Mexico,Brazil,3,3,Friendly,Guadalajara,Mexico,FALSE
@@ -24022,7 +24022,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-03-24,Armenia,Wales,2,2,FIFA World Cup qualification,Yerevan,Armenia,FALSE
 2001-03-24,Azerbaijan,Moldova,0,0,FIFA World Cup qualification,Baku,Azerbaijan,FALSE
 2001-03-24,Bosnia and Herzegovina,Austria,1,1,FIFA World Cup qualification,Sarajevo,Bosnia and Herzegovina,FALSE
-2001-03-24,British Virgin Islands,USA Virgin Islands,2,0,Friendly,Road Town,British Virgin Islands,FALSE
+2001-03-24,British Virgin Islands,United States Virgin Islands,2,0,Friendly,Road Town,British Virgin Islands,FALSE
 2001-03-24,Bulgaria,Iceland,2,1,FIFA World Cup qualification,Sofia,Bulgaria,FALSE
 2001-03-24,Croatia,Latvia,4,1,FIFA World Cup qualification,Osijek,Croatia,FALSE
 2001-03-24,Cyprus,Republic of Ireland,0,4,FIFA World Cup qualification,Nicosia,Cyprus,FALSE
@@ -24073,7 +24073,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-03-28,Ecuador,Brazil,1,0,FIFA World Cup qualification,Quito,Ecuador,FALSE
 2001-03-28,Georgia,Romania,0,2,FIFA World Cup qualification,Tbilisi,Georgia,FALSE
 2001-03-28,Greece,Germany,2,4,FIFA World Cup qualification,Athens,Greece,FALSE
-2001-03-28,Honduras,USA,1,2,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
+2001-03-28,Honduras,United States,1,2,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2001-03-28,Italy,Lithuania,4,0,FIFA World Cup qualification,Trieste,Italy,FALSE
 2001-03-28,Liechtenstein,Bosnia and Herzegovina,0,3,FIFA World Cup qualification,Vaduz,Liechtenstein,FALSE
 2001-03-28,North Macedonia,Turkey,1,2,FIFA World Cup qualification,Skopje,North Macedonia,FALSE
@@ -24122,11 +24122,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-04-09,American Samoa,Samoa,0,8,FIFA World Cup qualification,Coffs Harbour,Australia,TRUE
 2001-04-09,Australia,Tonga,22,0,FIFA World Cup qualification,Coffs Harbour,Australia,FALSE
 2001-04-10,Guadeloupe,Saint Lucia,2,3,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,TRUE
-2001-04-10,Haiti,USA Virgin Islands,12,1,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
+2001-04-10,Haiti,United States Virgin Islands,12,1,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
 2001-04-11,Australia,American Samoa,31,0,FIFA World Cup qualification,Coffs Harbour,Australia,FALSE
 2001-04-11,Mexico,Chile,1,0,Friendly,Monterrey,Mexico,FALSE
 2001-04-11,Samoa,Fiji,1,6,FIFA World Cup qualification,Coffs Harbour,Australia,TRUE
-2001-04-12,Guadeloupe,USA Virgin Islands,11,0,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,TRUE
+2001-04-12,Guadeloupe,United States Virgin Islands,11,0,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,TRUE
 2001-04-12,Haiti,Saint Lucia,3,2,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
 2001-04-12,Iraq,Macau,8,0,FIFA World Cup qualification,Baghdad,Iraq,FALSE
 2001-04-12,Nepal,Kazakhstan,0,6,FIFA World Cup qualification,Baghdad,Iraq,TRUE
@@ -24136,7 +24136,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-04-14,Haiti,Guadeloupe,2,0,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
 2001-04-14,Iraq,Nepal,9,1,FIFA World Cup qualification,Baghdad,Iraq,FALSE
 2001-04-14,Kazakhstan,Macau,3,0,FIFA World Cup qualification,Baghdad,Iraq,TRUE
-2001-04-14,Saint Lucia,USA Virgin Islands,14,1,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,TRUE
+2001-04-14,Saint Lucia,United States Virgin Islands,14,1,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,TRUE
 2001-04-15,Cambodia,Maldives,1,1,FIFA World Cup qualification,Phnom Penh,Cambodia,FALSE
 2001-04-15,India,Yemen,1,1,FIFA World Cup qualification,Bangalore,India,FALSE
 2001-04-16,Australia,Samoa,11,0,FIFA World Cup qualification,Coffs Harbour,Australia,FALSE
@@ -24196,7 +24196,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-04-25,Switzerland,Sweden,0,2,Friendly,Geneva,Switzerland,FALSE
 2001-04-25,Trinidad and Tobago,Mexico,1,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2001-04-25,Turkey,Albania,0,2,Friendly,Gaziantep,Turkey,FALSE
-2001-04-25,USA,Costa Rica,1,0,FIFA World Cup qualification,Kansas City,USA,FALSE
+2001-04-25,United States,Costa Rica,1,0,FIFA World Cup qualification,Kansas City,United States,FALSE
 2001-04-25,Uzbekistan,Turkmenistan,1,0,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2001-04-26,Belize,Nicaragua,2,1,Friendly,Belize City,Belize,FALSE
 2001-04-26,Canada,Iran,1,0,Friendly,Cairo,Egypt,TRUE
@@ -24379,7 +24379,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-06-06,Ukraine,Wales,1,1,FIFA World Cup qualification,Kyiv,Ukraine,FALSE
 2001-06-07,France,Brazil,2,1,Confederations Cup,Suwon,South Korea,TRUE
 2001-06-07,Japan,Australia,1,0,Confederations Cup,Yokohama,Japan,FALSE
-2001-06-07,USA,Ecuador,0,0,Friendly,Columbus,USA,FALSE
+2001-06-07,United States,Ecuador,0,0,Friendly,Columbus,United States,FALSE
 2001-06-08,New Zealand,Cook Islands,2,0,FIFA World Cup qualification,North Shore,New Zealand,FALSE
 2001-06-08,Vanuatu,Solomon Islands,2,7,FIFA World Cup qualification,North Shore,New Zealand,TRUE
 2001-06-09,Australia,Brazil,1,0,Confederations Cup,Ulsan,South Korea,TRUE
@@ -24393,7 +24393,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-06-11,New Zealand,Solomon Islands,5,1,FIFA World Cup qualification,North Shore,New Zealand,FALSE
 2001-06-13,New Zealand,Vanuatu,7,0,FIFA World Cup qualification,North Shore,New Zealand,FALSE
 2001-06-13,Tahiti,Solomon Islands,2,0,FIFA World Cup qualification,North Shore,New Zealand,TRUE
-2001-06-16,Jamaica,USA,0,0,FIFA World Cup qualification,Kingston,Jamaica,FALSE
+2001-06-16,Jamaica,United States,0,0,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2001-06-16,Madagascar,Zambia,0,1,African Cup of Nations qualification,Antananarivo,Madagascar,FALSE
 2001-06-16,Mexico,Costa Rica,1,2,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2001-06-16,Morocco,Gabon,0,1,African Cup of Nations qualification,Fès,Morocco,FALSE
@@ -24407,7 +24407,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-06-20,Costa Rica,Jamaica,2,1,FIFA World Cup qualification,Alajuela,Costa Rica,FALSE
 2001-06-20,Honduras,Mexico,3,1,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2001-06-20,New Zealand,Australia,0,2,FIFA World Cup qualification,Wellington,New Zealand,FALSE
-2001-06-20,USA,Trinidad and Tobago,2,0,FIFA World Cup qualification,Foxborough,USA,FALSE
+2001-06-20,United States,Trinidad and Tobago,2,0,FIFA World Cup qualification,Foxborough,United States,FALSE
 2001-06-21,Slovakia,Bosnia and Herzegovina,0,1,Merdeka Tournament,Shah Alam,Malaysia,TRUE
 2001-06-21,Malaysia,Bahrain,2,4,Merdeka Tournament,Shah Alam,Malaysia,FALSE
 2001-06-23,Malaysia,Slovakia,0,2,Merdeka Tournament,Shah Alam,Malaysia,FALSE
@@ -24434,16 +24434,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-07-01,Japan,Paraguay,2,0,Kirin Cup,Sapporo,Japan,FALSE
 2001-07-01,Liberia,Ghana,1,2,FIFA World Cup qualification,Paynesville,Liberia,FALSE
 2001-07-01,Malawi,Eswatini,2,2,Friendly,Lilongwe,Malawi,FALSE
-2001-07-01,Mexico,USA,1,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+2001-07-01,Mexico,United States,1,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2001-07-01,Sudan,Nigeria,0,4,FIFA World Cup qualification,Omdurman,Sudan,FALSE
 2001-07-01,Tunisia,Congo,6,0,FIFA World Cup qualification,Tunis,Tunisia,FALSE
 2001-07-01,Uruguay,Brazil,1,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2001-07-02,El Salvador,Ecuador,0,1,Friendly,East Rutherford,USA,TRUE
+2001-07-02,El Salvador,Ecuador,0,1,Friendly,East Rutherford,United States,TRUE
 2001-07-03,Latvia,Estonia,3,1,Baltic Cup,Riga,Latvia,FALSE
 2001-07-04,Estonia,Lithuania,2,5,Baltic Cup,Riga,Latvia,TRUE
 2001-07-04,Japan,Serbia,1,0,Kirin Cup,Ōita,Japan,FALSE
 2001-07-05,Latvia,Lithuania,4,1,Baltic Cup,Riga,Latvia,FALSE
-2001-07-07,Honduras,Ecuador,1,1,Friendly,Miami,USA,TRUE
+2001-07-07,Honduras,Ecuador,1,1,Friendly,Miami,United States,TRUE
 2001-07-08,Zimbabwe,Eswatini,2,1,COSAFA Cup,Harare,Zimbabwe,FALSE
 2001-07-08,Ynys Môn,Saare County,4,1,Island Games,Castletown,Isle of Man,TRUE
 2001-07-08,Jersey,Orkney,12,0,Island Games,Douglas,Isle of Man,TRUE
@@ -24533,7 +24533,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-08-02,United Arab Emirates,Iraq,2,2,Friendly,Abu Dhabi,United Arab Emirates,FALSE
 2001-08-03,China PR,North Korea,2,2,Friendly,Shanghai,China PR,FALSE
 2001-08-03,Kuwait,Trinidad and Tobago,1,1,Friendly,Shanghai,China PR,TRUE
-2001-08-04,Colombia,Liberia,2,1,Friendly,East Rutherford,USA,TRUE
+2001-08-04,Colombia,Liberia,2,1,Friendly,East Rutherford,United States,TRUE
 2001-08-05,China PR,Trinidad and Tobago,3,0,Friendly,Shanghai,China PR,FALSE
 2001-08-05,Cuba,Panama,1,0,Gold Cup qualification,Havana,Cuba,FALSE
 2001-08-05,Kuwait,North Korea,1,1,Friendly,Shanghai,China PR,TRUE
@@ -24608,7 +24608,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-09-01,Switzerland,Serbia,1,2,FIFA World Cup qualification,Basel,Switzerland,FALSE
 2001-09-01,Thailand,Iran,0,0,FIFA World Cup qualification,Bangkok,Thailand,FALSE
 2001-09-01,Trinidad and Tobago,Costa Rica,0,2,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
-2001-09-01,USA,Honduras,2,3,FIFA World Cup qualification,Washington,USA,FALSE
+2001-09-01,United States,Honduras,2,3,FIFA World Cup qualification,Washington,United States,FALSE
 2001-09-01,Wales,Armenia,0,0,FIFA World Cup qualification,Cardiff,Wales,FALSE
 2001-09-02,Jamaica,Mexico,1,2,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2001-09-04,Chile,Venezuela,0,2,FIFA World Cup qualification,Santiago,Chile,FALSE
@@ -24620,7 +24620,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-09-05,Belgium,Scotland,2,0,FIFA World Cup qualification,Brussels,Belgium,FALSE
 2001-09-05,Bulgaria,Denmark,0,2,FIFA World Cup qualification,Sofia,Bulgaria,FALSE
 2001-09-05,Colombia,Ecuador,0,0,FIFA World Cup qualification,Bogotá,Colombia,FALSE
-2001-09-05,Costa Rica,USA,2,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
+2001-09-05,Costa Rica,United States,2,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2001-09-05,Cyprus,Portugal,1,3,FIFA World Cup qualification,Larnaca,Cyprus,FALSE
 2001-09-05,Czech Republic,Malta,3,2,FIFA World Cup qualification,Teplice,Czech Republic,FALSE
 2001-09-05,England,Albania,2,0,FIFA World Cup qualification,Newcastle,England,FALSE
@@ -24702,7 +24702,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-10-07,Paraguay,Argentina,2,2,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 2001-10-07,Sweden,Azerbaijan,3,0,FIFA World Cup qualification,Solna,Sweden,FALSE
 2001-10-07,Uruguay,Colombia,1,1,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2001-10-07,USA,Jamaica,2,1,FIFA World Cup qualification,Foxborough,USA,FALSE
+2001-10-07,United States,Jamaica,2,1,FIFA World Cup qualification,Foxborough,United States,FALSE
 2001-10-12,Gambia,Morocco,0,2,Friendly,Bamako,Mali,TRUE
 2001-10-12,Iran,Iraq,2,1,FIFA World Cup qualification,Tehran,Iran,FALSE
 2001-10-13,China PR,Qatar,3,0,FIFA World Cup qualification,Shenyang,China PR,FALSE
@@ -24753,7 +24753,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-11-11,Jamaica,Costa Rica,0,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2001-11-11,Mali,Guinea-Bissau,2,1,Amílcar Cabral Cup,Bamako,Mali,FALSE
 2001-11-11,Mexico,Honduras,3,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
-2001-11-11,Trinidad and Tobago,USA,0,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
+2001-11-11,Trinidad and Tobago,United States,0,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2001-11-13,South Korea,Croatia,1,1,Friendly,Gwangju,South Korea,FALSE
 2001-11-14,Brazil,Venezuela,3,0,FIFA World Cup qualification,São Luís,Brazil,FALSE
 2001-11-14,Chile,Ecuador,0,0,FIFA World Cup qualification,Santiago,Chile,FALSE
@@ -24784,7 +24784,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-12-05,Mali,Ivory Coast,0,3,Friendly,Sikasso,Mali,FALSE
 2001-12-08,Rwanda,Somalia,3,0,CECAFA Cup,Kigali,Rwanda,FALSE
 2001-12-09,Burundi,Tanzania,1,2,CECAFA Cup,Kigali,Rwanda,TRUE
-2001-12-09,South Korea,USA,1,0,Friendly,Seogwipo,South Korea,FALSE
+2001-12-09,South Korea,United States,1,0,Friendly,Seogwipo,South Korea,FALSE
 2001-12-09,Uganda,Djibouti,10,1,CECAFA Cup,Kigali,Rwanda,TRUE
 2001-12-10,Kenya,Eritrea,2,1,CECAFA Cup,Kigali,Rwanda,TRUE
 2001-12-11,Burundi,Djibouti,3,1,CECAFA Cup,Kigali,Rwanda,TRUE
@@ -24797,7 +24797,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2001-12-14,Eritrea,Somalia,0,0,CECAFA Cup,Kigali,Rwanda,TRUE
 2001-12-14,Uganda,Burundi,0,2,CECAFA Cup,Kigali,Rwanda,TRUE
 2001-12-15,Botswana,Namibia,3,2,Friendly,Gaborone,Botswana,FALSE
-2001-12-15,El Salvador,Haiti,0,0,Friendly,Miami,USA,TRUE
+2001-12-15,El Salvador,Haiti,0,0,Friendly,Miami,United States,TRUE
 2001-12-15,Rwanda,Kenya,0,0,CECAFA Cup,Kigali,Rwanda,FALSE
 2001-12-16,Botswana,Lesotho,1,0,Friendly,Gaborone,Botswana,FALSE
 2001-12-16,Burkina Faso,Togo,1,2,Friendly,Ouagadougou,Burkina Faso,FALSE
@@ -24855,32 +24855,32 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-01-16,Saudi Arabia,Kuwait,1,1,Gulf Cup,Riyadh,Saudi Arabia,FALSE
 2002-01-17,Qatar,Bahrain,1,0,Gulf Cup,Riyadh,Saudi Arabia,TRUE
 2002-01-17,United Arab Emirates,Oman,1,0,Gulf Cup,Riyadh,Saudi Arabia,TRUE
-2002-01-18,Haiti,Canada,0,2,Gold Cup,Miami,USA,TRUE
-2002-01-18,Martinique,Costa Rica,0,2,Gold Cup,Miami,USA,TRUE
-2002-01-19,El Salvador,Mexico,0,1,Gold Cup,Pasadena,USA,TRUE
+2002-01-18,Haiti,Canada,0,2,Gold Cup,Miami,United States,TRUE
+2002-01-18,Martinique,Costa Rica,0,2,Gold Cup,Miami,United States,TRUE
+2002-01-19,El Salvador,Mexico,0,1,Gold Cup,Pasadena,United States,TRUE
 2002-01-19,Kuwait,Oman,1,3,Gulf Cup,Riyadh,Saudi Arabia,TRUE
 2002-01-19,Mali,Liberia,1,1,African Cup of Nations,Bamako,Mali,FALSE
 2002-01-19,Saint Kitts and Nevis,Grenada,1,1,Friendly,Basseterre,Saint Kitts and Nevis,FALSE
-2002-01-19,USA,South Korea,2,1,Gold Cup,Pasadena,USA,FALSE
+2002-01-19,United States,South Korea,2,1,Gold Cup,Pasadena,United States,FALSE
 2002-01-20,Antigua and Barbuda,Dominica,4,0,Friendly,St. John's,Antigua and Barbuda,FALSE
 2002-01-20,Cameroon,DR Congo,1,0,African Cup of Nations,Sikasso,Mali,TRUE
-2002-01-20,Costa Rica,Trinidad and Tobago,1,1,Gold Cup,Miami,USA,TRUE
-2002-01-20,Ecuador,Haiti,0,2,Gold Cup,Miami,USA,TRUE
+2002-01-20,Costa Rica,Trinidad and Tobago,1,1,Gold Cup,Miami,United States,TRUE
+2002-01-20,Ecuador,Haiti,0,2,Gold Cup,Miami,United States,TRUE
 2002-01-20,Egypt,Senegal,0,1,African Cup of Nations,Bamako,Mali,TRUE
 2002-01-20,Saudi Arabia,Bahrain,3,1,Gulf Cup,Riyadh,Saudi Arabia,FALSE
 2002-01-20,South Africa,Burkina Faso,0,0,African Cup of Nations,Ségou,Mali,TRUE
 2002-01-20,United Arab Emirates,Qatar,0,2,Gulf Cup,Riyadh,Saudi Arabia,TRUE
 2002-01-21,Algeria,Nigeria,0,1,African Cup of Nations,Bamako,Mali,TRUE
-2002-01-21,Mexico,Guatemala,3,1,Gold Cup,Pasadena,USA,TRUE
+2002-01-21,Mexico,Guatemala,3,1,Gold Cup,Pasadena,United States,TRUE
 2002-01-21,Morocco,Ghana,0,0,African Cup of Nations,Ségou,Mali,TRUE
 2002-01-21,Togo,Ivory Coast,0,0,African Cup of Nations,Sikasso,Mali,TRUE
-2002-01-21,USA,Cuba,1,0,Gold Cup,Pasadena,USA,FALSE
+2002-01-21,United States,Cuba,1,0,Gold Cup,Pasadena,United States,FALSE
 2002-01-21,Zambia,Tunisia,0,0,African Cup of Nations,Bamako,Mali,TRUE
-2002-01-22,Canada,Ecuador,0,2,Gold Cup,Miami,USA,TRUE
+2002-01-22,Canada,Ecuador,0,2,Gold Cup,Miami,United States,TRUE
 2002-01-22,Kuwait,Bahrain,0,0,Gulf Cup,Riyadh,Saudi Arabia,TRUE
-2002-01-22,Trinidad and Tobago,Martinique,0,1,Gold Cup,Miami,USA,TRUE
-2002-01-23,Guatemala,El Salvador,0,1,Gold Cup,Pasadena,USA,TRUE
-2002-01-23,South Korea,Cuba,0,0,Gold Cup,Pasadena,USA,TRUE
+2002-01-22,Trinidad and Tobago,Martinique,0,1,Gold Cup,Miami,United States,TRUE
+2002-01-23,Guatemala,El Salvador,0,1,Gold Cup,Pasadena,United States,TRUE
+2002-01-23,South Korea,Cuba,0,0,Gold Cup,Pasadena,United States,TRUE
 2002-01-24,Mali,Nigeria,0,0,African Cup of Nations,Bamako,Mali,FALSE
 2002-01-24,South Africa,Ghana,0,0,African Cup of Nations,Ségou,Mali,TRUE
 2002-01-24,Oman,Qatar,1,2,Gulf Cup,Riyadh,Saudi Arabia,TRUE
@@ -24889,13 +24889,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-01-25,Egypt,Tunisia,1,0,African Cup of Nations,Bamako,Mali,TRUE
 2002-01-25,Liberia,Algeria,2,2,African Cup of Nations,Bamako,Mali,TRUE
 2002-01-26,Burkina Faso,Morocco,1,2,African Cup of Nations,Ségou,Mali,TRUE
-2002-01-26,Canada,Martinique,1,1,Gold Cup,Miami,USA,TRUE
+2002-01-26,Canada,Martinique,1,1,Gold Cup,Miami,United States,TRUE
 2002-01-26,DR Congo,Togo,0,0,African Cup of Nations,Sikasso,Mali,TRUE
-2002-01-26,Costa Rica,Haiti,2,1,Gold Cup,Miami,USA,TRUE
+2002-01-26,Costa Rica,Haiti,2,1,Gold Cup,Miami,United States,TRUE
 2002-01-26,Senegal,Zambia,1,0,African Cup of Nations,Bamako,Mali,TRUE
 2002-01-26,Kuwait,Qatar,0,1,Gulf Cup,Riyadh,Saudi Arabia,TRUE
-2002-01-27,Mexico,South Korea,0,0,Gold Cup,Pasadena,USA,TRUE
-2002-01-27,USA,El Salvador,4,0,Gold Cup,Pasadena,USA,FALSE
+2002-01-27,Mexico,South Korea,0,0,Gold Cup,Pasadena,United States,TRUE
+2002-01-27,United States,El Salvador,4,0,Gold Cup,Pasadena,United States,FALSE
 2002-01-27,United Arab Emirates,Bahrain,1,2,Gulf Cup,Riyadh,Saudi Arabia,TRUE
 2002-01-27,Saudi Arabia,Oman,2,0,Gulf Cup,Riyadh,Saudi Arabia,FALSE
 2002-01-28,Liberia,Nigeria,0,1,African Cup of Nations,Mopti,Mali,TRUE
@@ -24904,16 +24904,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-01-29,DR Congo,Ivory Coast,3,1,African Cup of Nations,Kayes,Mali,TRUE
 2002-01-29,Kuwait,United Arab Emirates,2,1,Gulf Cup,Riyadh,Saudi Arabia,TRUE
 2002-01-30,Burkina Faso,Ghana,1,2,African Cup of Nations,Mopti,Mali,TRUE
-2002-01-30,Costa Rica,South Korea,3,1,Gold Cup,Pasadena,USA,TRUE
+2002-01-30,Costa Rica,South Korea,3,1,Gold Cup,Pasadena,United States,TRUE
 2002-01-30,South Africa,Morocco,3,1,African Cup of Nations,Ségou,Mali,TRUE
-2002-01-30,USA,Canada,0,0,Gold Cup,Pasadena,USA,FALSE
+2002-01-30,United States,Canada,0,0,Gold Cup,Pasadena,United States,FALSE
 2002-01-30,Bahrain,Oman,1,1,Gulf Cup,Riyadh,Saudi Arabia,TRUE
 2002-01-30,Saudi Arabia,Qatar,3,1,Gulf Cup,Riyadh,Saudi Arabia,FALSE
 2002-01-31,Brazil,Bolivia,6,0,Friendly,Goiânia,Brazil,FALSE
 2002-01-31,Egypt,Zambia,2,1,African Cup of Nations,Bamako,Mali,TRUE
 2002-01-31,Senegal,Tunisia,0,0,African Cup of Nations,Kayes,Mali,TRUE
-2002-02-02,Canada,South Korea,2,1,Gold Cup,Pasadena,USA,TRUE
-2002-02-02,USA,Costa Rica,2,0,Gold Cup,Pasadena,USA,FALSE
+2002-02-02,Canada,South Korea,2,1,Gold Cup,Pasadena,United States,TRUE
+2002-02-02,United States,Costa Rica,2,0,Gold Cup,Pasadena,United States,FALSE
 2002-02-03,Mali,South Africa,2,0,African Cup of Nations,Kayes,Mali,FALSE
 2002-02-03,Nigeria,Ghana,1,0,African Cup of Nations,Bamako,Mali,TRUE
 2002-02-04,Cameroon,Egypt,1,0,African Cup of Nations,Sikasso,Mali,TRUE
@@ -24946,11 +24946,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-02-13,Germany,Israel,7,1,Friendly,Kaiserslautern,Germany,FALSE
 2002-02-13,Greece,Sweden,2,2,Friendly,Salonica,Greece,FALSE
 2002-02-13,Republic of Ireland,Russia,2,0,Friendly,Dublin,Republic of Ireland,FALSE
-2002-02-13,Italy,USA,1,0,Friendly,Catania,Italy,FALSE
+2002-02-13,Italy,United States,1,0,Friendly,Catania,Italy,FALSE
 2002-02-13,Lithuania,Jordan,0,3,Malta International Tournament,Attard,Malta,TRUE
 2002-02-13,Luxembourg,Albania,0,0,Friendly,Hesperange,Luxembourg,FALSE
 2002-02-13,Malta,Moldova,3,0,Malta International Tournament,Attard,Malta,FALSE
-2002-02-13,Mexico,Serbia,1,2,Friendly,Phoenix,USA,TRUE
+2002-02-13,Mexico,Serbia,1,2,Friendly,Phoenix,United States,TRUE
 2002-02-13,Netherlands,England,1,1,Friendly,Amsterdam,Netherlands,FALSE
 2002-02-13,Northern Ireland,Poland,1,4,Friendly,Limassol,Cyprus,TRUE
 2002-02-13,Paraguay,Bolivia,2,2,Friendly,Ciudad del Este,Paraguay,FALSE
@@ -24967,15 +24967,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-02-18,Gibraltar,Monaco,2,2,Friendly,Nice,France,TRUE
 2002-03-01,Iran,Venezuela,1,0,Friendly,Casablanca,Morocco,TRUE
 2002-03-02,Botswana,Eswatini,6,2,Friendly,Gaborone,Botswana,FALSE
-2002-03-02,USA,Honduras,4,0,Friendly,Seattle,USA,FALSE
+2002-03-02,United States,Honduras,4,0,Friendly,Seattle,United States,FALSE
 2002-03-07,Brazil,Iceland,6,1,Friendly,Cuiabá,Brazil,FALSE
 2002-03-09,American Samoa,New Caledonia,0,10,Oceania Nations Cup qualification,Apia,Samoa,TRUE
 2002-03-09,Samoa,Tonga,2,0,Oceania Nations Cup qualification,Apia,Samoa,FALSE
 2002-03-10,Eswatini,Lesotho,1,0,Friendly,Mbabane,Eswatini,FALSE
-2002-03-10,USA,Ecuador,1,0,Friendly,Birmingham,USA,FALSE
+2002-03-10,United States,Ecuador,1,0,Friendly,Birmingham,United States,FALSE
 2002-03-12,American Samoa,Tonga,2,7,Oceania Nations Cup qualification,Apia,Samoa,TRUE
 2002-03-12,New Caledonia,Papua New Guinea,1,4,Oceania Nations Cup qualification,Apia,Samoa,TRUE
-2002-03-13,Mexico,Albania,4,0,Friendly,San Diego,USA,TRUE
+2002-03-13,Mexico,Albania,4,0,Friendly,San Diego,United States,TRUE
 2002-03-13,Tunisia,South Korea,0,0,Friendly,Tunis,Tunisia,FALSE
 2002-03-14,Estonia,Saudi Arabia,2,0,Friendly,Montecatini Terme,Italy,TRUE
 2002-03-14,Papua New Guinea,Tonga,5,0,Oceania Nations Cup qualification,Apia,Samoa,TRUE
@@ -25001,13 +25001,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-03-27,Belize,Guyana,3,1,Friendly,Belize,Belize,FALSE
 2002-03-27,Bosnia and Herzegovina,North Macedonia,4,4,Friendly,Sarajevo,Bosnia and Herzegovina,FALSE
 2002-03-27,Brazil,Serbia,1,0,Friendly,Fortaleza,Brazil,FALSE
-2002-03-27,Bulgaria,Ecuador,0,3,Friendly,East Rutherford,USA,TRUE
+2002-03-27,Bulgaria,Ecuador,0,3,Friendly,East Rutherford,United States,TRUE
 2002-03-27,Croatia,Slovenia,0,0,Friendly,Zagreb,Croatia,FALSE
 2002-03-27,England,Italy,1,2,Friendly,Leeds,England,FALSE
 2002-03-27,Estonia,Russia,2,1,Friendly,Tallinn,Estonia,FALSE
 2002-03-27,France,Scotland,5,0,Friendly,Saint-Denis,France,FALSE
 2002-03-27,Georgia,South Africa,4,1,Friendly,Tbilisi,Georgia,FALSE
-2002-03-27,Germany,USA,4,2,Friendly,Rostock,Germany,FALSE
+2002-03-27,Germany,United States,4,2,Friendly,Rostock,Germany,FALSE
 2002-03-27,Republic of Ireland,Denmark,3,0,Friendly,Dublin,Republic of Ireland,FALSE
 2002-03-27,Liechtenstein,Northern Ireland,0,0,Friendly,Vaduz,Liechtenstein,FALSE
 2002-03-27,Luxembourg,Latvia,0,3,Friendly,Hesperange,Luxembourg,FALSE
@@ -25042,14 +25042,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-04-17,Germany,Argentina,0,1,Friendly,Stuttgart,Germany,FALSE
 2002-04-17,Greece,Czech Republic,0,0,Friendly,Ioannina,Greece,FALSE
 2002-04-17,Hungary,Belarus,2,5,Friendly,Debrecen,Hungary,FALSE
-2002-04-17,Republic of Ireland,USA,2,1,Friendly,Dublin,Republic of Ireland,FALSE
+2002-04-17,Republic of Ireland,United States,2,1,Friendly,Dublin,Republic of Ireland,FALSE
 2002-04-17,Italy,Uruguay,1,1,Friendly,Milan,Italy,FALSE
 2002-04-17,Japan,Costa Rica,1,1,Friendly,Yokohama,Japan,FALSE
 2002-04-17,Latvia,Kazakhstan,2,1,Friendly,Ventspils,Latvia,FALSE
 2002-04-17,Luxembourg,Liechtenstein,3,3,Friendly,Hesperange,Luxembourg,FALSE
 2002-04-17,North Macedonia,Finland,1,0,Friendly,Prilep,North Macedonia,FALSE
 2002-04-17,Malta,Azerbaijan,1,0,Friendly,Attard,Malta,FALSE
-2002-04-17,Mexico,Bulgaria,1,0,Friendly,East Rutherford,USA,TRUE
+2002-04-17,Mexico,Bulgaria,1,0,Friendly,East Rutherford,United States,TRUE
 2002-04-17,Northern Ireland,Spain,0,5,Friendly,Belfast,Northern Ireland,FALSE
 2002-04-17,Norway,Sweden,0,0,Friendly,Oslo,Norway,FALSE
 2002-04-17,Poland,Romania,1,2,Friendly,Bydgoszcz,Poland,FALSE
@@ -25069,14 +25069,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-05-05,Zimbabwe,Eswatini,0,2,COSAFA Cup,Harare,Zimbabwe,FALSE
 2002-05-06,Jersey,Guernsey,2,1,Friendly,St. Helier,Jersey,FALSE
 2002-05-07,Venezuela,Colombia,0,0,Friendly,Caracas,Venezuela,FALSE
-2002-05-08,Ecuador,Serbia,1,0,Friendly,East Rutherford,USA,TRUE
+2002-05-08,Ecuador,Serbia,1,0,Friendly,East Rutherford,United States,TRUE
 2002-05-08,Hungary,Croatia,0,2,Friendly,Pécs,Hungary,FALSE
 2002-05-09,Costa Rica,Colombia,1,2,Friendly,San José,Costa Rica,FALSE
 2002-05-09,Germany,Kuwait,7,0,Friendly,Freiburg,Germany,FALSE
 2002-05-11,Kenya,Tanzania,1,0,Friendly,Nairobi,Kenya,FALSE
 2002-05-12,Mexico,Colombia,2,1,Friendly,Mexico City,Mexico,FALSE
 2002-05-12,South Africa,Madagascar,1,0,Friendly,Durban,South Africa,FALSE
-2002-05-12,USA,Uruguay,2,1,Friendly,Washington,USA,FALSE
+2002-05-12,United States,Uruguay,2,1,Friendly,Washington,United States,FALSE
 2002-05-14,Belgium,Algeria,0,0,Friendly,Brussels,Belgium,FALSE
 2002-05-14,Norway,Japan,3,0,Friendly,Oslo,Norway,FALSE
 2002-05-14,Saudi Arabia,Senegal,3,2,Friendly,Riyadh,Saudi Arabia,FALSE
@@ -25087,8 +25087,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-05-16,China PR,Uruguay,0,2,Friendly,Shenyang,China PR,FALSE
 2002-05-16,Republic of Ireland,Nigeria,1,2,Friendly,Dublin,Republic of Ireland,FALSE
 2002-05-16,South Korea,Scotland,4,1,Friendly,Busan,South Korea,FALSE
-2002-05-16,Mexico,Bolivia,1,0,Friendly,San Francisco,USA,TRUE
-2002-05-16,USA,Jamaica,5,0,Friendly,East Rutherford,USA,FALSE
+2002-05-16,Mexico,Bolivia,1,0,Friendly,San Francisco,United States,TRUE
+2002-05-16,United States,Jamaica,5,0,Friendly,East Rutherford,United States,FALSE
 2002-05-17,Myanmar,Malaysia,1,1,Friendly,Yangon,Myanmar,FALSE
 2002-05-17,Denmark,Cameroon,2,1,Friendly,Copenhagen,Denmark,FALSE
 2002-05-17,Russia,Belarus,1,1,Friendly,Moscow,Russia,FALSE
@@ -25107,7 +25107,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-05-19,Belarus,Ukraine,2,0,Friendly,Moscow,Russia,TRUE
 2002-05-19,Myanmar,Malaysia,0,0,Friendly,Yangon,Myanmar,FALSE
 2002-05-19,Russia,Serbia,1,1,Friendly,Moscow,Russia,FALSE
-2002-05-19,USA,Netherlands,0,2,Friendly,Foxborough,USA,FALSE
+2002-05-19,United States,Netherlands,0,2,Friendly,Foxborough,United States,FALSE
 2002-05-20,Scotland,South Africa,0,2,Friendly,So Kon Po,Hong Kong,TRUE
 2002-05-21,South Korea,England,1,1,Friendly,Seogwipo,South Korea,FALSE
 2002-05-21,San Marino,Estonia,0,1,Friendly,Serravalle,San Marino,FALSE
@@ -25140,7 +25140,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-06-04,South Korea,Poland,2,0,FIFA World Cup,Busan,South Korea,FALSE
 2002-06-05,Germany,Republic of Ireland,1,1,FIFA World Cup,Kashima,Japan,TRUE
 2002-06-05,Russia,Tunisia,2,0,FIFA World Cup,Kobe,Japan,TRUE
-2002-06-05,USA,Portugal,3,2,FIFA World Cup,Suwon,South Korea,TRUE
+2002-06-05,United States,Portugal,3,2,FIFA World Cup,Suwon,South Korea,TRUE
 2002-06-06,Cameroon,Saudi Arabia,1,0,FIFA World Cup,Saitama,Japan,TRUE
 2002-06-06,Denmark,Senegal,1,1,FIFA World Cup,Daegu,South Korea,TRUE
 2002-06-06,France,Uruguay,0,0,FIFA World Cup,Busan,South Korea,TRUE
@@ -25157,7 +25157,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-06-09,Japan,Russia,1,0,FIFA World Cup,Yokohama,Japan,FALSE
 2002-06-09,Malawi,Botswana,1,0,Friendly,Blantyre,Malawi,FALSE
 2002-06-09,Mexico,Ecuador,2,1,FIFA World Cup,Rifu,Japan,TRUE
-2002-06-10,South Korea,USA,1,1,FIFA World Cup,Daegu,South Korea,FALSE
+2002-06-10,South Korea,United States,1,1,FIFA World Cup,Daegu,South Korea,FALSE
 2002-06-10,Portugal,Poland,4,0,FIFA World Cup,Jeonju,South Korea,TRUE
 2002-06-10,Tunisia,Belgium,1,1,FIFA World Cup,Ōita,Japan,TRUE
 2002-06-11,Cameroon,Germany,0,2,FIFA World Cup,Fukuroi,Japan,TRUE
@@ -25175,17 +25175,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-06-14,Belgium,Russia,3,2,FIFA World Cup,Fukuroi,Japan,TRUE
 2002-06-14,Japan,Tunisia,2,0,FIFA World Cup,Osaka,Japan,FALSE
 2002-06-14,South Korea,Portugal,1,0,FIFA World Cup,Incheon,South Korea,FALSE
-2002-06-14,Poland,USA,3,1,FIFA World Cup,Daejeon,South Korea,TRUE
+2002-06-14,Poland,United States,3,1,FIFA World Cup,Daejeon,South Korea,TRUE
 2002-06-15,Denmark,England,0,3,FIFA World Cup,Niigata,Japan,TRUE
 2002-06-15,Germany,Paraguay,1,0,FIFA World Cup,Seogwipo,South Korea,TRUE
 2002-06-16,Spain,Republic of Ireland,1,1,FIFA World Cup,Suwon,South Korea,TRUE
 2002-06-16,Sweden,Senegal,1,2,FIFA World Cup,Ōita,Japan,TRUE
 2002-06-17,Brazil,Belgium,2,0,FIFA World Cup,Kobe,Japan,TRUE
-2002-06-17,Mexico,USA,0,2,FIFA World Cup,Jeonju,South Korea,TRUE
+2002-06-17,Mexico,United States,0,2,FIFA World Cup,Jeonju,South Korea,TRUE
 2002-06-18,Japan,Turkey,0,1,FIFA World Cup,Rifu,Japan,FALSE
 2002-06-18,South Korea,Italy,2,1,FIFA World Cup,Daejeon,South Korea,FALSE
 2002-06-21,England,Brazil,1,2,FIFA World Cup,Fukuroi,Japan,TRUE
-2002-06-21,Germany,USA,1,0,FIFA World Cup,Ulsan,South Korea,TRUE
+2002-06-21,Germany,United States,1,0,FIFA World Cup,Ulsan,South Korea,TRUE
 2002-06-22,Grenada,British Virgin Islands,5,0,Friendly,St. George's,Grenada,FALSE
 2002-06-22,South Korea,Spain,0,0,FIFA World Cup,Gwangju,South Korea,FALSE
 2002-06-22,Senegal,Turkey,0,1,FIFA World Cup,Osaka,Japan,TRUE
@@ -25251,9 +25251,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-08-11,Curaçao,Guyana,1,0,Gold Cup qualification,Willemstad,Netherlands Antilles,FALSE
 2002-08-11,Saint Lucia,Jamaica,1,3,Friendly,Vieux Fort,Saint Lucia,FALSE
 2002-08-11,Suriname,Aruba,6,0,Gold Cup qualification,Paramaribo,Suriname,FALSE
-2002-08-16,Dominican Republic,USA Virgin Islands,6,1,Gold Cup qualification,San Cristóbal,Dominican Republic,FALSE
+2002-08-16,Dominican Republic,United States Virgin Islands,6,1,Gold Cup qualification,San Cristóbal,Dominican Republic,FALSE
 2002-08-17,Jordan,Kenya,1,1,Friendly,Amman,Jordan,FALSE
-2002-08-18,Dominican Republic,USA Virgin Islands,5,1,Gold Cup qualification,San Cristóbal,Dominican Republic,FALSE
+2002-08-18,Dominican Republic,United States Virgin Islands,5,1,Gold Cup qualification,San Cristóbal,Dominican Republic,FALSE
 2002-08-19,Jordan,Sudan,0,0,Friendly,Amman,Jordan,FALSE
 2002-08-20,Algeria,DR Congo,1,1,Friendly,Blida,Algeria,FALSE
 2002-08-20,Egypt,Uganda,2,0,Friendly,Alexandria,Egypt,FALSE
@@ -25455,7 +25455,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2002-11-15,Trinidad and Tobago,Saint Kitts and Nevis,2,0,Gold Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2002-11-17,Cayman Islands,Nicaragua,0,1,Friendly,George Town,Cayman Islands,FALSE
 2002-11-17,Trinidad and Tobago,Saint Lucia,0,1,Gold Cup qualification,Macoya,Trinidad and Tobago,FALSE
-2002-11-17,USA,El Salvador,2,0,Friendly,Washington,USA,FALSE
+2002-11-17,United States,El Salvador,2,0,Friendly,Washington,United States,FALSE
 2002-11-18,Haiti,Antigua and Barbuda,1,0,Gold Cup qualification,Port-au-Prince,Haiti,FALSE
 2002-11-19,South Africa,Senegal,1,1,Friendly,Johannesburg,South Africa,FALSE
 2002-11-20,Antigua and Barbuda,Curaçao,1,1,Gold Cup qualification,Port-au-Prince,Haiti,TRUE
@@ -25596,11 +25596,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-01-14,India,Sri Lanka,1,1,SAFF Cup,Dhaka,Bangladesh,TRUE
 2003-01-15,Bangladesh,Bhutan,3,0,SAFF Cup,Dhaka,Bangladesh,FALSE
 2003-01-15,Nepal,Maldives,2,3,SAFF Cup,Dhaka,Bangladesh,TRUE
-2003-01-17,El Salvador,Guatemala,0,0,Friendly,Santa Ana,USA,TRUE
+2003-01-17,El Salvador,Guatemala,0,0,Friendly,Santa Ana,United States,TRUE
 2003-01-18,Bangladesh,India,2,1,SAFF Cup,Dhaka,Bangladesh,FALSE
 2003-01-18,Pakistan,Maldives,0,1,SAFF Cup,Dhaka,Bangladesh,TRUE
-2003-01-18,USA,Canada,4,0,Friendly,Fort Lauderdale,USA,FALSE
-2003-01-19,El Salvador,Guatemala,0,0,Friendly,Los Angeles,USA,TRUE
+2003-01-18,United States,Canada,4,0,Friendly,Fort Lauderdale,United States,FALSE
+2003-01-19,El Salvador,Guatemala,0,0,Friendly,Los Angeles,United States,TRUE
 2003-01-20,Bangladesh,Maldives,1,1,SAFF Cup,Dhaka,Bangladesh,FALSE
 2003-01-20,Pakistan,India,1,2,SAFF Cup,Dhaka,Bangladesh,TRUE
 2003-01-25,Uganda,Algeria,0,1,Friendly,Kampala,Uganda,FALSE
@@ -25611,9 +25611,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-01-29,Cyprus,Greece,1,2,Friendly,Larnaca,Cyprus,FALSE
 2003-01-29,Trinidad and Tobago,Finland,1,2,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 2003-01-31,Honduras,Argentina,1,3,Friendly,San Pedro Sula,Honduras,FALSE
-2003-02-04,Mexico,Argentina,0,1,Friendly,Los Angeles,USA,TRUE
+2003-02-04,Mexico,Argentina,0,1,Friendly,Los Angeles,United States,TRUE
 2003-02-04,Uruguay,Iran,1,1,Lunar New Year Cup,So Kon Po,Hong Kong,TRUE
-2003-02-08,USA,Argentina,0,1,Friendly,Miami,USA,FALSE
+2003-02-08,United States,Argentina,0,1,Friendly,Miami,United States,FALSE
 2003-02-09,Croatia,North Macedonia,2,2,Friendly,Šibenik,Croatia,FALSE
 2003-02-09,Ecuador,Estonia,1,0,Friendly,Guayaquil,Ecuador,FALSE
 2003-02-09,Panama,El Salvador,1,2,UNCAF Cup,Panama City,Panama,FALSE
@@ -25636,11 +25636,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-02-12,Guinea,Mali,0,1,Friendly,Toulon,France,TRUE
 2003-02-12,Israel,Armenia,2,0,Friendly,Ramat-Gan,Israel,FALSE
 2003-02-12,Italy,Portugal,1,0,Friendly,Genoa,Italy,FALSE
-2003-02-12,Jamaica,USA,1,2,Friendly,Kingston,Jamaica,FALSE
+2003-02-12,Jamaica,United States,1,2,Friendly,Kingston,Jamaica,FALSE
 2003-02-12,Latvia,Lithuania,2,1,Friendly,Antalya,Turkey,TRUE
 2003-02-12,Libya,Canada,2,4,Friendly,Tripoli,Libya,FALSE
 2003-02-12,Malta,Kazakhstan,2,2,Friendly,Attard,Malta,FALSE
-2003-02-12,Mexico,Colombia,0,0,Friendly,Phoenix,USA,TRUE
+2003-02-12,Mexico,Colombia,0,0,Friendly,Phoenix,United States,TRUE
 2003-02-12,Morocco,Senegal,1,0,Friendly,Paris,France,TRUE
 2003-02-12,Netherlands,Argentina,1,0,Friendly,Amsterdam,Netherlands,FALSE
 2003-02-12,Northern Ireland,Finland,0,1,Friendly,Belfast,Northern Ireland,FALSE
@@ -25709,7 +25709,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-03-16,Zimbabwe,Malawi,0,0,Friendly,Harare,Zimbabwe,FALSE
 2003-03-18,Nepal,Afghanistan,4,0,AFC Asian Cup qualification,Kathmandu,Nepal,FALSE
 2003-03-19,Egypt,Qatar,6,0,Friendly,Port Said,Egypt,FALSE
-2003-03-19,Mexico,Bolivia,2,0,Friendly,Dallas,USA,TRUE
+2003-03-19,Mexico,Bolivia,2,0,Friendly,Dallas,United States,TRUE
 2003-03-19,Eswatini,Lesotho,1,0,Friendly,Lobamba,Eswatini,FALSE
 2003-03-20,Nepal,Kyrgyzstan,0,2,AFC Asian Cup qualification,Kathmandu,Nepal,FALSE
 2003-03-21,Macau,Pakistan,0,3,AFC Asian Cup qualification,Singapore,Singapore,TRUE
@@ -25733,7 +25733,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-03-26,Guadeloupe,Cuba,2,3,Gold Cup qualification,Port of Spain,Trinidad and Tobago,TRUE
 2003-03-26,Haiti,Martinique,2,1,Gold Cup qualification,Kingston,Jamaica,TRUE
 2003-03-26,Jamaica,Saint Lucia,5,0,Gold Cup qualification,Kingston,Jamaica,FALSE
-2003-03-26,Mexico,Paraguay,1,1,Friendly,San Diego,USA,TRUE
+2003-03-26,Mexico,Paraguay,1,1,Friendly,San Diego,United States,TRUE
 2003-03-26,Trinidad and Tobago,Antigua and Barbuda,2,0,Gold Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2003-03-27,Cameroon,Madagascar,2,0,Friendly,Tunis,Tunisia,TRUE
 2003-03-27,Laos,Bangladesh,2,1,AFC Asian Cup qualification,Kowloon,Hong Kong,TRUE
@@ -25776,7 +25776,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-03-29,Sudan,Benin,3,0,African Cup of Nations qualification,Khartoum,Sudan,FALSE
 2003-03-29,Tanzania,Zambia,0,1,African Cup of Nations qualification,Dar es Salaam,Tanzania,FALSE
 2003-03-29,Ukraine,Spain,2,2,UEFA Euro qualification,Kyiv,Ukraine,FALSE
-2003-03-29,USA,Venezuela,2,0,Friendly,Seattle,USA,FALSE
+2003-03-29,United States,Venezuela,2,0,Friendly,Seattle,United States,FALSE
 2003-03-29,Wales,Azerbaijan,4,0,UEFA Euro qualification,Cardiff,Wales,FALSE
 2003-03-30,Burundi,Ivory Coast,0,1,African Cup of Nations qualification,Bujumbura,Burundi,FALSE
 2003-03-30,Chad,Namibia,2,0,African Cup of Nations qualification,N'Djamena,Chad,FALSE
@@ -25842,7 +25842,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-04-30,France,Egypt,5,0,Friendly,Saint-Denis,France,FALSE
 2003-04-30,Georgia,Russia,1,0,UEFA Euro qualification,Tbilisi,Georgia,FALSE
 2003-04-30,Germany,Serbia,1,0,Friendly,Bremen,Germany,FALSE
-2003-04-30,Honduras,Colombia,0,0,Friendly,Miami,USA,TRUE
+2003-04-30,Honduras,Colombia,0,0,Friendly,Miami,United States,TRUE
 2003-04-30,Hungary,Luxembourg,5,1,Friendly,Budapest,Hungary,FALSE
 2003-04-30,Republic of Ireland,Norway,1,0,Friendly,Dublin,Republic of Ireland,FALSE
 2003-04-30,Israel,Cyprus,2,0,UEFA Euro qualification,Palermo,Italy,TRUE
@@ -25867,7 +25867,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-05-01,Fiji,Tuvalu,9,0,Friendly,Suva,Fiji,FALSE
 2003-05-04,Congo,Central African Republic,2,1,African Cup of Nations qualification,Brazzaville,Congo,FALSE
 2003-05-05,Guernsey,Jersey,3,3,Friendly,St. Sampson,Guernsey,FALSE
-2003-05-08,USA,Mexico,0,0,Friendly,Houston,USA,FALSE
+2003-05-08,United States,Mexico,0,0,Friendly,Houston,United States,FALSE
 2003-05-16,Lesotho,Botswana,1,2,Friendly,Maseru,Lesotho,FALSE
 2003-05-17,Malawi,Zambia,0,1,Friendly,Blantyre,Malawi,FALSE
 2003-05-18,Jersey,Guernsey,1,0,Friendly,St. Helier,Jersey,FALSE
@@ -25880,7 +25880,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-05-25,Jamaica,Nigeria,3,2,Friendly,Kingston,Jamaica,FALSE
 2003-05-25,Lesotho,Eswatini,2,1,Friendly,Maseru,Lesotho,FALSE
 2003-05-25,Togo,Benin,3,1,Friendly,Lomé,Togo,FALSE
-2003-05-26,USA,Wales,2,0,Friendly,San Jose,USA,FALSE
+2003-05-26,United States,Wales,2,0,Friendly,San Jose,United States,FALSE
 2003-05-27,Scotland,New Zealand,1,1,Friendly,Edinburgh,Scotland,FALSE
 2003-05-29,Algeria,Burkina Faso,0,1,Friendly,Amiens,France,TRUE
 2003-05-30,Nigeria,Ghana,3,1,Friendly,Abuja,Nigeria,FALSE
@@ -25926,7 +25926,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-06-07,Switzerland,Russia,2,2,UEFA Euro qualification,Basel,Switzerland,FALSE
 2003-06-07,Uganda,Rwanda,0,1,African Cup of Nations qualification,Kampala,Uganda,FALSE
 2003-06-07,Ukraine,Armenia,4,3,UEFA Euro qualification,Lviv,Ukraine,FALSE
-2003-06-07,Venezuela,Honduras,2,1,Friendly,Miami,USA,TRUE
+2003-06-07,Venezuela,Honduras,2,1,Friendly,Miami,United States,TRUE
 2003-06-07,Zambia,Tanzania,2,0,African Cup of Nations qualification,Lusaka,Zambia,FALSE
 2003-06-08,Benin,Sudan,3,0,African Cup of Nations qualification,Cotonou,Benin,FALSE
 2003-06-08,Central African Republic,Congo,0,0,African Cup of Nations qualification,Bangui,Central African Republic,FALSE
@@ -25941,14 +25941,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-06-08,Liberia,Ethiopia,1,0,African Cup of Nations qualification,Monrovia,Liberia,FALSE
 2003-06-08,Morocco,Sierra Leone,1,0,African Cup of Nations qualification,Casablanca,Morocco,FALSE
 2003-06-08,Togo,Cape Verde,5,2,African Cup of Nations qualification,Lomé,Togo,FALSE
-2003-06-08,USA,New Zealand,2,1,Friendly,Richmond,USA,FALSE
+2003-06-08,United States,New Zealand,2,1,Friendly,Richmond,United States,FALSE
 2003-06-10,Botswana,Trinidad and Tobago,0,0,Friendly,Gaborone,Botswana,FALSE
 2003-06-10,Portugal,Bolivia,4,0,Friendly,Oeiras,Portugal,FALSE
 2003-06-11,Austria,Belarus,5,0,UEFA Euro qualification,Innsbruck,Austria,FALSE
 2003-06-11,Azerbaijan,Serbia,2,1,UEFA Euro qualification,Baku,Azerbaijan,FALSE
 2003-06-11,Belgium,Andorra,3,0,UEFA Euro qualification,Ghent,Belgium,FALSE
 2003-06-11,Czech Republic,Moldova,5,0,UEFA Euro qualification,Olomouc,Czech Republic,FALSE
-2003-06-11,Ecuador,Peru,2,2,Friendly,East Rutherford,USA,TRUE
+2003-06-11,Ecuador,Peru,2,2,Friendly,East Rutherford,United States,TRUE
 2003-06-11,England,Slovakia,2,1,UEFA Euro qualification,Middlesbrough,England,FALSE
 2003-06-11,Estonia,Croatia,0,1,UEFA Euro qualification,Tallinn,Estonia,FALSE
 2003-06-11,Faroe Islands,Germany,0,2,UEFA Euro qualification,Tórshavn,Faroe Islands,FALSE
@@ -25975,13 +25975,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-06-18,France,Colombia,1,0,Confederations Cup,Lyon,France,FALSE
 2003-06-18,New Zealand,Japan,0,3,Confederations Cup,Saint-Denis,France,TRUE
 2003-06-19,Brazil,Cameroon,0,1,Confederations Cup,Saint-Denis,France,TRUE
-2003-06-19,Turkey,USA,2,1,Confederations Cup,Saint-Étienne,France,TRUE
+2003-06-19,Turkey,United States,2,1,Confederations Cup,Saint-Étienne,France,TRUE
 2003-06-20,Algeria,Namibia,1,0,African Cup of Nations qualification,Blida,Algeria,FALSE
 2003-06-20,Colombia,New Zealand,3,1,Confederations Cup,Lyon,France,TRUE
 2003-06-20,Egypt,Madagascar,6,0,African Cup of Nations qualification,Port Said,Egypt,FALSE
 2003-06-20,France,Japan,2,1,Confederations Cup,Saint-Étienne,France,FALSE
 2003-06-20,Morocco,Gabon,2,0,African Cup of Nations qualification,Rabat,Morocco,FALSE
-2003-06-21,Brazil,USA,1,0,Confederations Cup,Lyon,France,TRUE
+2003-06-21,Brazil,United States,1,0,Confederations Cup,Lyon,France,TRUE
 2003-06-21,Burkina Faso,Congo,3,0,African Cup of Nations qualification,Ouagadougou,Burkina Faso,FALSE
 2003-06-21,Cameroon,Turkey,1,0,Confederations Cup,Saint-Denis,France,TRUE
 2003-06-21,Cape Verde,Mauritania,3,0,African Cup of Nations qualification,Praia,Cape Verde,FALSE
@@ -25993,7 +25993,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-06-22,Ethiopia,Niger,2,0,African Cup of Nations qualification,Addis Ababa,Ethiopia,FALSE
 2003-06-22,France,New Zealand,5,0,Confederations Cup,Saint-Denis,France,FALSE
 2003-06-22,Ghana,Uganda,1,1,African Cup of Nations qualification,Kumasi,Ghana,FALSE
-2003-06-22,Guatemala,Honduras,1,2,Friendly,Carson,USA,TRUE
+2003-06-22,Guatemala,Honduras,1,2,Friendly,Carson,United States,TRUE
 2003-06-22,Japan,Colombia,0,1,Confederations Cup,Saint-Étienne,France,TRUE
 2003-06-22,Mali,Zimbabwe,0,0,African Cup of Nations qualification,Bamako,Mali,FALSE
 2003-06-22,Mozambique,Central African Republic,1,0,African Cup of Nations qualification,Maputo,Mozambique,FALSE
@@ -26003,10 +26003,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-06-22,Tanzania,Benin,0,1,African Cup of Nations qualification,Dar es Salaam,Tanzania,FALSE
 2003-06-22,Togo,Kenya,2,0,African Cup of Nations qualification,Lomé,Togo,FALSE
 2003-06-23,Brazil,Turkey,2,2,Confederations Cup,Saint-Étienne,France,TRUE
-2003-06-23,USA,Cameroon,0,0,Confederations Cup,Lyon,France,TRUE
+2003-06-23,United States,Cameroon,0,0,Confederations Cup,Lyon,France,TRUE
 2003-06-26,Cameroon,Colombia,1,0,Confederations Cup,Lyon,France,TRUE
 2003-06-26,France,Turkey,3,2,Confederations Cup,Saint-Denis,France,FALSE
-2003-06-26,Peru,Venezuela,1,0,Friendly,Miami,USA,TRUE
+2003-06-26,Peru,Venezuela,1,0,Friendly,Miami,United States,TRUE
 2003-06-27,Panama,Cuba,2,0,Friendly,Panama City,Panama,FALSE
 2003-06-28,Colombia,Turkey,1,2,Confederations Cup,Saint-Étienne,France,TRUE
 2003-06-29,France,Cameroon,1,0,Confederations Cup,Saint-Denis,France,FALSE
@@ -26038,8 +26038,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-07-01,Orkney,Alderney,3,1,Island Games,St. Sampson,Guernsey,TRUE
 2003-07-01,Isle of Wight,Gibraltar,2,1,Island Games,St. Martin,Guernsey,TRUE
 2003-07-01,Greenland,Sark,16,0,Island Games,St. Martin,Guernsey,TRUE
-2003-07-02,El Salvador,Paraguay,0,1,Friendly,San Francisco,USA,TRUE
-2003-07-02,Guatemala,Peru,1,2,Friendly,San Francisco,USA,TRUE
+2003-07-02,El Salvador,Paraguay,0,1,Friendly,San Francisco,United States,TRUE
+2003-07-02,Guatemala,Peru,1,2,Friendly,San Francisco,United States,TRUE
 2003-07-03,Estonia,Lithuania,1,5,Baltic Cup,Valga,Estonia,FALSE
 2003-07-03,Solomon Islands,Kiribati,7,0,South Pacific Games,Suva,Fiji,TRUE
 2003-07-03,Tahiti,Papua New Guinea,3,0,South Pacific Games,Suva,Fiji,TRUE
@@ -26077,7 +26077,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-07-06,Central African Republic,Burkina Faso,0,3,African Cup of Nations qualification,Bangui,Central African Republic,FALSE
 2003-07-06,Chad,Algeria,0,0,African Cup of Nations qualification,N'Djamena,Chad,FALSE
 2003-07-06,Congo,Mozambique,0,0,African Cup of Nations qualification,Brazzaville,Congo,FALSE
-2003-07-06,El Salvador,Mexico,2,1,Friendly,Carson,USA,TRUE
+2003-07-06,El Salvador,Mexico,2,1,Friendly,Carson,United States,TRUE
 2003-07-06,Equatorial Guinea,Morocco,0,1,African Cup of Nations qualification,Malabo,Equatorial Guinea,FALSE
 2003-07-06,Gabon,Sierra Leone,2,0,African Cup of Nations qualification,Libreville,Gabon,FALSE
 2003-07-06,Guinea,Ethiopia,3,0,African Cup of Nations qualification,Conakry,Guinea,FALSE
@@ -26085,41 +26085,41 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-07-06,Lesotho,Gambia,1,0,African Cup of Nations qualification,Maseru,Lesotho,FALSE
 2003-07-06,Madagascar,Mauritius,0,2,African Cup of Nations qualification,Antananarivo,Madagascar,FALSE
 2003-07-06,Rwanda,Ghana,1,0,African Cup of Nations qualification,Kigali,Rwanda,FALSE
-2003-07-06,USA,Paraguay,2,0,Friendly,Columbus,USA,FALSE
+2003-07-06,United States,Paraguay,2,0,Friendly,Columbus,United States,FALSE
 2003-07-07,Fiji,Solomon Islands,2,1,South Pacific Games,Lautoka,Fiji,FALSE
 2003-07-07,Kiribati,Vanuatu,0,18,South Pacific Games,Lautoka,Fiji,TRUE
 2003-07-07,Papua New Guinea,Micronesia,10,0,South Pacific Games,Lautoka,Fiji,TRUE
 2003-07-07,Tahiti,Tonga,4,0,South Pacific Games,Lautoka,Fiji,TRUE
-2003-07-08,El Salvador,Guatemala,1,2,Friendly,Houston,USA,TRUE
+2003-07-08,El Salvador,Guatemala,1,2,Friendly,Houston,United States,TRUE
 2003-07-09,Fiji,Tahiti,2,1,South Pacific Games,Lautoka,Fiji,FALSE
 2003-07-09,Jamaica,Paraguay,2,0,Friendly,Kingston,Jamaica,FALSE
 2003-07-09,New Caledonia,Vanuatu,1,1,South Pacific Games,Lautoka,Fiji,TRUE
 2003-07-11,Fiji,New Caledonia,2,0,South Pacific Games,Suva,Fiji,FALSE
 2003-07-11,Tahiti,Vanuatu,0,1,South Pacific Games,Suva,Fiji,TRUE
-2003-07-12,Costa Rica,Canada,0,1,Gold Cup,Foxborough,USA,TRUE
-2003-07-12,USA,El Salvador,2,0,Gold Cup,Foxborough,USA,FALSE
-2003-07-13,Jamaica,Colombia,0,1,Gold Cup,Miami,USA,TRUE
+2003-07-12,Costa Rica,Canada,0,1,Gold Cup,Foxborough,United States,TRUE
+2003-07-12,United States,El Salvador,2,0,Gold Cup,Foxborough,United States,FALSE
+2003-07-13,Jamaica,Colombia,0,1,Gold Cup,Miami,United States,TRUE
 2003-07-13,Mexico,Brazil,1,0,Gold Cup,Mexico City,Mexico,FALSE
 2003-07-13,Eswatini,Madagascar,2,0,COSAFA Cup,Lobamba,Eswatini,FALSE
-2003-07-14,Canada,Cuba,0,2,Gold Cup,Foxborough,USA,TRUE
-2003-07-14,USA,Martinique,2,0,Gold Cup,Foxborough,USA,FALSE
+2003-07-14,Canada,Cuba,0,2,Gold Cup,Foxborough,United States,TRUE
+2003-07-14,United States,Martinique,2,0,Gold Cup,Foxborough,United States,FALSE
 2003-07-15,Brazil,Honduras,2,1,Gold Cup,Mexico City,Mexico,TRUE
-2003-07-15,Guatemala,Jamaica,0,2,Gold Cup,Miami,USA,TRUE
+2003-07-15,Guatemala,Jamaica,0,2,Gold Cup,Miami,United States,TRUE
 2003-07-16,Argentina,Uruguay,2,2,Friendly,La Plata,Argentina,FALSE
-2003-07-16,Cuba,Costa Rica,0,3,Gold Cup,Foxborough,USA,TRUE
-2003-07-16,El Salvador,Martinique,1,0,Gold Cup,Foxborough,USA,TRUE
-2003-07-17,Colombia,Guatemala,1,1,Gold Cup,Miami,USA,TRUE
+2003-07-16,Cuba,Costa Rica,0,3,Gold Cup,Foxborough,United States,TRUE
+2003-07-16,El Salvador,Martinique,1,0,Gold Cup,Foxborough,United States,TRUE
+2003-07-17,Colombia,Guatemala,1,1,Gold Cup,Miami,United States,TRUE
 2003-07-17,Mexico,Honduras,0,0,Gold Cup,Mexico City,Mexico,FALSE
-2003-07-19,Colombia,Brazil,0,2,Gold Cup,Miami,USA,TRUE
-2003-07-19,Costa Rica,El Salvador,5,2,Gold Cup,Foxborough,USA,TRUE
+2003-07-19,Colombia,Brazil,0,2,Gold Cup,Miami,United States,TRUE
+2003-07-19,Costa Rica,El Salvador,5,2,Gold Cup,Foxborough,United States,TRUE
 2003-07-19,South Africa,Zimbabwe,0,1,COSAFA Cup,East London,South Africa,FALSE
-2003-07-19,USA,Cuba,5,0,Gold Cup,Foxborough,USA,FALSE
+2003-07-19,United States,Cuba,5,0,Gold Cup,Foxborough,United States,FALSE
 2003-07-20,Mexico,Jamaica,5,0,Gold Cup,Mexico City,Mexico,FALSE
-2003-07-23,USA,Brazil,1,2,Gold Cup,Miami,USA,FALSE
+2003-07-23,United States,Brazil,1,2,Gold Cup,Miami,United States,FALSE
 2003-07-24,Mexico,Costa Rica,2,0,Gold Cup,Mexico City,Mexico,FALSE
 2003-07-24,Peru,Uruguay,3,4,Friendly,Lima,Peru,FALSE
 2003-07-26,Nigeria,Venezuela,1,0,Friendly,Watford,England,TRUE
-2003-07-26,USA,Costa Rica,3,2,Gold Cup,Miami,USA,FALSE
+2003-07-26,United States,Costa Rica,3,2,Gold Cup,Miami,United States,FALSE
 2003-07-27,Zambia,Mozambique,4,2,COSAFA Cup,Lusaka,Zambia,FALSE
 2003-07-27,Mexico,Brazil,1,0,Gold Cup,Mexico City,Mexico,FALSE
 2003-07-29,Saint Kitts and Nevis,Haiti,1,0,SKN Football Festival,Basseterre,Saint Kitts and Nevis,FALSE
@@ -26140,7 +26140,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-08-20,Belgium,Netherlands,1,1,Friendly,Brussels,Belgium,FALSE
 2003-08-20,Bulgaria,Lithuania,3,0,Friendly,Sofia,Bulgaria,FALSE
 2003-08-20,China PR,Chile,0,0,Friendly,Tianjin,China PR,FALSE
-2003-08-20,Colombia,Slovakia,0,0,Friendly,New York,USA,TRUE
+2003-08-20,Colombia,Slovakia,0,0,Friendly,New York,United States,TRUE
 2003-08-20,Denmark,Finland,1,1,Friendly,Copenhagen,Denmark,FALSE
 2003-08-20,Ecuador,Guatemala,2,0,Friendly,Ambato,Ecuador,FALSE
 2003-08-20,England,Croatia,3,1,Friendly,Ipswich,England,FALSE
@@ -26151,7 +26151,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-08-20,Latvia,Uzbekistan,0,3,Friendly,Riga,Latvia,FALSE
 2003-08-20,Liechtenstein,San Marino,2,2,Friendly,Vaduz,Liechtenstein,FALSE
 2003-08-20,North Macedonia,Albania,3,1,Friendly,Prilep,North Macedonia,FALSE
-2003-08-20,Mexico,Peru,1,3,Friendly,East Rutherford,USA,TRUE
+2003-08-20,Mexico,Peru,1,3,Friendly,East Rutherford,United States,TRUE
 2003-08-20,Norway,Scotland,0,0,Friendly,Oslo,Norway,FALSE
 2003-08-20,Panama,Paraguay,1,2,Friendly,Panama City,Panama,FALSE
 2003-08-20,Portugal,Kazakhstan,1,0,Friendly,Chaves,Portugal,FALSE
@@ -26168,7 +26168,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-08-26,Jordan,Iraq,2,1,Friendly,Amman,Jordan,FALSE
 2003-08-27,Peru,Guatemala,0,0,Friendly,Lima,Peru,FALSE
 2003-08-31,Bolivia,Panama,3,0,Friendly,La Paz,Bolivia,FALSE
-2003-08-31,Haiti,China PR,4,3,Friendly,Fort Lauderdale,USA,TRUE
+2003-08-31,Haiti,China PR,4,3,Friendly,Fort Lauderdale,United States,TRUE
 2003-08-31,Zimbabwe,Eswatini,2,0,COSAFA Cup,Bulawayo,Zimbabwe,FALSE
 2003-09-04,Algeria,Qatar,1,0,Friendly,Dinard,France,TRUE
 2003-09-04,North Korea,Lebanon,0,1,AFC Asian Cup qualification,Pyongyang,North Korea,FALSE
@@ -26202,7 +26202,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-09-07,Angola,Namibia,2,0,Friendly,Luanda,Angola,FALSE
 2003-09-07,Australia,Jamaica,2,1,Friendly,Reading,England,TRUE
 2003-09-07,Colombia,Brazil,1,2,FIFA World Cup qualification,Barranquilla,Colombia,FALSE
-2003-09-07,Costa Rica,China PR,2,0,Friendly,Fort Lauderdale,USA,TRUE
+2003-09-07,Costa Rica,China PR,2,0,Friendly,Fort Lauderdale,United States,TRUE
 2003-09-07,Uruguay,Bolivia,5,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 2003-09-09,Chile,Peru,2,1,FIFA World Cup qualification,Santiago,Chile,FALSE
 2003-09-09,Republic of Ireland,Turkey,2,2,Friendly,Dublin,Republic of Ireland,FALSE
@@ -26284,7 +26284,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-10-11,Armenia,Spain,0,4,UEFA Euro qualification,Yerevan,Armenia,FALSE
 2003-10-11,Austria,Czech Republic,2,3,UEFA Euro qualification,Vienna,Austria,FALSE
 2003-10-11,Belgium,Estonia,2,0,UEFA Euro qualification,Liège,Belgium,FALSE
-2003-10-11,Bolivia,Honduras,1,0,Friendly,Washington,USA,TRUE
+2003-10-11,Bolivia,Honduras,1,0,Friendly,Washington,United States,TRUE
 2003-10-11,Bosnia and Herzegovina,Denmark,1,1,UEFA Euro qualification,Sarajevo,Bosnia and Herzegovina,FALSE
 2003-10-11,Botswana,Lesotho,4,1,FIFA World Cup qualification,Gaborone,Botswana,FALSE
 2003-10-11,Croatia,Bulgaria,1,0,UEFA Euro qualification,Zagreb,Croatia,FALSE
@@ -26335,7 +26335,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-10-13,Bhutan,Indonesia,0,2,AFC Asian Cup qualification,Jeddah,Saudi Arabia,TRUE
 2003-10-13,Saudi Arabia,Yemen,3,1,AFC Asian Cup qualification,Jeddah,Saudi Arabia,FALSE
 2003-10-15,Indonesia,Yemen,2,2,AFC Asian Cup qualification,Jeddah,Saudi Arabia,TRUE
-2003-10-15,Mexico,Uruguay,0,2,Friendly,Chicago,USA,TRUE
+2003-10-15,Mexico,Uruguay,0,2,Friendly,Chicago,United States,TRUE
 2003-10-15,Saudi Arabia,Bhutan,4,0,AFC Asian Cup qualification,Jeddah,Saudi Arabia,FALSE
 2003-10-15,Syria,Sri Lanka,5,0,AFC Asian Cup qualification,Damascus,Syria,FALSE
 2003-10-16,Thailand,India,2,0,Friendly,Bangkok,Thailand,FALSE
@@ -26412,7 +26412,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-11-16,England,Denmark,2,3,Friendly,Manchester,England,FALSE
 2003-11-16,Eritrea,Sudan,0,0,FIFA World Cup qualification,Asmara,Eritrea,FALSE
 2003-11-16,Ghana,Somalia,5,0,FIFA World Cup qualification,Accra,Ghana,FALSE
-2003-11-16,Honduras,Finland,1,2,Friendly,Houston,USA,TRUE
+2003-11-16,Honduras,Finland,1,2,Friendly,Houston,United States,TRUE
 2003-11-16,Italy,Romania,1,0,Friendly,Ancona,Italy,FALSE
 2003-11-16,Jamaica,El Salvador,3,0,Friendly,Kingston,Jamaica,FALSE
 2003-11-16,Lesotho,Botswana,0,0,FIFA World Cup qualification,Maseru,Lesotho,FALSE
@@ -26442,7 +26442,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-11-19,Hungary,Estonia,0,1,Friendly,Budapest,Hungary,FALSE
 2003-11-19,Japan,Cameroon,0,0,Friendly,Ōita,Japan,FALSE
 2003-11-19,Lebanon,Iran,0,3,AFC Asian Cup qualification,Beirut,Lebanon,FALSE
-2003-11-19,Mexico,Iceland,0,0,Friendly,San Francisco,USA,TRUE
+2003-11-19,Mexico,Iceland,0,0,Friendly,San Francisco,United States,TRUE
 2003-11-19,Morocco,Mali,0,1,Friendly,Casablanca,Morocco,FALSE
 2003-11-19,Netherlands,Scotland,6,0,UEFA Euro qualification,Amsterdam,Netherlands,FALSE
 2003-11-19,Norway,Spain,0,3,UEFA Euro qualification,Oslo,Norway,FALSE
@@ -26508,7 +26508,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2003-12-26,Bermuda,Barbados,1,2,Friendly,Hamilton,Bermuda,FALSE
 2003-12-26,Kuwait,Oman,0,0,Gulf Cup,Kuwait City,Kuwait,FALSE
 2003-12-26,United Arab Emirates,Saudi Arabia,0,2,Gulf Cup,Kuwait City,Kuwait,TRUE
-2003-12-27,Bahamas,Haiti,0,6,Friendly,Miami,USA,TRUE
+2003-12-27,Bahamas,Haiti,0,6,Friendly,Miami,United States,TRUE
 2003-12-27,Bahrain,Qatar,0,0,Gulf Cup,Kuwait City,Kuwait,TRUE
 2003-12-27,Basque Country,Uruguay,2,1,Friendly,Bilbao,Spain,FALSE
 2003-12-27,Andalusia,Latvia,1,0,Friendly,Huelva,Spain,FALSE
@@ -26569,12 +26569,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-01-29,Algeria,Egypt,2,1,African Cup of Nations,Sousse,Tunisia,TRUE
 2004-01-29,Cameroon,Zimbabwe,5,3,African Cup of Nations,Sfax,Tunisia,TRUE
 2004-01-29,China PR,North Macedonia,1,0,Friendly,Suzhou,China PR,FALSE
-2004-01-30,British Virgin Islands,USA Virgin Islands,5,0,Friendly,Road Town,British Virgin Islands,FALSE
+2004-01-30,British Virgin Islands,United States Virgin Islands,5,0,Friendly,Road Town,British Virgin Islands,FALSE
 2004-01-30,Burkina Faso,Mali,1,3,African Cup of Nations,Tunis,Tunisia,TRUE
 2004-01-30,Senegal,Kenya,3,0,African Cup of Nations,Bizerte,Tunisia,TRUE
-2004-01-31,Dominica,USA Virgin Islands,5,0,Friendly,Spanish Town,British Virgin Islands,TRUE
+2004-01-31,Dominica,United States Virgin Islands,5,0,Friendly,Spanish Town,British Virgin Islands,TRUE
 2004-01-31,Grenada,Barbados,0,1,Friendly,St. George's,Grenada,FALSE
-2004-01-31,Haiti,Nicaragua,1,1,Friendly,West Palm Beach,USA,TRUE
+2004-01-31,Haiti,Nicaragua,1,1,Friendly,West Palm Beach,United States,TRUE
 2004-01-31,Morocco,Benin,4,0,African Cup of Nations,Sfax,Tunisia,TRUE
 2004-01-31,Nigeria,South Africa,4,0,African Cup of Nations,Monastir,Tunisia,TRUE
 2004-02-01,British Virgin Islands,Dominica,1,2,Friendly,Road Town,British Virgin Islands,FALSE
@@ -26618,7 +26618,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-02-18,Cyprus,Belarus,0,2,Cyprus International Tournament,Achna,Cyprus,FALSE
 2004-02-18,Estonia,Moldova,1,0,Malta International Tournament,Attard,Malta,TRUE
 2004-02-18,Greece,Bulgaria,2,0,Friendly,Athens,Greece,FALSE
-2004-02-18,Haiti,Turks and Caicos Islands,5,0,FIFA World Cup qualification,Miami,USA,TRUE
+2004-02-18,Haiti,Turks and Caicos Islands,5,0,FIFA World Cup qualification,Miami,United States,TRUE
 2004-02-18,Honduras,Colombia,1,1,Friendly,Tegucigalpa,Honduras,FALSE
 2004-02-18,Hungary,Armenia,2,0,Cyprus International Tournament,Paphos,Cyprus,TRUE
 2004-02-18,India,Singapore,1,0,FIFA World Cup qualification,Margao,India,FALSE
@@ -26634,9 +26634,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-02-18,Libya,Ukraine,1,1,Friendly,Tripoli,Libya,FALSE
 2004-02-18,North Macedonia,Bosnia and Herzegovina,1,0,Friendly,Skopje,North Macedonia,FALSE
 2004-02-18,Malaysia,Hong Kong,1,3,FIFA World Cup qualification,Kuantan,Malaysia,FALSE
-2004-02-18,Mexico,Chile,1,1,Friendly,Carson,USA,TRUE
+2004-02-18,Mexico,Chile,1,1,Friendly,Carson,United States,TRUE
 2004-02-18,Morocco,Switzerland,2,1,Friendly,Rabat,Morocco,FALSE
-2004-02-18,Netherlands,USA,1,0,Friendly,Amsterdam,Netherlands,FALSE
+2004-02-18,Netherlands,United States,1,0,Friendly,Amsterdam,Netherlands,FALSE
 2004-02-18,Northern Ireland,Norway,1,4,Friendly,Belfast,Northern Ireland,FALSE
 2004-02-18,Palestine,Taiwan,8,0,FIFA World Cup qualification,Al Wakrah,Qatar,TRUE
 2004-02-18,Poland,Slovenia,2,0,Friendly,San Fernando,Spain,TRUE
@@ -26649,7 +26649,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-02-18,Uzbekistan,Iraq,1,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2004-02-18,Venezuela,Australia,1,1,Friendly,Caracas,Venezuela,FALSE
 2004-02-18,Vietnam,Maldives,4,0,FIFA World Cup qualification,Hanoi,Vietnam,FALSE
-2004-02-18,USA Virgin Islands,Saint Kitts and Nevis,0,4,FIFA World Cup qualification,Charlotte Amalie,USA Virgin Islands,FALSE
+2004-02-18,United States Virgin Islands,Saint Kitts and Nevis,0,4,FIFA World Cup qualification,Charlotte Amalie,United States Virgin Islands,FALSE
 2004-02-18,Wales,Scotland,4,0,Friendly,Cardiff,Wales,FALSE
 2004-02-18,Yemen,North Korea,1,1,FIFA World Cup qualification,Sana'a,Yemen,FALSE
 2004-02-19,Cyprus,Georgia,3,1,Cyprus International Tournament,Nicosia,Cyprus,FALSE
@@ -26659,7 +26659,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-02-21,Cyprus,Kazakhstan,2,1,Cyprus International Tournament,Limassol,Cyprus,FALSE
 2004-02-21,Georgia,Armenia,0,2,Cyprus International Tournament,Nicosia,Cyprus,TRUE
 2004-02-21,Poland,Faroe Islands,6,0,Friendly,San Fernando,Spain,TRUE
-2004-02-21,Turks and Caicos Islands,Haiti,0,2,FIFA World Cup qualification,Hialeah,USA,TRUE
+2004-02-21,Turks and Caicos Islands,Haiti,0,2,FIFA World Cup qualification,Hialeah,United States,TRUE
 2004-02-22,British Virgin Islands,Saint Lucia,0,1,FIFA World Cup qualification,Road Town,British Virgin Islands,FALSE
 2004-02-22,Cayman Islands,Cuba,1,2,FIFA World Cup qualification,George Town,Cayman Islands,FALSE
 2004-02-24,Faroe Islands,Luxembourg,4,2,Friendly,San Fernando,Spain,TRUE
@@ -26672,7 +26672,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-03-10,Mexico,Ecuador,2,1,Friendly,Tuxtla Gutiérrez,Mexico,FALSE
 2004-03-10,Venezuela,Honduras,2,1,Friendly,Maracaibo,Venezuela,FALSE
 2004-03-12,Barbados,Dominica,2,1,Friendly,Bridgetown,Barbados,FALSE
-2004-03-13,USA,Haiti,1,1,Friendly,Miami,USA,FALSE
+2004-03-13,United States,Haiti,1,1,Friendly,Miami,United States,FALSE
 2004-03-14,Guyana,Grenada,1,3,FIFA World Cup qualification,Blairmont,Guyana,FALSE
 2004-03-16,Cuba,Panama,1,1,Friendly,Havana,Cuba,FALSE
 2004-03-17,China PR,Myanmar,2,0,Friendly,Guangzhou,China PR,FALSE
@@ -26722,14 +26722,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-03-31,Malaysia,Kuwait,0,2,FIFA World Cup qualification,Kuantan,Malaysia,FALSE
 2004-03-31,Maldives,South Korea,0,0,FIFA World Cup qualification,Malé,Maldives,FALSE
 2004-03-31,Malta,Finland,1,2,Friendly,Attard,Malta,FALSE
-2004-03-31,Mexico,Costa Rica,2,0,Friendly,Carson,USA,TRUE
+2004-03-31,Mexico,Costa Rica,2,0,Friendly,Carson,United States,TRUE
 2004-03-31,Moldova,Azerbaijan,2,1,Friendly,Chișinău,Moldova,FALSE
 2004-03-31,Morocco,Angola,3,1,Friendly,Casablanca,Morocco,FALSE
 2004-03-31,Netherlands,France,0,0,Friendly,Rotterdam,Netherlands,FALSE
 2004-03-31,Palestine,Iraq,1,1,FIFA World Cup qualification,Al Wakrah,Qatar,TRUE
 2004-03-31,Paraguay,Brazil,0,0,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 2004-03-31,Peru,Colombia,0,2,FIFA World Cup qualification,Lima,Peru,FALSE
-2004-03-31,Poland,USA,0,1,Friendly,Płock,Poland,FALSE
+2004-03-31,Poland,United States,0,1,Friendly,Płock,Poland,FALSE
 2004-03-31,Portugal,Italy,1,2,Friendly,Braga,Portugal,FALSE
 2004-03-31,Scotland,Romania,1,2,Friendly,Glasgow,Scotland,FALSE
 2004-03-31,Serbia,Norway,0,1,Friendly,Belgrade,Serbia and Montenegro,FALSE
@@ -26738,7 +26738,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-03-31,Slovenia,Latvia,0,1,Friendly,Celje,Slovenia,FALSE
 2004-03-31,Spain,Denmark,2,0,Friendly,Gijón,Spain,FALSE
 2004-03-31,Sri Lanka,Saudi Arabia,0,1,FIFA World Cup qualification,Colombo,Sri Lanka,FALSE
-2004-03-31,Saint Kitts and Nevis,USA Virgin Islands,7,0,FIFA World Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
+2004-03-31,Saint Kitts and Nevis,United States Virgin Islands,7,0,FIFA World Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
 2004-03-31,Sweden,England,1,0,Friendly,Gothenburg,Sweden,FALSE
 2004-03-31,Tajikistan,Bahrain,0,0,FIFA World Cup qualification,Dushanbe,Tajikistan,FALSE
 2004-03-31,Tunisia,Ivory Coast,0,2,Friendly,Tunis,Tunisia,FALSE
@@ -26767,10 +26767,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-04-28,Chile,Peru,1,1,Friendly,Antofagasta,Chile,FALSE
 2004-04-28,Czech Republic,Japan,0,1,Friendly,Prague,Czech Republic,FALSE
 2004-04-28,Denmark,Scotland,1,0,Friendly,Copenhagen,Denmark,FALSE
-2004-04-28,El Salvador,Colombia,0,2,Friendly,Washington,USA,TRUE
+2004-04-28,El Salvador,Colombia,0,2,Friendly,Washington,United States,TRUE
 2004-04-28,Estonia,Albania,1,1,Friendly,Tallinn,Estonia,FALSE
 2004-04-28,Ghana,Angola,1,1,Friendly,Accra,Ghana,FALSE
-2004-04-28,Honduras,Ecuador,1,1,Friendly,Fort Lauderdale,USA,TRUE
+2004-04-28,Honduras,Ecuador,1,1,Friendly,Fort Lauderdale,United States,TRUE
 2004-04-28,Hungary,Brazil,1,4,Friendly,Budapest,Hungary,FALSE
 2004-04-28,Israel,Moldova,1,1,Friendly,Ramat-Gan,Israel,FALSE
 2004-04-28,Italy,Spain,1,1,Friendly,Genoa,Italy,FALSE
@@ -26793,7 +26793,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-04-28,Switzerland,Slovenia,2,1,Friendly,Geneva,Switzerland,FALSE
 2004-04-28,Tunisia,Mali,1,0,Friendly,Sfax,Tunisia,FALSE
 2004-04-28,Ukraine,Slovakia,1,1,Friendly,Kyiv,Ukraine,FALSE
-2004-04-28,USA,Mexico,1,0,Friendly,Dallas,USA,FALSE
+2004-04-28,United States,Mexico,1,0,Friendly,Dallas,United States,FALSE
 2004-04-30,Libya,Jordan,1,0,Friendly,Lagos,Nigeria,TRUE
 2004-04-30,Nicaragua,Bermuda,2,0,Friendly,Diriamba,Nicaragua,FALSE
 2004-05-01,Guatemala,Panama,1,2,Friendly,Guatemala,Guatemala,FALSE
@@ -26809,7 +26809,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-05-10,Solomon Islands,Tonga,6,0,FIFA World Cup qualification,Honiara,Solomon Islands,FALSE
 2004-05-10,Tahiti,Cook Islands,2,0,FIFA World Cup qualification,Honiara,Solomon Islands,TRUE
 2004-05-12,American Samoa,Vanuatu,1,9,FIFA World Cup qualification,Apia,Samoa,TRUE
-2004-05-12,El Salvador,Haiti,3,3,Friendly,Houston,USA,TRUE
+2004-05-12,El Salvador,Haiti,3,3,Friendly,Houston,United States,TRUE
 2004-05-12,Fiji,Papua New Guinea,4,2,FIFA World Cup qualification,Apia,Samoa,TRUE
 2004-05-12,Solomon Islands,Cook Islands,5,0,FIFA World Cup qualification,Honiara,Solomon Islands,FALSE
 2004-05-12,Tahiti,New Caledonia,0,0,FIFA World Cup qualification,Honiara,Solomon Islands,TRUE
@@ -26900,7 +26900,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-06-02,Saint Kitts and Nevis,Northern Ireland,0,2,Friendly,Basseterre,Saint Kitts and Nevis,FALSE
 2004-06-02,Switzerland,Germany,0,2,Friendly,Basel,Switzerland,FALSE
 2004-06-02,Tahiti,Solomon Islands,0,4,FIFA World Cup qualification,Adelaide,Australia,TRUE
-2004-06-02,USA,Honduras,4,0,Friendly,Foxborough,USA,FALSE
+2004-06-02,United States,Honduras,4,0,Friendly,Foxborough,United States,FALSE
 2004-06-03,Indonesia,India,1,1,Friendly,Jakarta,Indonesia,FALSE
 2004-06-03,Kuwait,Syria,1,2,Friendly,Kuwait City,Kuwait,FALSE
 2004-06-03,Liechtenstein,Greece,0,2,Friendly,Vaduz,Liechtenstein,FALSE
@@ -26964,7 +26964,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-06-11,Estonia,North Macedonia,2,4,Friendly,Tallinn,Estonia,FALSE
 2004-06-12,Cuba,Costa Rica,2,2,FIFA World Cup qualification,Havana,Cuba,FALSE
 2004-06-12,Curaçao,Honduras,1,2,FIFA World Cup qualification,Willemstad,Netherlands Antilles,TRUE
-2004-06-12,Haiti,Jamaica,1,1,FIFA World Cup qualification,Miami,USA,TRUE
+2004-06-12,Haiti,Jamaica,1,1,FIFA World Cup qualification,Miami,United States,TRUE
 2004-06-12,Portugal,Greece,1,2,UEFA Euro,Porto,Portugal,FALSE
 2004-06-12,Spain,Russia,1,0,UEFA Euro,Faro,Portugal,TRUE
 2004-06-12,Suriname,Guatemala,1,1,FIFA World Cup qualification,Paramaribo,Suriname,FALSE
@@ -26978,7 +26978,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-06-13,Mozambique,Malawi,2,0,COSAFA Cup,Maputo,Mozambique,FALSE
 2004-06-13,Panama,Saint Lucia,4,0,FIFA World Cup qualification,Panama City,Panama,FALSE
 2004-06-13,Switzerland,Croatia,0,0,UEFA Euro,Leiria,Portugal,TRUE
-2004-06-13,USA,Grenada,3,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2004-06-13,United States,Grenada,3,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2004-06-14,Denmark,Italy,0,0,UEFA Euro,Guimarães,Portugal,TRUE
 2004-06-14,Ghana,Togo,0,0,Friendly,Kumasi,Ghana,FALSE
 2004-06-14,Sweden,Bulgaria,5,0,UEFA Euro,Lisbon,Portugal,TRUE
@@ -26996,7 +26996,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-06-18,Libya,Cameroon,0,0,FIFA World Cup qualification,Misrata,Libya,FALSE
 2004-06-19,Botswana,Malawi,2,0,FIFA World Cup qualification,Gaborone,Botswana,FALSE
 2004-06-19,Cape Verde,Uganda,1,0,FIFA World Cup qualification,Praia,Cape Verde,FALSE
-2004-06-19,Dominica,Mexico,0,10,FIFA World Cup qualification,San Antonio,USA,TRUE
+2004-06-19,Dominica,Mexico,0,10,FIFA World Cup qualification,San Antonio,United States,TRUE
 2004-06-19,Honduras,Curaçao,4,0,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2004-06-19,Iraq,Palestine,2,1,WAFF Championship,Tehran,Iran,TRUE
 2004-06-19,Latvia,Germany,0,0,UEFA Euro,Porto,Portugal,TRUE
@@ -27013,7 +27013,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-06-20,Costa Rica,Cuba,1,1,FIFA World Cup qualification,Alajuela,Costa Rica,FALSE
 2004-06-20,Egypt,Ivory Coast,1,2,FIFA World Cup qualification,Alexandria,Egypt,FALSE
 2004-06-20,Ghana,South Africa,3,0,FIFA World Cup qualification,Kumasi,Ghana,FALSE
-2004-06-20,Grenada,USA,2,3,FIFA World Cup qualification,St. George's,Grenada,FALSE
+2004-06-20,Grenada,United States,2,3,FIFA World Cup qualification,St. George's,Grenada,FALSE
 2004-06-20,Guatemala,Suriname,3,1,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
 2004-06-20,Guinea,Tunisia,2,1,FIFA World Cup qualification,Conakry,Guinea,FALSE
 2004-06-20,Jamaica,Haiti,3,0,FIFA World Cup qualification,Kingston,Jamaica,FALSE
@@ -27038,11 +27038,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-06-25,Iran,Syria,4,1,WAFF Championship,Tehran,Iran,FALSE
 2004-06-25,Iraq,Jordan,1,3,WAFF Championship,Tehran,Iran,TRUE
 2004-06-26,Sweden,Netherlands,0,0,UEFA Euro,Faro,Portugal,TRUE
-2004-06-27,Argentina,Colombia,0,2,Friendly,Miami,USA,TRUE
+2004-06-27,Argentina,Colombia,0,2,Friendly,Miami,United States,TRUE
 2004-06-27,Czech Republic,Denmark,3,0,UEFA Euro,Porto,Portugal,TRUE
 2004-06-27,Mexico,Dominica,8,0,FIFA World Cup qualification,Aguascalientes,Mexico,FALSE
 2004-06-27,Eswatini,Zimbabwe,0,5,COSAFA Cup,Lobamba,Eswatini,FALSE
-2004-06-30,Argentina,Peru,2,1,Friendly,East Rutherford,USA,TRUE
+2004-06-30,Argentina,Peru,2,1,Friendly,East Rutherford,United States,TRUE
 2004-06-30,Portugal,Netherlands,2,1,UEFA Euro,Lisbon,Portugal,FALSE
 2004-07-01,Greece,Czech Republic,1,0,UEFA Euro,Porto,Portugal,TRUE
 2004-07-03,Botswana,Morocco,0,1,FIFA World Cup qualification,Gaborone,Botswana,FALSE
@@ -27081,7 +27081,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-07-11,Brazil,Costa Rica,4,1,Copa América,Arequipa,Peru,TRUE
 2004-07-11,Paraguay,Chile,1,1,Copa América,Arequipa,Peru,TRUE
 2004-07-11,Serbia,Slovakia,2,0,Kirin Cup,Fukuoka,Japan,TRUE
-2004-07-11,USA,Poland,1,1,Friendly,Chicago,USA,FALSE
+2004-07-11,United States,Poland,1,1,Friendly,Chicago,United States,FALSE
 2004-07-12,Malaysia,Singapore,2,0,Friendly,Kuala Lumpur,Malaysia,FALSE
 2004-07-12,Peru,Colombia,2,2,Copa América,Trujillo,Peru,FALSE
 2004-07-12,Venezuela,Bolivia,1,1,Copa América,Trujillo,Peru,TRUE
@@ -27095,7 +27095,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-07-17,Colombia,Costa Rica,2,0,Copa América,Trujillo,Peru,TRUE
 2004-07-17,Peru,Argentina,0,1,Copa América,Chiclayo,Peru,FALSE
 2004-07-18,Angola,Botswana,1,1,COSAFA Cup,Luanda,Angola,FALSE
-2004-07-18,El Salvador,Guatemala,0,1,Friendly,Los Angeles,USA,TRUE
+2004-07-18,El Salvador,Guatemala,0,1,Friendly,Los Angeles,United States,TRUE
 2004-07-18,Iraq,Uzbekistan,0,1,AFC Asian Cup,Chengdu,China PR,TRUE
 2004-07-18,Mexico,Brazil,0,4,Copa América,Piura,Peru,TRUE
 2004-07-18,Paraguay,Uruguay,1,3,Copa América,Tacna,Peru,TRUE
@@ -27135,7 +27135,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-08-03,Bahrain,Japan,3,4,AFC Asian Cup,Jinan,China PR,TRUE
 2004-08-03,China PR,Iran,1,1,AFC Asian Cup,Beijing,China PR,FALSE
 2004-08-03,El Salvador,Honduras,0,4,Friendly,San Salvador,El Salvador,FALSE
-2004-08-06,El Salvador,Guatemala,0,2,Friendly,Washington,USA,TRUE
+2004-08-06,El Salvador,Guatemala,0,2,Friendly,Washington,United States,TRUE
 2004-08-06,Iran,Bahrain,4,2,AFC Asian Cup,Beijing,China PR,TRUE
 2004-08-07,China PR,Japan,1,3,AFC Asian Cup,Beijing,China PR,FALSE
 2004-08-07,Uganda,Kenya,1,1,Friendly,Kampala,Uganda,FALSE
@@ -27156,7 +27156,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-08-18,Haiti,Brazil,0,6,Friendly,Port-au-Prince,Haiti,FALSE
 2004-08-18,Iceland,Italy,2,0,Friendly,Reykjavík,Iceland,FALSE
 2004-08-18,Republic of Ireland,Bulgaria,1,1,Friendly,Dublin,Republic of Ireland,FALSE
-2004-08-18,Jamaica,USA,1,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
+2004-08-18,Jamaica,United States,1,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2004-08-18,Japan,Argentina,1,2,Friendly,Fukuroi,Japan,FALSE
 2004-08-18,Jordan,Azerbaijan,1,1,Friendly,Amman,Jordan,FALSE
 2004-08-18,Kenya,Uganda,4,1,Friendly,Nairobi,Kenya,FALSE
@@ -27223,7 +27223,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-09-04,Saint Kitts and Nevis,Trinidad and Tobago,1,2,FIFA World Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
 2004-09-04,Switzerland,Faroe Islands,6,0,FIFA World Cup qualification,Basel,Switzerland,FALSE
 2004-09-04,Turkey,Georgia,1,1,FIFA World Cup qualification,Trabzon,Turkey,FALSE
-2004-09-04,USA,El Salvador,2,0,FIFA World Cup qualification,Foxborough,USA,FALSE
+2004-09-04,United States,El Salvador,2,0,FIFA World Cup qualification,Foxborough,United States,FALSE
 2004-09-04,Zambia,Liberia,1,0,FIFA World Cup qualification,Lusaka,Zambia,FALSE
 2004-09-05,Algeria,Gabon,0,3,FIFA World Cup qualification,Annaba,Algeria,FALSE
 2004-09-05,Angola,Rwanda,1,0,FIFA World Cup qualification,Luanda,Angola,FALSE
@@ -27268,7 +27268,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-09-08,Netherlands,Czech Republic,2,0,FIFA World Cup qualification,Amsterdam,Netherlands,FALSE
 2004-09-08,Norway,Belarus,1,1,FIFA World Cup qualification,Oslo,Norway,FALSE
 2004-09-08,Palestine,Uzbekistan,0,3,FIFA World Cup qualification,Al Rayyan,Qatar,TRUE
-2004-09-08,Panama,USA,1,1,FIFA World Cup qualification,Panama City,Panama,FALSE
+2004-09-08,Panama,United States,1,1,FIFA World Cup qualification,Panama City,Panama,FALSE
 2004-09-08,Poland,England,1,2,FIFA World Cup qualification,Chorzów,Poland,FALSE
 2004-09-08,Portugal,Estonia,4,0,FIFA World Cup qualification,Leiria,Portugal,FALSE
 2004-09-08,Scotland,Slovenia,0,0,FIFA World Cup qualification,Glasgow,Scotland,FALSE
@@ -27285,10 +27285,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-09-08,Yemen,United Arab Emirates,3,1,FIFA World Cup qualification,Sana'a,Yemen,FALSE
 2004-09-10,Saint Vincent and the Grenadines,Saint Kitts and Nevis,1,0,FIFA World Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
 2004-09-19,Mozambique,Angola,0,1,COSAFA Cup,Maputo,Mozambique,FALSE
-2004-09-25,British Virgin Islands,USA Virgin Islands,2,1,Friendly,Road Town,British Virgin Islands,FALSE
+2004-09-25,British Virgin Islands,United States Virgin Islands,2,1,Friendly,Road Town,British Virgin Islands,FALSE
 2004-09-29,Kuwait,Syria,1,1,Friendly,Tripoli,Lebanon,TRUE
 2004-09-30,Botswana,Zambia,1,0,Friendly,Gaborone,Botswana,FALSE
-2004-10-02,Jamaica,Guatemala,2,2,Friendly,Fort Lauderdale,USA,TRUE
+2004-10-02,Jamaica,Guatemala,2,2,Friendly,Fort Lauderdale,United States,TRUE
 2004-10-03,Gabon,Benin,2,0,Friendly,Libreville,Gabon,FALSE
 2004-10-03,Lebanon,Kuwait,1,3,Friendly,Tripoli,Lebanon,FALSE
 2004-10-06,Lebanon,Kuwait,1,1,Friendly,Beirut,Lebanon,FALSE
@@ -27312,7 +27312,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-10-09,Croatia,Bulgaria,2,2,FIFA World Cup qualification,Zagreb,Croatia,FALSE
 2004-10-09,Cyprus,Faroe Islands,2,2,FIFA World Cup qualification,Nicosia,Cyprus,FALSE
 2004-10-09,Czech Republic,Romania,1,0,FIFA World Cup qualification,Prague,Czech Republic,FALSE
-2004-10-09,El Salvador,USA,0,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
+2004-10-09,El Salvador,United States,0,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2004-10-09,England,Wales,2,0,FIFA World Cup qualification,Manchester,England,FALSE
 2004-10-09,Finland,Armenia,3,1,FIFA World Cup qualification,Tampere,Finland,FALSE
 2004-10-09,France,Republic of Ireland,0,0,FIFA World Cup qualification,Saint-Denis,France,FALSE
@@ -27392,7 +27392,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-10-13,Tajikistan,Kyrgyzstan,2,1,FIFA World Cup qualification,Dushanbe,Tajikistan,FALSE
 2004-10-13,Thailand,United Arab Emirates,3,0,FIFA World Cup qualification,Bangkok,Thailand,FALSE
 2004-10-13,Ukraine,Georgia,2,0,FIFA World Cup qualification,Lviv,Ukraine,FALSE
-2004-10-13,USA,Panama,6,0,FIFA World Cup qualification,Washington,USA,FALSE
+2004-10-13,United States,Panama,6,0,FIFA World Cup qualification,Washington,United States,FALSE
 2004-10-13,Wales,Poland,2,3,FIFA World Cup qualification,Cardiff,Wales,FALSE
 2004-10-14,Venezuela,Ecuador,3,1,FIFA World Cup qualification,San Cristóbal,Venezuela,FALSE
 2004-10-16,Jersey,Kernow,1,4,Friendly,St. Helier,Jersey,FALSE
@@ -27402,7 +27402,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-10-22,Libya,Jordan,1,0,Friendly,Tripoli,Libya,FALSE
 2004-10-22,Nigeria,Ecuador,2,2,Friendly,Tripoli,Libya,TRUE
 2004-10-24,Zimbabwe,Zambia,0,0,COSAFA Cup,Harare,Zimbabwe,FALSE
-2004-10-27,Mexico,Ecuador,2,1,Friendly,East Rutherford,USA,TRUE
+2004-10-27,Mexico,Ecuador,2,1,Friendly,East Rutherford,United States,TRUE
 2004-10-31,Saint Kitts and Nevis,Montserrat,6,1,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
 2004-11-01,Yemen,Zambia,2,2,Friendly,Dubai,United Arab Emirates,TRUE
 2004-11-02,Montserrat,Antigua and Barbuda,4,5,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,TRUE
@@ -27413,12 +27413,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-11-10,Guadeloupe,French Guiana,0,1,CFU Caribbean Cup qualification,Fort-de-France,Martinique,TRUE
 2004-11-10,Kuwait,Kyrgyzstan,3,0,Friendly,Kuwait City,Kuwait,FALSE
 2004-11-10,Martinique,Dominica,5,1,CFU Caribbean Cup qualification,Fort-de-France,Martinique,FALSE
-2004-11-10,Mexico,Guatemala,2,0,Friendly,San Antonio,USA,TRUE
+2004-11-10,Mexico,Guatemala,2,0,Friendly,San Antonio,United States,TRUE
 2004-11-11,United Arab Emirates,Jordan,4,0,Friendly,Abu Dhabi,United Arab Emirates,FALSE
 2004-11-12,Guadeloupe,Dominica,7,0,CFU Caribbean Cup qualification,Rivière-Pilote,Martinique,TRUE
 2004-11-12,Martinique,French Guiana,0,0,CFU Caribbean Cup qualification,Rivière-Pilote,Martinique,FALSE
-2004-11-13,Guatemala,Bolivia,1,0,Friendly,Washington,USA,TRUE
-2004-11-13,Saint Kitts and Nevis,Mexico,0,5,FIFA World Cup qualification,Miami,USA,TRUE
+2004-11-13,Guatemala,Bolivia,1,0,Friendly,Washington,United States,TRUE
+2004-11-13,Saint Kitts and Nevis,Mexico,0,5,FIFA World Cup qualification,Miami,United States,TRUE
 2004-11-14,Dominica,French Guiana,0,4,CFU Caribbean Cup qualification,Fort-de-France,Martinique,TRUE
 2004-11-14,Martinique,Guadeloupe,0,0,CFU Caribbean Cup qualification,Fort-de-France,Martinique,FALSE
 2004-11-16,Australia,Norway,2,2,Friendly,London,England,TRUE
@@ -27471,17 +27471,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-11-17,Turkey,Ukraine,0,3,FIFA World Cup qualification,Istanbul,Turkey,FALSE
 2004-11-17,United Arab Emirates,North Korea,1,0,FIFA World Cup qualification,Dubai,United Arab Emirates,FALSE
 2004-11-17,Uruguay,Paraguay,1,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2004-11-17,USA,Jamaica,1,1,FIFA World Cup qualification,Columbus,USA,FALSE
+2004-11-17,United States,Jamaica,1,1,FIFA World Cup qualification,Columbus,United States,FALSE
 2004-11-17,Uzbekistan,Taiwan,6,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2004-11-20,Zambia,Angola,0,0,COSAFA Cup,Lusaka,Zambia,FALSE
 2004-11-22,United Arab Emirates,Belarus,2,3,Friendly,Dubai,United Arab Emirates,FALSE
 2004-11-24,Cayman Islands,Bermuda,1,2,CFU Caribbean Cup qualification,Kingstown,Saint Vincent and the Grenadines,TRUE
 2004-11-24,Grenada,Suriname,2,2,CFU Caribbean Cup qualification,Macoya,Trinidad and Tobago,TRUE
-2004-11-24,Haiti,USA Virgin Islands,11,0,CFU Caribbean Cup qualification,Kingston,Jamaica,TRUE
+2004-11-24,Haiti,United States Virgin Islands,11,0,CFU Caribbean Cup qualification,Kingston,Jamaica,TRUE
 2004-11-24,Jamaica,Saint Martin,12,0,CFU Caribbean Cup qualification,Kingston,Jamaica,FALSE
 2004-11-24,Trinidad and Tobago,Puerto Rico,5,0,CFU Caribbean Cup qualification,Macoya,Trinidad and Tobago,FALSE
 2004-11-26,British Virgin Islands,Cayman Islands,0,1,CFU Caribbean Cup qualification,Kingstown,Saint Vincent and the Grenadines,TRUE
-2004-11-26,Jamaica,USA Virgin Islands,11,1,CFU Caribbean Cup qualification,Montego Bay,Jamaica,FALSE
+2004-11-26,Jamaica,United States Virgin Islands,11,1,CFU Caribbean Cup qualification,Montego Bay,Jamaica,FALSE
 2004-11-26,Puerto Rico,Suriname,1,1,CFU Caribbean Cup qualification,San Fernando,Trinidad and Tobago,TRUE
 2004-11-26,Saint Martin,Haiti,0,2,CFU Caribbean Cup qualification,Montego Bay,Jamaica,TRUE
 2004-11-26,Trinidad and Tobago,Grenada,2,0,CFU Caribbean Cup qualification,San Fernando,Trinidad and Tobago,FALSE
@@ -27491,7 +27491,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-11-28,Jamaica,Haiti,3,1,CFU Caribbean Cup qualification,Kingston,Jamaica,FALSE
 2004-11-28,Singapore,Myanmar,1,0,Friendly,Singapore,Singapore,FALSE
 2004-11-28,Trinidad and Tobago,Suriname,1,0,CFU Caribbean Cup qualification,Arima,Trinidad and Tobago,FALSE
-2004-11-28,USA Virgin Islands,Saint Martin,0,0,CFU Caribbean Cup qualification,Kingston,Jamaica,TRUE
+2004-11-28,United States Virgin Islands,Saint Martin,0,0,CFU Caribbean Cup qualification,Kingston,Jamaica,TRUE
 2004-11-29,Egypt,Bulgaria,1,1,Friendly,Cairo,Egypt,FALSE
 2004-11-30,Hungary,Slovakia,0,1,King's Cup,Bangkok,Thailand,TRUE
 2004-11-30,Singapore,Hong Kong,0,0,Friendly,Singapore,Singapore,FALSE
@@ -27527,7 +27527,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2004-12-12,British Virgin Islands,Trinidad and Tobago,0,4,CFU Caribbean Cup qualification,Road Town,British Virgin Islands,FALSE
 2004-12-12,Cuba,Martinique,2,0,CFU Caribbean Cup qualification,Havana,Cuba,FALSE
 2004-12-12,Timor-Leste,Thailand,0,8,AFF Championship,Kuala Lumpur,Malaysia,TRUE
-2004-12-12,Haiti,Saint Kitts and Nevis,1,0,CFU Caribbean Cup qualification,Fort Lauderdale,USA,TRUE
+2004-12-12,Haiti,Saint Kitts and Nevis,1,0,CFU Caribbean Cup qualification,Fort Lauderdale,United States,TRUE
 2004-12-12,Kenya,Sudan,2,2,CECAFA Cup,Addis Ababa,Ethiopia,TRUE
 2004-12-12,Malaysia,Myanmar,0,1,AFF Championship,Kuala Lumpur,Malaysia,FALSE
 2004-12-12,Saint Lucia,Jamaica,1,1,CFU Caribbean Cup qualification,Vieux Fort,Saint Lucia,FALSE
@@ -27592,24 +27592,24 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-01-09,Haiti,Cuba,0,1,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
 2005-01-12,Antigua and Barbuda,Trinidad and Tobago,2,1,Friendly,St. John's,Antigua and Barbuda,FALSE
 2005-01-12,Costa Rica,Haiti,3,3,Friendly,San José,Costa Rica,FALSE
-2005-01-15,Colombia,South Korea,2,1,Friendly,Los Angeles,USA,TRUE
+2005-01-15,Colombia,South Korea,2,1,Friendly,Los Angeles,United States,TRUE
 2005-01-15,French Guiana,Jamaica,0,0,CFU Caribbean Cup qualification,Cayenne,French Guiana,FALSE
 2005-01-15,Malaysia,Myanmar,2,1,AFF Championship,Singapore,Singapore,TRUE
 2005-01-16,Cuba,Haiti,1,1,CFU Caribbean Cup qualification,Havana,Cuba,FALSE
 2005-01-16,Singapore,Indonesia,2,1,AFF Championship,Singapore,Singapore,FALSE
-2005-01-17,Guatemala,Colombia,1,1,Friendly,Los Angeles,USA,TRUE
-2005-01-19,Paraguay,South Korea,1,1,Friendly,Los Angeles,USA,TRUE
+2005-01-17,Guatemala,Colombia,1,1,Friendly,Los Angeles,United States,TRUE
+2005-01-19,Paraguay,South Korea,1,1,Friendly,Los Angeles,United States,TRUE
 2005-01-21,Trinidad and Tobago,Azerbaijan,1,0,Friendly,Port of Spain,Trinidad and Tobago,FALSE
 2005-01-22,Kuwait,Norway,1,1,Friendly,Kuwait City,Kuwait,FALSE
-2005-01-22,Sweden,South Korea,1,1,Friendly,Carson,USA,TRUE
+2005-01-22,Sweden,South Korea,1,1,Friendly,Carson,United States,TRUE
 2005-01-23,Barbados,Grenada,3,0,Friendly,Bridgetown,Barbados,FALSE
-2005-01-23,Guatemala,Paraguay,1,2,Friendly,Los Angeles,USA,TRUE
+2005-01-23,Guatemala,Paraguay,1,2,Friendly,Los Angeles,United States,TRUE
 2005-01-23,Trinidad and Tobago,Azerbaijan,2,0,Friendly,San Fernando,Trinidad and Tobago,FALSE
 2005-01-25,Bahrain,Norway,0,1,Friendly,Riffa,Bahrain,FALSE
 2005-01-25,Saudi Arabia,Tajikistan,3,0,Friendly,Riyadh,Saudi Arabia,FALSE
 2005-01-26,Ecuador,Panama,2,0,Friendly,Ambato,Ecuador,FALSE
 2005-01-26,Kuwait,Syria,3,2,Friendly,Kuwait City,Kuwait,FALSE
-2005-01-26,Mexico,Sweden,0,0,Friendly,San Diego,USA,TRUE
+2005-01-26,Mexico,Sweden,0,0,Friendly,San Diego,United States,TRUE
 2005-01-28,Jordan,Norway,0,0,Friendly,Amman,Jordan,FALSE
 2005-01-29,Ecuador,Panama,2,0,Friendly,Babahoyo,Ecuador,FALSE
 2005-01-29,Japan,Kazakhstan,4,0,Friendly,Yokohama,Japan,FALSE
@@ -27660,13 +27660,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-02-09,Slovenia,Czech Republic,0,3,Friendly,Celje,Slovenia,FALSE
 2005-02-09,South Africa,Australia,1,1,Friendly,Durban,South Africa,FALSE
 2005-02-09,Spain,San Marino,5,0,FIFA World Cup qualification,Almería,Spain,FALSE
-2005-02-09,Trinidad and Tobago,USA,1,2,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
+2005-02-09,Trinidad and Tobago,United States,1,2,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2005-02-09,United Arab Emirates,Switzerland,1,2,Friendly,Dubai,United Arab Emirates,FALSE
 2005-02-09,Uzbekistan,Saudi Arabia,1,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2005-02-09,Venezuela,Estonia,3,0,Friendly,Maracaibo,Venezuela,FALSE
 2005-02-09,Wales,Hungary,2,0,Friendly,Cardiff,Wales,FALSE
 2005-02-13,Barbados,Guyana,3,3,Friendly,Bridgetown,Barbados,FALSE
-2005-02-13,Guatemala,Haiti,2,1,Friendly,Fort Lauderdale,USA,TRUE
+2005-02-13,Guatemala,Haiti,2,1,Friendly,Fort Lauderdale,United States,TRUE
 2005-02-16,Costa Rica,Ecuador,1,2,Friendly,Heredia,Costa Rica,FALSE
 2005-02-19,El Salvador,Panama,0,1,UNCAF Cup,Guatemala,Guatemala,TRUE
 2005-02-19,Guatemala,Belize,2,0,UNCAF Cup,Guatemala,Guatemala,FALSE
@@ -27697,9 +27697,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-03-05,Hong Kong,Mongolia,6,0,EAFF Championship,Taipei,Taiwan,TRUE
 2005-03-07,Guam,Hong Kong,0,15,EAFF Championship,Taipei,Taiwan,TRUE
 2005-03-07,North Korea,Mongolia,6,0,EAFF Championship,Taipei,Taiwan,TRUE
-2005-03-09,Mexico,Argentina,1,1,Friendly,Los Angeles,USA,TRUE
+2005-03-09,Mexico,Argentina,1,1,Friendly,Los Angeles,United States,TRUE
 2005-03-09,Mongolia,Guam,4,1,EAFF Championship,Taipei,Taiwan,TRUE
-2005-03-09,USA,Colombia,3,0,Friendly,Fullerton,USA,FALSE
+2005-03-09,United States,Colombia,3,0,Friendly,Fullerton,United States,FALSE
 2005-03-11,Guam,North Korea,0,21,EAFF Championship,Taipei,Taiwan,TRUE
 2005-03-12,Kenya,Rwanda,1,1,Friendly,Nairobi,Kenya,FALSE
 2005-03-12,Kuwait,Finland,0,1,Friendly,Kuwait City,Kuwait,FALSE
@@ -27711,7 +27711,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-03-18,Saudi Arabia,Finland,1,4,Friendly,Dammam,Saudi Arabia,FALSE
 2005-03-19,Gabon,Congo,0,0,Friendly,Libreville,Gabon,FALSE
 2005-03-19,Lesotho,Namibia,1,2,Friendly,Maseru,Lesotho,FALSE
-2005-03-19,USA,Honduras,1,0,Friendly,Albuquerque,USA,FALSE
+2005-03-19,United States,Honduras,1,0,Friendly,Albuquerque,United States,FALSE
 2005-03-20,South Korea,Burkina Faso,1,0,Friendly,Dubai,United Arab Emirates,TRUE
 2005-03-23,Kenya,Ghana,2,2,Friendly,Nairobi,Kenya,FALSE
 2005-03-25,Iran,Japan,2,1,FIFA World Cup qualification,Tehran,Iran,FALSE
@@ -27761,7 +27761,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-03-27,Egypt,Libya,4,1,FIFA World Cup qualification,Cairo,Egypt,FALSE
 2005-03-27,Ivory Coast,Benin,3,0,FIFA World Cup qualification,Abidjan,Ivory Coast,FALSE
 2005-03-27,Mali,Togo,1,2,FIFA World Cup qualification,Bamako,Mali,FALSE
-2005-03-27,Mexico,USA,2,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+2005-03-27,Mexico,United States,2,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2005-03-27,Zimbabwe,Angola,2,0,FIFA World Cup qualification,Harare,Zimbabwe,FALSE
 2005-03-29,Australia,Indonesia,3,0,Friendly,Perth,Australia,FALSE
 2005-03-29,Bolivia,Venezuela,3,1,FIFA World Cup qualification,La Paz,Bolivia,FALSE
@@ -27798,16 +27798,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-03-30,Trinidad and Tobago,Costa Rica,0,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2005-03-30,Ukraine,Denmark,1,0,FIFA World Cup qualification,Kyiv,Ukraine,FALSE
 2005-03-30,Uruguay,Brazil,1,1,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2005-03-30,USA,Guatemala,2,0,FIFA World Cup qualification,Birmingham,USA,FALSE
+2005-03-30,United States,Guatemala,2,0,FIFA World Cup qualification,Birmingham,United States,FALSE
 2005-04-16,Mozambique,Zimbabwe,0,3,COSAFA Cup,Windhoek,Namibia,TRUE
 2005-04-16,Namibia,Botswana,1,1,COSAFA Cup,Windhoek,Namibia,FALSE
 2005-04-17,Botswana,Zimbabwe,0,2,COSAFA Cup,Windhoek,Namibia,TRUE
 2005-04-20,Estonia,Norway,1,2,Friendly,Tallinn,Estonia,FALSE
-2005-04-20,Guatemala,Jamaica,0,1,Friendly,Atlanta,USA,TRUE
+2005-04-20,Guatemala,Jamaica,0,1,Friendly,Atlanta,United States,TRUE
 2005-04-27,Brazil,Guatemala,3,0,Friendly,São Paulo,Brazil,FALSE
-2005-04-27,Mexico,Poland,1,1,Friendly,Chicago,USA,TRUE
+2005-04-27,Mexico,Poland,1,1,Friendly,Chicago,United States,TRUE
 2005-05-02,Guernsey,Jersey,0,0,Friendly,St. Sampson,Guernsey,FALSE
-2005-05-04,Ecuador,Paraguay,1,0,Friendly,East Rutherford,USA,TRUE
+2005-05-04,Ecuador,Paraguay,1,0,Friendly,East Rutherford,United States,TRUE
 2005-05-15,Jersey,Guernsey,3,3,Friendly,St. Helier,Jersey,FALSE
 2005-05-21,Lithuania,Latvia,2,0,Baltic Cup,Kaunas,Lithuania,FALSE
 2005-05-22,Japan,Peru,0,1,Kirin Cup,Niigata,Japan,FALSE
@@ -27824,12 +27824,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-05-27,Sudan,Chad,1,1,Friendly,Khartoum,Sudan,FALSE
 2005-05-27,Trinidad and Tobago,Bermuda,1,0,Friendly,San Fernando,Trinidad and Tobago,FALSE
 2005-05-27,Tunisia,Angola,4,1,Friendly,Tunis,Tunisia,FALSE
-2005-05-28,USA,England,1,2,Friendly,Chicago,USA,FALSE
+2005-05-28,United States,England,1,2,Friendly,Chicago,United States,FALSE
 2005-05-29,Hong Kong,Macau,8,1,Friendly,Victoria,Hong Kong,FALSE
 2005-05-29,Iran,Azerbaijan,2,1,Friendly,Tehran,Iran,FALSE
 2005-05-29,Poland,Albania,1,0,Friendly,Szczecin,Poland,FALSE
 2005-05-29,Togo,Burkina Faso,1,0,Friendly,Lomé,Togo,FALSE
-2005-05-31,Colombia,England,2,3,Friendly,East Rutherford,USA,TRUE
+2005-05-31,Colombia,England,2,3,Friendly,East Rutherford,United States,TRUE
 2005-05-31,France,Hungary,2,1,Friendly,Metz,France,FALSE
 2005-06-01,Gabon,Zambia,0,1,Friendly,Johannesburg,South Africa,TRUE
 2005-06-01,Lesotho,Eswatini,3,4,Friendly,Maseru,Lesotho,FALSE
@@ -27856,7 +27856,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-06-04,Guatemala,Mexico,0,2,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
 2005-06-04,Iceland,Hungary,2,3,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
 2005-06-04,Republic of Ireland,Israel,2,2,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
-2005-06-04,Jamaica,Honduras,0,0,Friendly,Atlanta,USA,TRUE
+2005-06-04,Jamaica,Honduras,0,0,Friendly,Atlanta,United States,TRUE
 2005-06-04,Morocco,Malawi,4,1,FIFA World Cup qualification,Rabat,Morocco,FALSE
 2005-06-04,Netherlands,Romania,2,0,FIFA World Cup qualification,Rotterdam,Netherlands,FALSE
 2005-06-04,Northern Ireland,Germany,1,4,Friendly,Belfast,Northern Ireland,FALSE
@@ -27872,7 +27872,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-06-04,Trinidad and Tobago,Panama,2,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2005-06-04,Turkey,Greece,0,0,FIFA World Cup qualification,Istanbul,Turkey,FALSE
 2005-06-04,Ukraine,Kazakhstan,2,0,FIFA World Cup qualification,Kyiv,Ukraine,FALSE
-2005-06-04,USA,Costa Rica,3,0,FIFA World Cup qualification,Salt Lake City,USA,FALSE
+2005-06-04,United States,Costa Rica,3,0,FIFA World Cup qualification,Salt Lake City,United States,FALSE
 2005-06-04,Venezuela,Uruguay,1,1,FIFA World Cup qualification,Maracaibo,Venezuela,FALSE
 2005-06-05,Angola,Algeria,2,1,FIFA World Cup qualification,Luanda,Angola,FALSE
 2005-06-05,Brazil,Paraguay,4,1,FIFA World Cup qualification,Porto Alegre,Brazil,FALSE
@@ -27909,7 +27909,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-06-08,Luxembourg,Slovakia,0,4,FIFA World Cup qualification,Luxembourg,Luxembourg,FALSE
 2005-06-08,Malaysia,Singapore,1,2,Friendly,George Town,Malaysia,FALSE
 2005-06-08,Mexico,Trinidad and Tobago,2,0,FIFA World Cup qualification,Monterrey,Mexico,FALSE
-2005-06-08,Panama,USA,0,3,FIFA World Cup qualification,Panama City,Panama,FALSE
+2005-06-08,Panama,United States,0,3,FIFA World Cup qualification,Panama City,Panama,FALSE
 2005-06-08,Paraguay,Bolivia,4,1,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 2005-06-08,Romania,Armenia,3,0,FIFA World Cup qualification,Constanţa,Romania,FALSE
 2005-06-08,Saudi Arabia,Uzbekistan,3,0,FIFA World Cup qualification,Riyadh,Saudi Arabia,FALSE
@@ -27918,7 +27918,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-06-09,Australia,New Zealand,1,0,Friendly,London,England,TRUE
 2005-06-10,Gambia,Guinea,2,3,Friendly,Freetown,Sierra Leone,TRUE
 2005-06-10,Sierra Leone,Liberia,2,0,Friendly,Freetown,Sierra Leone,FALSE
-2005-06-11,Ecuador,Italy,1,1,Friendly,East Rutherford,USA,TRUE
+2005-06-11,Ecuador,Italy,1,1,Friendly,East Rutherford,United States,TRUE
 2005-06-11,Lesotho,Malawi,1,2,COSAFA Cup,Lusaka,Zambia,TRUE
 2005-06-11,Tunisia,Guinea,2,0,FIFA World Cup qualification,Radès,Tunisia,FALSE
 2005-06-11,Zambia,Eswatini,3,0,COSAFA Cup,Lusaka,Zambia,FALSE
@@ -27964,18 +27964,18 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-07-01,Botswana,DR Congo,0,0,Friendly,Gaborone,Botswana,FALSE
 2005-07-02,Canada,Honduras,1,2,Friendly,Burnaby,Canada,FALSE
 2005-07-04,Congo,Mali,1,0,FIFA World Cup qualification,Brazzaville,Congo,FALSE
-2005-07-06,Colombia,Panama,0,1,Gold Cup,Miami,USA,TRUE
-2005-07-06,Trinidad and Tobago,Honduras,1,1,Gold Cup,Miami,USA,TRUE
-2005-07-07,Canada,Costa Rica,0,1,Gold Cup,Seattle,USA,TRUE
-2005-07-07,USA,Cuba,4,1,Gold Cup,Seattle,USA,FALSE
-2005-07-08,Guatemala,Jamaica,3,4,Gold Cup,Carson,USA,TRUE
-2005-07-08,South Africa,Mexico,2,1,Gold Cup,Carson,USA,TRUE
-2005-07-09,Costa Rica,Cuba,3,1,Gold Cup,Seattle,USA,TRUE
-2005-07-09,USA,Canada,2,0,Gold Cup,Seattle,USA,FALSE
-2005-07-10,Honduras,Colombia,2,1,Gold Cup,Miami,USA,TRUE
-2005-07-10,Jamaica,South Africa,3,3,Gold Cup,Los Angeles,USA,TRUE
-2005-07-10,Mexico,Guatemala,4,0,Gold Cup,Los Angeles,USA,TRUE
-2005-07-10,Panama,Trinidad and Tobago,2,2,Gold Cup,Miami,USA,TRUE
+2005-07-06,Colombia,Panama,0,1,Gold Cup,Miami,United States,TRUE
+2005-07-06,Trinidad and Tobago,Honduras,1,1,Gold Cup,Miami,United States,TRUE
+2005-07-07,Canada,Costa Rica,0,1,Gold Cup,Seattle,United States,TRUE
+2005-07-07,United States,Cuba,4,1,Gold Cup,Seattle,United States,FALSE
+2005-07-08,Guatemala,Jamaica,3,4,Gold Cup,Carson,United States,TRUE
+2005-07-08,South Africa,Mexico,2,1,Gold Cup,Carson,United States,TRUE
+2005-07-09,Costa Rica,Cuba,3,1,Gold Cup,Seattle,United States,TRUE
+2005-07-09,United States,Canada,2,0,Gold Cup,Seattle,United States,FALSE
+2005-07-10,Honduras,Colombia,2,1,Gold Cup,Miami,United States,TRUE
+2005-07-10,Jamaica,South Africa,3,3,Gold Cup,Los Angeles,United States,TRUE
+2005-07-10,Mexico,Guatemala,4,0,Gold Cup,Los Angeles,United States,TRUE
+2005-07-10,Panama,Trinidad and Tobago,2,2,Gold Cup,Miami,United States,TRUE
 2005-07-10,Saare County,Åland Islands,2,1,Island Games,Shetland,Scotland,TRUE
 2005-07-10,Shetland,Falkland Islands,4,0,Island Games,Shetland,Scotland,FALSE
 2005-07-10,Guernsey,Orkney,3,0,Island Games,Shetland,Scotland,TRUE
@@ -27984,16 +27984,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-07-11,Isle of Man,Saare County,2,2,Island Games,Shetland,Scotland,TRUE
 2005-07-11,Orkney,Greenland,1,2,Island Games,Shetland,Scotland,TRUE
 2005-07-11,Guernsey,Western Isles,2,1,Island Games,Shetland,Scotland,TRUE
-2005-07-12,Canada,Cuba,2,1,Gold Cup,Foxborough,USA,TRUE
-2005-07-12,Colombia,Trinidad and Tobago,2,0,Gold Cup,Miami,USA,TRUE
-2005-07-12,Honduras,Panama,1,0,Gold Cup,Miami,USA,TRUE
-2005-07-12,USA,Costa Rica,0,0,Gold Cup,Foxborough,USA,FALSE
+2005-07-12,Canada,Cuba,2,1,Gold Cup,Foxborough,United States,TRUE
+2005-07-12,Colombia,Trinidad and Tobago,2,0,Gold Cup,Miami,United States,TRUE
+2005-07-12,Honduras,Panama,1,0,Gold Cup,Miami,United States,TRUE
+2005-07-12,United States,Costa Rica,0,0,Gold Cup,Foxborough,United States,FALSE
 2005-07-12,Saare County,Falkland Islands,1,2,Island Games,Shetland,Scotland,TRUE
 2005-07-12,Åland Islands,Isle of Man,0,1,Island Games,Shetland,Scotland,TRUE
 2005-07-12,Orkney,Ynys Môn,0,2,Island Games,Shetland,Scotland,TRUE
 2005-07-12,Western Isles,Greenland,4,4,Island Games,Shetland,Scotland,TRUE
-2005-07-13,Guatemala,South Africa,1,1,Gold Cup,Houston,USA,TRUE
-2005-07-13,Mexico,Jamaica,1,0,Gold Cup,Houston,USA,TRUE
+2005-07-13,Guatemala,South Africa,1,1,Gold Cup,Houston,United States,TRUE
+2005-07-13,Mexico,Jamaica,1,0,Gold Cup,Houston,United States,TRUE
 2005-07-13,Shetland,Saare County,0,0,Island Games,Shetland,Scotland,FALSE
 2005-07-13,Falkland Islands,Isle of Man,0,9,Island Games,Shetland,Scotland,TRUE
 2005-07-13,Ynys Môn,Western Isles,0,0,Island Games,Shetland,Scotland,TRUE
@@ -28007,13 +28007,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-07-15,Ynys Môn,Saare County,3,2,Island Games,Shetland,Scotland,TRUE
 2005-07-15,Western Isles,Isle of Man,4,0,Island Games,Shetland,Scotland,TRUE
 2005-07-15,Shetland,Guernsey,2,0,Island Games,Shetland,Scotland,FALSE
-2005-07-16,Honduras,Costa Rica,3,2,Gold Cup,Foxborough,USA,TRUE
-2005-07-16,USA,Jamaica,3,1,Gold Cup,Foxborough,USA,FALSE
-2005-07-17,Mexico,Colombia,1,2,Gold Cup,Houston,USA,TRUE
-2005-07-17,South Africa,Panama,1,1,Gold Cup,Houston,USA,TRUE
-2005-07-21,Colombia,Panama,2,3,Gold Cup,East Rutherford,USA,TRUE
-2005-07-21,USA,Honduras,2,1,Gold Cup,East Rutherford,USA,FALSE
-2005-07-24,USA,Panama,0,0,Gold Cup,East Rutherford,USA,FALSE
+2005-07-16,Honduras,Costa Rica,3,2,Gold Cup,Foxborough,United States,TRUE
+2005-07-16,United States,Jamaica,3,1,Gold Cup,Foxborough,United States,FALSE
+2005-07-17,Mexico,Colombia,1,2,Gold Cup,Houston,United States,TRUE
+2005-07-17,South Africa,Panama,1,1,Gold Cup,Houston,United States,TRUE
+2005-07-21,Colombia,Panama,2,3,Gold Cup,East Rutherford,United States,TRUE
+2005-07-21,United States,Honduras,2,1,Gold Cup,East Rutherford,United States,FALSE
+2005-07-24,United States,Panama,0,0,Gold Cup,East Rutherford,United States,FALSE
 2005-07-28,Kuwait,United Arab Emirates,1,1,Friendly,Geneva,Switzerland,TRUE
 2005-07-30,Egypt,United Arab Emirates,0,0,Friendly,Geneva,Switzerland,TRUE
 2005-07-31,North Korea,Japan,1,0,EAFF Championship,Daejeon,South Korea,TRUE
@@ -28077,7 +28077,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-08-17,Sweden,Czech Republic,2,1,Friendly,Gothenburg,Sweden,FALSE
 2005-08-17,Tunisia,Kenya,1,0,FIFA World Cup qualification,Radès,Tunisia,FALSE
 2005-08-17,Ukraine,Serbia,2,1,Friendly,Kyiv,Ukraine,FALSE
-2005-08-17,USA,Trinidad and Tobago,1,0,FIFA World Cup qualification,Hartford,USA,FALSE
+2005-08-17,United States,Trinidad and Tobago,1,0,FIFA World Cup qualification,Hartford,United States,FALSE
 2005-08-17,Uzbekistan,Kuwait,3,2,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2005-08-17,Wales,Slovenia,0,0,Friendly,Swansea,Wales,FALSE
 2005-08-24,Iran,Libya,4,0,Friendly,Tehran,Iran,FALSE
@@ -28115,7 +28115,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-09-03,Switzerland,Israel,1,1,FIFA World Cup qualification,Basel,Switzerland,FALSE
 2005-09-03,Trinidad and Tobago,Guatemala,3,2,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2005-09-03,Turkey,Denmark,2,2,FIFA World Cup qualification,Istanbul,Turkey,FALSE
-2005-09-03,USA,Mexico,2,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2005-09-03,United States,Mexico,2,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2005-09-03,Venezuela,Peru,4,1,FIFA World Cup qualification,Maracaibo,Venezuela,FALSE
 2005-09-03,Wales,England,0,1,FIFA World Cup qualification,Cardiff,Wales,FALSE
 2005-09-03,Zambia,Senegal,0,1,FIFA World Cup qualification,Chililabombwe,Zambia,FALSE
@@ -28142,7 +28142,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-09-07,Faroe Islands,Israel,0,2,FIFA World Cup qualification,Tórshavn,Faroe Islands,FALSE
 2005-09-07,Finland,North Macedonia,5,1,FIFA World Cup qualification,Tampere,Finland,FALSE
 2005-09-07,Germany,South Africa,4,2,Friendly,Bremen,Germany,FALSE
-2005-09-07,Guatemala,USA,0,0,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
+2005-09-07,Guatemala,United States,0,0,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
 2005-09-07,Hungary,Sweden,0,1,FIFA World Cup qualification,Budapest,Hungary,FALSE
 2005-09-07,Republic of Ireland,France,0,1,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
 2005-09-07,Japan,Honduras,5,4,Friendly,Rifu,Japan,FALSE
@@ -28166,7 +28166,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-09-25,Zambia,DR Congo,2,2,Friendly,Chililabombwe,Zambia,FALSE
 2005-09-27,DR Congo,Zambia,0,0,Friendly,Lubumbashi,DR Congo,FALSE
 2005-09-30,Guyana,Dominica,3,0,Friendly,Linden,Guyana,FALSE
-2005-10-01,Guatemala,Jamaica,1,2,Friendly,Fort Lauderdale,USA,TRUE
+2005-10-01,Guatemala,Jamaica,1,2,Friendly,Fort Lauderdale,United States,TRUE
 2005-10-01,Liberia,Zambia,0,5,FIFA World Cup qualification,Monrovia,Liberia,FALSE
 2005-10-02,Guyana,Dominica,3,0,Friendly,Georgetown,Guyana,FALSE
 2005-10-07,Poland,Iceland,3,2,Friendly,Warsaw,Poland,FALSE
@@ -28178,7 +28178,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-10-08,Cape Verde,Ghana,0,4,FIFA World Cup qualification,Praia,Cape Verde,FALSE
 2005-10-08,Colombia,Chile,1,1,FIFA World Cup qualification,Barranquilla,Colombia,FALSE
 2005-10-08,Congo,Togo,2,3,FIFA World Cup qualification,Brazzaville,Congo,FALSE
-2005-10-08,Costa Rica,USA,3,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
+2005-10-08,Costa Rica,United States,3,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2005-10-08,Croatia,Sweden,1,0,FIFA World Cup qualification,Zagreb,Croatia,FALSE
 2005-10-08,Cyprus,Republic of Ireland,0,1,FIFA World Cup qualification,Nicosia,Cyprus,FALSE
 2005-10-08,Czech Republic,Netherlands,0,2,FIFA World Cup qualification,Prague,Czech Republic,FALSE
@@ -28253,7 +28253,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-10-12,Trinidad and Tobago,Mexico,2,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2005-10-12,Ukraine,Japan,1,0,Friendly,Kyiv,Ukraine,FALSE
 2005-10-12,Uruguay,Argentina,1,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2005-10-12,USA,Panama,2,0,FIFA World Cup qualification,Foxborough,USA,FALSE
+2005-10-12,United States,Panama,2,0,FIFA World Cup qualification,Foxborough,United States,FALSE
 2005-10-12,Wales,Azerbaijan,2,0,FIFA World Cup qualification,Cardiff,Wales,FALSE
 2005-10-15,Kernow,Jersey,3,2,Friendly,Cornwall,England,FALSE
 2005-10-23,Madagascar,Mauritius,2,0,Friendly,Antananarivo,Madagascar,FALSE
@@ -28278,7 +28278,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-11-12,Norway,Czech Republic,0,1,FIFA World Cup qualification,Oslo,Norway,FALSE
 2005-11-12,Portugal,Croatia,2,0,Friendly,Coimbra,Portugal,FALSE
 2005-11-12,Romania,Ivory Coast,1,2,Friendly,Le Mans,France,TRUE
-2005-11-12,Scotland,USA,1,1,Friendly,Glasgow,Scotland,FALSE
+2005-11-12,Scotland,United States,1,1,Friendly,Glasgow,Scotland,FALSE
 2005-11-12,South Africa,Senegal,2,3,Friendly,Port Elizabeth,South Africa,FALSE
 2005-11-12,Spain,Slovakia,5,1,FIFA World Cup qualification,Madrid,Spain,FALSE
 2005-11-12,Switzerland,Turkey,2,0,FIFA World Cup qualification,Berne,Switzerland,FALSE
@@ -28303,7 +28303,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-11-16,South Korea,Serbia,2,0,Friendly,Seoul,South Korea,FALSE
 2005-11-16,Libya,DR Congo,2,1,Friendly,Paris,France,TRUE
 2005-11-16,Luxembourg,Canada,0,1,Friendly,Hesperange,Luxembourg,FALSE
-2005-11-16,Mexico,Bulgaria,0,3,Friendly,Houston,USA,TRUE
+2005-11-16,Mexico,Bulgaria,0,3,Friendly,Houston,United States,TRUE
 2005-11-16,Poland,Estonia,3,1,Friendly,Ostrowiec Świętokrzyski,Poland,FALSE
 2005-11-16,Qatar,Argentina,0,3,Friendly,Doha,Qatar,FALSE
 2005-11-16,Romania,Nigeria,3,0,Friendly,Bucharest,Romania,FALSE
@@ -28362,12 +28362,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2005-12-12,Bangladesh,India,1,1,SAFF Cup,Karachi,Pakistan,TRUE
 2005-12-12,Nepal,Bhutan,3,1,SAFF Cup,Karachi,Pakistan,TRUE
 2005-12-14,Maldives,India,0,1,SAFF Cup,Karachi,Pakistan,TRUE
-2005-12-14,Mexico,Hungary,2,0,Friendly,Phoenix,USA,TRUE
+2005-12-14,Mexico,Hungary,2,0,Friendly,Phoenix,United States,TRUE
 2005-12-14,Pakistan,Bangladesh,0,1,SAFF Cup,Karachi,Pakistan,FALSE
 2005-12-14,Zambia,DR Congo,4,1,Friendly,Chingola,Zambia,FALSE
 2005-12-16,Mauritius,Réunion,1,1,Friendly,Curepipe,Mauritius,FALSE
 2005-12-17,Bangladesh,India,0,2,SAFF Cup,Karachi,Pakistan,TRUE
-2005-12-18,Antigua and Barbuda,Hungary,0,3,Friendly,Miami,USA,TRUE
+2005-12-18,Antigua and Barbuda,Hungary,0,3,Friendly,Miami,United States,TRUE
 2005-12-18,Réunion,Mauritius,1,2,Friendly,Saint-Pierre,Réunion,FALSE
 2005-12-22,Bangladesh,Pakistan,0,0,AFC Asian Cup qualification,Dhaka,Bangladesh,FALSE
 2005-12-24,Thailand,Latvia,1,1,King's Cup,Phang Nga,Thailand,FALSE
@@ -28405,7 +28405,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-01-21,Togo,DR Congo,0,2,African Cup of Nations,Cairo,Egypt,TRUE
 2006-01-22,South Africa,Guinea,0,2,African Cup of Nations,Alexandria,Egypt,TRUE
 2006-01-22,Tunisia,Zambia,4,1,African Cup of Nations,Alexandria,Egypt,TRUE
-2006-01-22,USA,Canada,0,0,Friendly,San Diego,USA,FALSE
+2006-01-22,United States,Canada,0,0,Friendly,San Diego,United States,FALSE
 2006-01-23,Jordan,Sweden,0,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
 2006-01-23,Nigeria,Ghana,1,0,African Cup of Nations,Port Said,Egypt,TRUE
 2006-01-23,Zimbabwe,Senegal,0,2,African Cup of Nations,Port Said,Egypt,TRUE
@@ -28415,7 +28415,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-01-25,Cameroon,Togo,2,0,African Cup of Nations,Cairo,Egypt,TRUE
 2006-01-25,Ecuador,Honduras,1,0,Friendly,Guayaquil,Ecuador,FALSE
 2006-01-25,Finland,South Korea,0,1,Friendly,Riyadh,Saudi Arabia,TRUE
-2006-01-25,Mexico,Norway,2,1,Friendly,San Francisco,USA,TRUE
+2006-01-25,Mexico,Norway,2,1,Friendly,San Francisco,United States,TRUE
 2006-01-25,Saudi Arabia,Greece,1,1,Friendly,Riyadh,Saudi Arabia,FALSE
 2006-01-26,Tunisia,South Africa,2,0,African Cup of Nations,Alexandria,Egypt,TRUE
 2006-01-26,Zambia,Guinea,1,2,African Cup of Nations,Alexandria,Egypt,TRUE
@@ -28428,7 +28428,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-01-29,Angola,Togo,3,2,African Cup of Nations,Cairo,Egypt,TRUE
 2006-01-29,Cameroon,DR Congo,2,0,African Cup of Nations,Cairo,Egypt,TRUE
 2006-01-29,South Korea,Croatia,2,0,Lunar New Year Cup,So Kon Po,Hong Kong,TRUE
-2006-01-29,USA,Norway,5,0,Friendly,Carson,USA,FALSE
+2006-01-29,United States,Norway,5,0,Friendly,Carson,United States,FALSE
 2006-01-30,Bahrain,Syria,1,1,Friendly,Manama,Bahrain,FALSE
 2006-01-30,Tunisia,Guinea,0,3,African Cup of Nations,Alexandria,Egypt,TRUE
 2006-01-30,Zambia,South Africa,1,0,African Cup of Nations,Alexandria,Egypt,TRUE
@@ -28447,22 +28447,22 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-02-07,Syria,Palestine,3,0,Friendly,Aleppo,Syria,FALSE
 2006-02-09,Senegal,Nigeria,0,1,African Cup of Nations,Cairo,Egypt,TRUE
 2006-02-10,Egypt,Ivory Coast,0,0,African Cup of Nations,Cairo,Egypt,FALSE
-2006-02-10,USA,Japan,3,2,Friendly,San Francisco,USA,FALSE
-2006-02-11,Costa Rica,South Korea,1,0,Friendly,Oakland,USA,TRUE
+2006-02-10,United States,Japan,3,2,Friendly,San Francisco,United States,FALSE
+2006-02-11,Costa Rica,South Korea,1,0,Friendly,Oakland,United States,TRUE
 2006-02-12,China PR,Honduras,0,1,Friendly,Guangzhou,China PR,FALSE
 2006-02-13,Oman,Iraq,1,0,Friendly,Muscat,Oman,FALSE
 2006-02-14,Jordan,Kazakhstan,2,0,Friendly,Amman,Jordan,FALSE
 2006-02-14,Qatar,Tajikistan,2,0,Friendly,Doha,Qatar,FALSE
 2006-02-14,Saudi Arabia,Syria,1,1,Friendly,Jeddah,Saudi Arabia,FALSE
 2006-02-15,Hong Kong,Singapore,1,1,Friendly,Victoria,Hong Kong,FALSE
-2006-02-15,Mexico,South Korea,0,1,Friendly,Los Angeles,USA,TRUE
+2006-02-15,Mexico,South Korea,0,1,Friendly,Los Angeles,United States,TRUE
 2006-02-16,Bahrain,Palestine,0,2,Friendly,Muharraq,Bahrain,FALSE
 2006-02-16,Thailand,Iraq,4,3,Friendly,Ayutthaya,Thailand,FALSE
 2006-02-18,Hong Kong,India,2,2,Friendly,Victoria,Hong Kong,FALSE
 2006-02-18,Japan,Finland,2,0,Friendly,Fukuroi,Japan,FALSE
 2006-02-18,Pakistan,Palestine,0,3,Friendly,Muharraq,Bahrain,TRUE
 2006-02-19,New Zealand,Malaysia,1,0,Friendly,Christchurch,New Zealand,FALSE
-2006-02-19,USA,Guatemala,4,0,Friendly,Frisco,USA,FALSE
+2006-02-19,United States,Guatemala,4,0,Friendly,Frisco,United States,FALSE
 2006-02-22,Bahrain,Australia,1,3,AFC Asian Cup qualification,Riffa,Bahrain,FALSE
 2006-02-22,China PR,Palestine,2,0,AFC Asian Cup qualification,Guangzhou,China PR,FALSE
 2006-02-22,Hong Kong,Qatar,0,3,AFC Asian Cup qualification,So Kon Po,Hong Kong,FALSE
@@ -28508,13 +28508,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-03-01,Luxembourg,Belgium,0,2,Friendly,Luxembourg,Luxembourg,FALSE
 2006-03-01,North Macedonia,Bulgaria,0,1,Friendly,Skopje,North Macedonia,FALSE
 2006-03-01,Malta,Georgia,0,2,Malta International Tournament,Attard,Malta,FALSE
-2006-03-01,Mexico,Ghana,1,0,Friendly,Frisco,USA,TRUE
+2006-03-01,Mexico,Ghana,1,0,Friendly,Frisco,United States,TRUE
 2006-03-01,Netherlands,Ecuador,1,0,Friendly,Amsterdam,Netherlands,FALSE
 2006-03-01,Northern Ireland,Estonia,1,0,Friendly,Belfast,Northern Ireland,FALSE
 2006-03-01,Oman,Jordan,3,0,AFC Asian Cup qualification,Muscat,Oman,FALSE
 2006-03-01,Pakistan,United Arab Emirates,1,4,AFC Asian Cup qualification,Karachi,Pakistan,FALSE
 2006-03-01,Palestine,Singapore,1,0,AFC Asian Cup qualification,Amman,Jordan,TRUE
-2006-03-01,Poland,USA,0,1,Friendly,Kaiserslautern,Germany,TRUE
+2006-03-01,Poland,United States,0,1,Friendly,Kaiserslautern,Germany,TRUE
 2006-03-01,Qatar,Uzbekistan,2,1,AFC Asian Cup qualification,Doha,Qatar,FALSE
 2006-03-01,Russia,Brazil,0,1,Friendly,Moscow,Russia,FALSE
 2006-03-01,Saudi Arabia,Portugal,0,3,Friendly,Düsseldorf,Germany,TRUE
@@ -28528,11 +28528,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-03-01,Wales,Paraguay,0,0,Friendly,Cardiff,Wales,FALSE
 2006-03-15,Saudi Arabia,Iraq,2,2,Friendly,Jeddah,Saudi Arabia,FALSE
 2006-03-22,Albania,Georgia,0,0,Friendly,Tirana,Albania,FALSE
-2006-03-22,Germany,USA,4,1,Friendly,Dortmund,Germany,FALSE
+2006-03-22,Germany,United States,4,1,Friendly,Dortmund,Germany,FALSE
 2006-03-26,Thailand,Philippines,5,0,Friendly,Chonburi,Thailand,FALSE
 2006-03-28,Saudi Arabia,Poland,1,2,Friendly,Riyadh,Saudi Arabia,FALSE
 2006-03-29,Equatorial Guinea,Benin,2,0,Friendly,Bata,Equatorial Guinea,FALSE
-2006-03-29,Mexico,Paraguay,2,1,Friendly,Chicago,USA,TRUE
+2006-03-29,Mexico,Paraguay,2,1,Friendly,Chicago,United States,TRUE
 2006-03-30,Japan,Ecuador,1,0,Friendly,Ōita,Japan,FALSE
 2006-04-01,Bangladesh,Cambodia,2,1,AFC Challenge Cup,Dhaka,Bangladesh,FALSE
 2006-04-01,Palestine,Guam,11,0,AFC Challenge Cup,Dhaka,Bangladesh,TRUE
@@ -28558,7 +28558,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-04-08,Sri Lanka,Taiwan,3,0,AFC Challenge Cup,Chittagong,Bangladesh,TRUE
 2006-04-09,Palestine,Kyrgyzstan,0,1,AFC Challenge Cup,Dhaka,Bangladesh,TRUE
 2006-04-10,Bangladesh,Tajikistan,1,6,AFC Challenge Cup,Dhaka,Bangladesh,FALSE
-2006-04-11,USA,Jamaica,1,1,Friendly,Cary,USA,FALSE
+2006-04-11,United States,Jamaica,1,1,Friendly,Cary,United States,FALSE
 2006-04-12,Azerbaijan,Turkey,1,1,Friendly,Baku,Azerbaijan,FALSE
 2006-04-12,Sri Lanka,Nepal,1,1,AFC Challenge Cup,Chittagong,Bangladesh,TRUE
 2006-04-13,Tajikistan,Kyrgyzstan,2,0,AFC Challenge Cup,Dhaka,Bangladesh,TRUE
@@ -28575,7 +28575,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-05-01,Jersey,Guernsey,3,2,Friendly,St. Helier,Jersey,FALSE
 2006-05-02,Poland,Lithuania,0,1,Friendly,Bełchatów,Poland,FALSE
 2006-05-02,United Arab Emirates,Syria,2,1,Friendly,Dubai,United Arab Emirates,FALSE
-2006-05-05,Mexico,Venezuela,1,0,Friendly,Pasadena,USA,TRUE
+2006-05-05,Mexico,Venezuela,1,0,Friendly,Pasadena,United States,TRUE
 2006-05-09,Japan,Bulgaria,1,2,Kirin Cup,Osaka,Japan,FALSE
 2006-05-10,Lesotho,South Africa,0,0,Friendly,Maseru,Lesotho,FALSE
 2006-05-10,Trinidad and Tobago,Peru,1,1,Friendly,Port of Spain,Trinidad and Tobago,FALSE
@@ -28593,14 +28593,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-05-20,South Africa,Eswatini,1,0,COSAFA Cup,Gaborone,Botswana,TRUE
 2006-05-21,Botswana,South Africa,0,0,COSAFA Cup,Gaborone,Botswana,FALSE
 2006-05-21,Madagascar,Eswatini,0,2,COSAFA Cup,Gaborone,Botswana,TRUE
-2006-05-21,Northern Ireland,Uruguay,0,1,Friendly,East Rutherford,USA,TRUE
+2006-05-21,Northern Ireland,Uruguay,0,1,Friendly,East Rutherford,United States,TRUE
 2006-05-21,Basque Country,Wales,0,1,Friendly,Bilbao,Spain,FALSE
 2006-05-23,Austria,Croatia,1,4,Friendly,Vienna,Austria,FALSE
 2006-05-23,South Korea,Senegal,1,1,Friendly,Seoul,South Korea,FALSE
-2006-05-23,Romania,Uruguay,0,2,Friendly,Los Angeles,USA,TRUE
-2006-05-23,USA,Morocco,0,1,Friendly,Nashville,USA,FALSE
+2006-05-23,Romania,Uruguay,0,2,Friendly,Los Angeles,United States,TRUE
+2006-05-23,United States,Morocco,0,1,Friendly,Nashville,United States,FALSE
 2006-05-24,Belgium,Turkey,3,3,Friendly,Genk,Belgium,FALSE
-2006-05-24,Colombia,Ecuador,1,1,Friendly,East Rutherford,USA,TRUE
+2006-05-24,Colombia,Ecuador,1,1,Friendly,East Rutherford,United States,TRUE
 2006-05-24,Hungary,New Zealand,2,0,Friendly,Budapest,Hungary,FALSE
 2006-05-24,Republic of Ireland,Chile,0,1,Friendly,Dublin,Republic of Ireland,FALSE
 2006-05-24,Norway,Paraguay,2,2,Friendly,Oslo,Norway,FALSE
@@ -28609,16 +28609,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-05-25,Sweden,Finland,0,0,Friendly,Gothenburg,Sweden,FALSE
 2006-05-26,Czech Republic,Saudi Arabia,2,0,Friendly,Innsbruck,Austria,TRUE
 2006-05-26,South Korea,Bosnia and Herzegovina,2,0,Friendly,Seoul,South Korea,FALSE
-2006-05-26,Romania,Northern Ireland,2,0,Friendly,Chicago,USA,TRUE
+2006-05-26,Romania,Northern Ireland,2,0,Friendly,Chicago,United States,TRUE
 2006-05-26,Turkey,Ghana,1,1,Friendly,Bochum,Germany,TRUE
-2006-05-26,USA,Venezuela,2,0,Friendly,Cleveland,USA,FALSE
+2006-05-26,United States,Venezuela,2,0,Friendly,Cleveland,United States,FALSE
 2006-05-27,Denmark,Paraguay,1,1,Friendly,Aarhus,Denmark,FALSE
 2006-05-27,France,Mexico,1,0,Friendly,Saint-Denis,France,FALSE
 2006-05-27,Georgia,New Zealand,1,3,Friendly,Altenkirchen,Germany,TRUE
 2006-05-27,Germany,Luxembourg,7,0,Friendly,Freiburg,Germany,FALSE
 2006-05-27,Netherlands,Cameroon,1,0,Friendly,Rotterdam,Netherlands,FALSE
 2006-05-27,Portugal,Cape Verde,4,1,Friendly,Évora,Portugal,FALSE
-2006-05-27,Romania,Colombia,0,0,Friendly,Chicago,USA,TRUE
+2006-05-27,Romania,Colombia,0,0,Friendly,Chicago,United States,TRUE
 2006-05-27,Serbia,Uruguay,1,1,Friendly,Belgrade,Serbia and Montenegro,FALSE
 2006-05-27,Spain,Russia,0,0,Friendly,Albacete,Spain,FALSE
 2006-05-27,Switzerland,Ivory Coast,1,1,Friendly,Basel,Switzerland,FALSE
@@ -28628,7 +28628,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-05-28,Morocco,Mali,0,1,Friendly,Colombes,France,TRUE
 2006-05-28,Turkey,Estonia,1,1,Friendly,Hamburg,Germany,TRUE
 2006-05-28,Ukraine,Costa Rica,4,0,Friendly,Kyiv,Ukraine,FALSE
-2006-05-28,USA,Latvia,1,0,Friendly,East Hartford,USA,FALSE
+2006-05-28,United States,Latvia,1,0,Friendly,East Hartford,United States,FALSE
 2006-05-29,Jamaica,Ghana,1,4,Friendly,Leicester,England,TRUE
 2006-05-29,Northern Cyprus,Greenland,1,0,FIFI Wild Cup,Hamburg,Germany,TRUE
 2006-05-29,Republic of St. Pauli,Gibraltar,1,1,FIFI Wild Cup,Hamburg,Germany,FALSE
@@ -28696,7 +28696,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-06-11,Serbia,Netherlands,0,1,FIFA World Cup,Leipzig,Germany,TRUE
 2006-06-12,Australia,Japan,3,1,FIFA World Cup,Kaiserslautern,Germany,TRUE
 2006-06-12,Italy,Ghana,2,0,FIFA World Cup,Hanover,Germany,TRUE
-2006-06-12,USA,Czech Republic,0,3,FIFA World Cup,Gelsenkirchen,Germany,TRUE
+2006-06-12,United States,Czech Republic,0,3,FIFA World Cup,Gelsenkirchen,Germany,TRUE
 2006-06-13,Brazil,Croatia,1,0,FIFA World Cup,Berlin,Germany,TRUE
 2006-06-13,France,Switzerland,0,0,FIFA World Cup,Stuttgart,Germany,TRUE
 2006-06-13,South Korea,Togo,2,1,FIFA World Cup,Frankfurt am Main,Germany,TRUE
@@ -28710,7 +28710,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-06-16,Mexico,Angola,0,0,FIFA World Cup,Hanover,Germany,TRUE
 2006-06-16,Netherlands,Ivory Coast,2,1,FIFA World Cup,Stuttgart,Germany,TRUE
 2006-06-17,Czech Republic,Ghana,0,2,FIFA World Cup,Cologne,Germany,TRUE
-2006-06-17,Italy,USA,1,1,FIFA World Cup,Kaiserslautern,Germany,TRUE
+2006-06-17,Italy,United States,1,1,FIFA World Cup,Kaiserslautern,Germany,TRUE
 2006-06-17,Portugal,Iran,2,0,FIFA World Cup,Frankfurt am Main,Germany,TRUE
 2006-06-18,Brazil,Australia,2,0,FIFA World Cup,Munich,Germany,TRUE
 2006-06-18,France,South Korea,1,1,FIFA World Cup,Leipzig,Germany,TRUE
@@ -28728,7 +28728,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-06-21,Portugal,Mexico,2,1,FIFA World Cup,Gelsenkirchen,Germany,TRUE
 2006-06-22,Croatia,Australia,2,2,FIFA World Cup,Stuttgart,Germany,TRUE
 2006-06-22,Czech Republic,Italy,0,2,FIFA World Cup,Hamburg,Germany,TRUE
-2006-06-22,Ghana,USA,2,1,FIFA World Cup,Nuremberg,Germany,TRUE
+2006-06-22,Ghana,United States,2,1,FIFA World Cup,Nuremberg,Germany,TRUE
 2006-06-22,Japan,Brazil,1,4,FIFA World Cup,Dortmund,Germany,TRUE
 2006-06-23,Saudi Arabia,Spain,0,1,FIFA World Cup,Kaiserslautern,Germany,TRUE
 2006-06-23,Switzerland,South Korea,2,0,FIFA World Cup,Hanover,Germany,TRUE
@@ -28809,7 +28809,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-08-16,Faroe Islands,Georgia,0,6,UEFA Euro qualification,Toftir,Faroe Islands,FALSE
 2006-08-16,Finland,Northern Ireland,1,2,Friendly,Helsinki,Finland,FALSE
 2006-08-16,Germany,Sweden,3,0,Friendly,Gelsenkirchen,Germany,FALSE
-2006-08-16,Guatemala,Haiti,1,1,Friendly,Miami,USA,TRUE
+2006-08-16,Guatemala,Haiti,1,1,Friendly,Miami,United States,TRUE
 2006-08-16,India,Saudi Arabia,0,3,AFC Asian Cup qualification,Calcutta,India,FALSE
 2006-08-16,Iran,Syria,1,1,AFC Asian Cup qualification,Tehran,Iran,FALSE
 2006-08-16,Republic of Ireland,Netherlands,0,4,Friendly,Dublin,Republic of Ireland,FALSE
@@ -28907,7 +28907,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-09-06,Bulgaria,Slovenia,3,0,UEFA Euro qualification,Sofia,Bulgaria,FALSE
 2006-09-06,Cuba,Cayman Islands,7,0,CFU Caribbean Cup qualification,Havana,Cuba,FALSE
 2006-09-06,Curaçao,Grenada,1,1,CFU Caribbean Cup qualification,Willemstad,Netherlands Antilles,TRUE
-2006-09-06,Ecuador,Peru,1,1,Friendly,East Rutherford,USA,TRUE
+2006-09-06,Ecuador,Peru,1,1,Friendly,East Rutherford,United States,TRUE
 2006-09-06,Finland,Portugal,1,1,UEFA Euro qualification,Helsinki,Finland,FALSE
 2006-09-06,France,Italy,3,1,UEFA Euro qualification,Saint-Denis,France,FALSE
 2006-09-06,Guatemala,Panama,1,2,Friendly,Guatemala,Guatemala,FALSE
@@ -28962,14 +28962,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-09-24,Guadeloupe,Martinique,4,0,CFU Caribbean Cup qualification,Les Abymes,Guadeloupe,FALSE
 2006-09-27,Jamaica,Saint Lucia,4,0,CFU Caribbean Cup qualification,Kingston,Jamaica,FALSE
 2006-09-27,Venezuela,Uruguay,1,0,Friendly,Maracaibo,Venezuela,FALSE
-2006-09-27,USA Virgin Islands,Bermuda,0,6,CFU Caribbean Cup qualification,Charlotte Amalie,USA Virgin Islands,FALSE
-2006-09-29,Bermuda,Dominican Republic,3,1,CFU Caribbean Cup qualification,Charlotte Amalie,USA Virgin Islands,TRUE
+2006-09-27,United States Virgin Islands,Bermuda,0,6,CFU Caribbean Cup qualification,Charlotte Amalie,United States Virgin Islands,FALSE
+2006-09-29,Bermuda,Dominican Republic,3,1,CFU Caribbean Cup qualification,Charlotte Amalie,United States Virgin Islands,TRUE
 2006-09-29,Saint Lucia,Haiti,1,7,CFU Caribbean Cup qualification,Kingston,Jamaica,TRUE
 2006-09-30,Tanzania,Kenya,0,0,Friendly,Dar es Salaam,Tanzania,FALSE
 2006-10-01,Jamaica,Haiti,2,0,CFU Caribbean Cup qualification,Kingston,Jamaica,FALSE
 2006-10-01,Libya,Sudan,1,0,Friendly,Tripoli,Libya,FALSE
 2006-10-01,Saint Vincent and the Grenadines,Saint Lucia,8,0,CFU Caribbean Cup qualification,Kingston,Jamaica,TRUE
-2006-10-01,USA Virgin Islands,Dominican Republic,1,6,CFU Caribbean Cup qualification,Charlotte Amalie,USA Virgin Islands,FALSE
+2006-10-01,United States Virgin Islands,Dominican Republic,1,6,CFU Caribbean Cup qualification,Charlotte Amalie,United States Virgin Islands,FALSE
 2006-10-03,Botswana,Lesotho,1,0,Friendly,Gaborone,Botswana,FALSE
 2006-10-04,Ethiopia,Eswatini,2,0,Friendly,Addis Ababa,Ethiopia,FALSE
 2006-10-04,Iran,Iraq,2,0,Friendly,Amman,Jordan,TRUE
@@ -28994,7 +28994,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-10-07,Faroe Islands,Lithuania,0,1,UEFA Euro qualification,Tórshavn,Faroe Islands,FALSE
 2006-10-07,Germany,Georgia,2,0,Friendly,Rostock,Germany,FALSE
 2006-10-07,Greece,Norway,1,0,UEFA Euro qualification,Piraeus,Greece,FALSE
-2006-10-07,Guatemala,Honduras,2,3,Friendly,Fort Lauderdale,USA,TRUE
+2006-10-07,Guatemala,Honduras,2,3,Friendly,Fort Lauderdale,United States,TRUE
 2006-10-07,Hungary,Turkey,0,1,UEFA Euro qualification,Budapest,Hungary,FALSE
 2006-10-07,Italy,Ukraine,2,0,UEFA Euro qualification,Rome,Italy,FALSE
 2006-10-07,Kazakhstan,Poland,0,1,UEFA Euro qualification,Almaty,Kazakhstan,FALSE
@@ -29029,7 +29029,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2006-10-08,Zambia,South Africa,0,1,African Cup of Nations qualification,Lusaka,Zambia,FALSE
 2006-10-08,Catalonia,Basque Country,2,2,Friendly,Barcelona,Spain,FALSE
 2006-10-10,Brazil,Ecuador,2,1,Friendly,Solna,Sweden,TRUE
-2006-10-10,Honduras,Guatemala,2,1,Friendly,Atlanta,USA,TRUE
+2006-10-10,Honduras,Guatemala,2,1,Friendly,Atlanta,United States,TRUE
 2006-10-11,Andorra,North Macedonia,0,3,UEFA Euro qualification,Sant Julià de Lòria,Andorra,FALSE
 2006-10-11,Australia,Bahrain,2,0,AFC Asian Cup qualification,Sydney,Australia,FALSE
 2006-10-11,Austria,Switzerland,2,1,Friendly,Innsbruck,Austria,FALSE
@@ -29232,7 +29232,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-01-13,Singapore,Vietnam,0,0,AFF Championship,Singapore,Singapore,FALSE
 2007-01-14,Cuba,Guadeloupe,1,2,CFU Caribbean Cup,San Fernando,Trinidad and Tobago,TRUE
 2007-01-14,Malaysia,Myanmar,0,0,AFF Championship,Bangkok,Thailand,TRUE
-2007-01-14,Panama,Armenia,1,1,Friendly,Monterey Park,USA,TRUE
+2007-01-14,Panama,Armenia,1,1,Friendly,Monterey Park,United States,TRUE
 2007-01-14,Thailand,Philippines,4,0,AFF Championship,Bangkok,Thailand,FALSE
 2007-01-14,Venezuela,Sweden,2,0,Friendly,Maracaibo,Venezuela,FALSE
 2007-01-15,Haiti,Barbados,2,0,CFU Caribbean Cup,Port of Spain,Trinidad and Tobago,TRUE
@@ -29315,7 +29315,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-02-07,Senegal,Benin,2,1,Friendly,Rouen,France,TRUE
 2007-02-07,Slovenia,Estonia,1,0,Friendly,Domžale,Slovenia,FALSE
 2007-02-07,Togo,Cameroon,2,2,Friendly,Lomé,Togo,FALSE
-2007-02-07,USA,Mexico,2,0,Friendly,Glendale,USA,FALSE
+2007-02-07,United States,Mexico,2,0,Friendly,Glendale,United States,FALSE
 2007-02-07,Uzbekistan,Azerbaijan,0,0,Friendly,Qarshi,Uzbekistan,FALSE
 2007-02-07,Venezuela,Chile,0,1,Friendly,Maracaibo,Venezuela,FALSE
 2007-02-08,El Salvador,Belize,2,1,UNCAF Cup,San Salvador,El Salvador,FALSE
@@ -29334,7 +29334,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-02-18,Costa Rica,Panama,1,1,UNCAF Cup,San Salvador,El Salvador,TRUE
 2007-02-18,El Salvador,Guatemala,0,1,UNCAF Cup,San Salvador,El Salvador,FALSE
 2007-02-22,Benin,Chad,0,1,Friendly,Cotonou,Benin,FALSE
-2007-02-28,Mexico,Venezuela,3,1,Friendly,San Diego,USA,TRUE
+2007-02-28,Mexico,Venezuela,3,1,Friendly,San Diego,United States,TRUE
 2007-03-07,Azerbaijan,Uzbekistan,1,0,Friendly,Shymkent,Kazakhstan,TRUE
 2007-03-07,Kazakhstan,Kyrgyzstan,2,0,Friendly,Shymkent,Kazakhstan,FALSE
 2007-03-09,Kazakhstan,Azerbaijan,1,0,Friendly,Shymkent,Kazakhstan,FALSE
@@ -29344,7 +29344,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-03-18,Eswatini,Lesotho,0,1,Friendly,Lobamba,Eswatini,FALSE
 2007-03-20,Libya,Mauritania,0,0,Friendly,Tripoli,Libya,FALSE
 2007-03-21,Mauritius,Ivory Coast,0,3,Friendly,Belle Vue,Mauritius,FALSE
-2007-03-22,Jamaica,Switzerland,0,2,Friendly,Fort Lauderdale,USA,TRUE
+2007-03-22,Jamaica,Switzerland,0,2,Friendly,Fort Lauderdale,United States,TRUE
 2007-03-24,Albania,Slovenia,0,0,UEFA Euro qualification,Shkodër,Albania,FALSE
 2007-03-24,Algeria,Cape Verde,2,0,African Cup of Nations qualification,Algiers,Algeria,FALSE
 2007-03-24,Austria,Ghana,1,1,Friendly,Graz,Austria,FALSE
@@ -29357,13 +29357,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-03-24,Croatia,North Macedonia,2,1,UEFA Euro qualification,Zagreb,Croatia,FALSE
 2007-03-24,Cyprus,Slovakia,1,3,UEFA Euro qualification,Nicosia,Cyprus,FALSE
 2007-03-24,Czech Republic,Germany,1,2,UEFA Euro qualification,Prague,Czech Republic,FALSE
-2007-03-24,El Salvador,Honduras,0,2,Friendly,Fort Lauderdale,USA,TRUE
+2007-03-24,El Salvador,Honduras,0,2,Friendly,Fort Lauderdale,United States,TRUE
 2007-03-24,Estonia,Russia,0,2,UEFA Euro qualification,Tallinn,Estonia,FALSE
 2007-03-24,Faroe Islands,Ukraine,0,2,UEFA Euro qualification,Toftir,Faroe Islands,FALSE
 2007-03-24,Gambia,Guinea,0,2,African Cup of Nations qualification,Bakau,Gambia,FALSE
 2007-03-24,Greece,Turkey,1,4,UEFA Euro qualification,Piraeus,Greece,FALSE
 2007-03-24,Guadeloupe,Trinidad and Tobago,2,2,Friendly,Le Gosier,Guadeloupe,FALSE
-2007-03-24,Haiti,Panama,3,0,Friendly,Miami,USA,TRUE
+2007-03-24,Haiti,Panama,3,0,Friendly,Miami,United States,TRUE
 2007-03-24,Republic of Ireland,Wales,1,0,UEFA Euro qualification,Dublin,Republic of Ireland,FALSE
 2007-03-24,Israel,England,0,0,UEFA Euro qualification,Ramat-Gan,Israel,FALSE
 2007-03-24,Japan,Peru,2,0,Friendly,Yokohama,Japan,FALSE
@@ -29391,7 +29391,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-03-25,Barbados,Guatemala,0,0,Friendly,Bridgetown,Barbados,FALSE
 2007-03-25,Bermuda,Canada,0,3,Friendly,Hamilton,Bermuda,FALSE
 2007-03-25,Botswana,Burundi,1,0,African Cup of Nations qualification,Gaborone,Botswana,FALSE
-2007-03-25,Colombia,Switzerland,3,1,Friendly,Miami,USA,TRUE
+2007-03-25,Colombia,Switzerland,3,1,Friendly,Miami,United States,TRUE
 2007-03-25,Congo,Zambia,0,0,African Cup of Nations qualification,Brazzaville,Congo,FALSE
 2007-03-25,Egypt,Mauritania,3,0,African Cup of Nations qualification,Cairo,Egypt,FALSE
 2007-03-25,Equatorial Guinea,Rwanda,3,1,African Cup of Nations qualification,Malabo,Equatorial Guinea,FALSE
@@ -29403,12 +29403,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-03-25,Mauritius,Sudan,1,2,African Cup of Nations qualification,Curepipe,Mauritius,FALSE
 2007-03-25,Mexico,Paraguay,2,1,Friendly,Monterrey,Mexico,FALSE
 2007-03-25,Northern Mariana Islands,Guam,2,3,EAFF Championship,Oleai,Northern Mariana Islands,FALSE
-2007-03-25,USA,Ecuador,3,1,Friendly,Tampa,USA,FALSE
+2007-03-25,United States,Ecuador,3,1,Friendly,Tampa,United States,FALSE
 2007-03-25,Zimbabwe,Morocco,1,1,African Cup of Nations qualification,Harare,Zimbabwe,FALSE
 2007-03-26,Jamaica,Panama,1,1,Friendly,Kingston,Jamaica,FALSE
 2007-03-27,Brazil,Ghana,1,0,Friendly,Solna,Sweden,TRUE
 2007-03-27,China PR,Uzbekistan,3,1,Friendly,Macau,Macau,TRUE
-2007-03-27,El Salvador,Honduras,0,2,Friendly,Cary,USA,TRUE
+2007-03-27,El Salvador,Honduras,0,2,Friendly,Cary,United States,TRUE
 2007-03-28,Andorra,England,0,3,UEFA Euro qualification,Barcelona,Spain,TRUE
 2007-03-28,Azerbaijan,Finland,1,0,UEFA Euro qualification,Baku,Azerbaijan,FALSE
 2007-03-28,Bulgaria,Albania,0,0,UEFA Euro qualification,Sofia,Bulgaria,FALSE
@@ -29424,7 +29424,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-03-28,Italy,Scotland,2,0,UEFA Euro qualification,Bari,Italy,FALSE
 2007-03-28,Liechtenstein,Latvia,1,0,UEFA Euro qualification,Vaduz,Liechtenstein,FALSE
 2007-03-28,Malta,Greece,0,1,UEFA Euro qualification,Attard,Malta,FALSE
-2007-03-28,Mexico,Ecuador,4,2,Friendly,Oakland,USA,TRUE
+2007-03-28,Mexico,Ecuador,4,2,Friendly,Oakland,United States,TRUE
 2007-03-28,Northern Ireland,Sweden,2,1,UEFA Euro qualification,Belfast,Northern Ireland,FALSE
 2007-03-28,Poland,Armenia,1,0,UEFA Euro qualification,Kielce,Poland,FALSE
 2007-03-28,Romania,Luxembourg,3,0,UEFA Euro qualification,Piatra Neamţ,Romania,FALSE
@@ -29434,7 +29434,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-03-28,Spain,Iceland,1,0,UEFA Euro qualification,Palma de Mallorca,Spain,FALSE
 2007-03-28,Turkey,Norway,2,2,UEFA Euro qualification,Frankfurt am Main,Germany,TRUE
 2007-03-28,Ukraine,Lithuania,1,0,UEFA Euro qualification,Odessa,Ukraine,FALSE
-2007-03-28,USA,Guatemala,0,0,Friendly,Frisco,USA,FALSE
+2007-03-28,United States,Guatemala,0,0,Friendly,Frisco,United States,FALSE
 2007-03-28,Venezuela,New Zealand,5,0,Friendly,Maracaibo,Venezuela,FALSE
 2007-03-28,Wales,San Marino,3,0,UEFA Euro qualification,Cardiff,Wales,FALSE
 2007-04-01,Guam,Northern Mariana Islands,9,0,EAFF Championship,Hagätña,Guam,FALSE
@@ -29457,11 +29457,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-05-17,Guadeloupe,Dominica,2,0,Friendly,Morne-à-l'Eau,Guadeloupe,FALSE
 2007-05-20,Guadeloupe,Dominica,0,0,Friendly,Basse-Terre,Guadeloupe,FALSE
 2007-05-21,Eritrea,Sudan,1,0,Friendly,Asmara,Eritrea,FALSE
-2007-05-23,Ecuador,Republic of Ireland,1,1,Friendly,East Rutherford,USA,TRUE
+2007-05-23,Ecuador,Republic of Ireland,1,1,Friendly,East Rutherford,United States,TRUE
 2007-05-23,Haiti,Chile,0,0,Friendly,Port-au-Prince,Haiti,FALSE
 2007-05-25,Venezuela,Honduras,2,1,Friendly,Mérida,Venezuela,FALSE
 2007-05-25,Zimbabwe,Lesotho,1,1,Friendly,Masvingo,Zimbabwe,FALSE
-2007-05-26,Bolivia,Republic of Ireland,1,1,Friendly,Foxborough,USA,TRUE
+2007-05-26,Bolivia,Republic of Ireland,1,1,Friendly,Foxborough,United States,TRUE
 2007-05-26,Eritrea,Sudan,1,1,Friendly,Asmara,Eritrea,FALSE
 2007-05-26,Malawi,South Africa,0,0,COSAFA Cup,Lobamba,Eswatini,TRUE
 2007-05-26,Namibia,Zambia,1,2,Friendly,Windhoek,Namibia,FALSE
@@ -29520,7 +29520,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-06-02,Tanzania,Senegal,1,1,African Cup of Nations qualification,Mwanza,Tanzania,FALSE
 2007-06-02,Tunisia,Seychelles,4,0,African Cup of Nations qualification,Radès,Tunisia,FALSE
 2007-06-02,Uganda,Nigeria,2,1,African Cup of Nations qualification,Kampala,Uganda,FALSE
-2007-06-02,USA,China PR,4,1,Friendly,San Jose,USA,FALSE
+2007-06-02,United States,China PR,4,1,Friendly,San Jose,United States,FALSE
 2007-06-02,Wales,Czech Republic,0,0,UEFA Euro qualification,Cardiff,Wales,FALSE
 2007-06-02,Zambia,Congo,3,0,African Cup of Nations qualification,Chililabombwe,Zambia,FALSE
 2007-06-03,Benin,Mali,0,0,African Cup of Nations qualification,Cotonou,Benin,FALSE
@@ -29545,7 +29545,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-06-06,Armenia,Poland,1,0,UEFA Euro qualification,Yerevan,Armenia,FALSE
 2007-06-06,Bosnia and Herzegovina,Malta,1,0,UEFA Euro qualification,Sarajevo,Bosnia and Herzegovina,FALSE
 2007-06-06,Bulgaria,Belarus,2,1,UEFA Euro qualification,Sofia,Bulgaria,FALSE
-2007-06-06,Costa Rica,Canada,1,2,Gold Cup,Miami,USA,TRUE
+2007-06-06,Costa Rica,Canada,1,2,Gold Cup,Miami,United States,TRUE
 2007-06-06,Croatia,Russia,0,0,UEFA Euro qualification,Zagreb,Croatia,FALSE
 2007-06-06,Ecuador,Peru,2,0,Friendly,Barcelona,Spain,TRUE
 2007-06-06,Estonia,England,0,3,UEFA Euro qualification,Tallinn,Estonia,FALSE
@@ -29554,7 +29554,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-06-06,France,Georgia,1,0,UEFA Euro qualification,Auxerre,France,FALSE
 2007-06-06,Germany,Slovakia,2,1,UEFA Euro qualification,Hamburg,Germany,FALSE
 2007-06-06,Greece,Moldova,2,1,UEFA Euro qualification,Heraklion,Greece,FALSE
-2007-06-06,Guadeloupe,Haiti,1,1,Gold Cup,Miami,USA,TRUE
+2007-06-06,Guadeloupe,Haiti,1,1,Gold Cup,Miami,United States,TRUE
 2007-06-06,Kazakhstan,Azerbaijan,1,1,UEFA Euro qualification,Almaty,Kazakhstan,FALSE
 2007-06-06,Latvia,Denmark,0,2,UEFA Euro qualification,Riga,Latvia,FALSE
 2007-06-06,Liechtenstein,Spain,0,2,UEFA Euro qualification,Vaduz,Liechtenstein,FALSE
@@ -29564,35 +29564,35 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-06-06,Romania,Slovenia,2,0,UEFA Euro qualification,Timişoara,Romania,FALSE
 2007-06-06,Sweden,Iceland,5,0,UEFA Euro qualification,Solna,Sweden,FALSE
 2007-06-06,Thailand,Netherlands,1,3,Friendly,Bangkok,Thailand,FALSE
-2007-06-07,El Salvador,Trinidad and Tobago,2,1,Gold Cup,Carson,USA,TRUE
-2007-06-07,USA,Guatemala,1,0,Gold Cup,Carson,USA,FALSE
+2007-06-07,El Salvador,Trinidad and Tobago,2,1,Gold Cup,Carson,United States,TRUE
+2007-06-07,United States,Guatemala,1,0,Gold Cup,Carson,United States,FALSE
 2007-06-08,Jordan,Iraq,1,1,Friendly,Amman,Jordan,FALSE
-2007-06-08,Mexico,Cuba,2,1,Gold Cup,East Rutherford,USA,TRUE
-2007-06-08,Panama,Honduras,3,2,Gold Cup,East Rutherford,USA,TRUE
+2007-06-08,Mexico,Cuba,2,1,Gold Cup,East Rutherford,United States,TRUE
+2007-06-08,Panama,Honduras,3,2,Gold Cup,East Rutherford,United States,TRUE
 2007-06-09,Burkina Faso,Mali,0,1,Friendly,Ouagadougou,Burkina Faso,FALSE
-2007-06-09,Canada,Guadeloupe,1,2,Gold Cup,Miami,USA,TRUE
-2007-06-09,Guatemala,El Salvador,1,0,Gold Cup,Carson,USA,TRUE
-2007-06-09,Haiti,Costa Rica,1,1,Gold Cup,Miami,USA,TRUE
+2007-06-09,Canada,Guadeloupe,1,2,Gold Cup,Miami,United States,TRUE
+2007-06-09,Guatemala,El Salvador,1,0,Gold Cup,Carson,United States,TRUE
+2007-06-09,Haiti,Costa Rica,1,1,Gold Cup,Miami,United States,TRUE
 2007-06-09,Tanzania,Zambia,1,1,Friendly,Morogoro,Tanzania,FALSE
-2007-06-09,USA,Trinidad and Tobago,2,0,Gold Cup,Carson,USA,FALSE
-2007-06-10,Honduras,Mexico,2,1,Gold Cup,East Rutherford,USA,TRUE
+2007-06-09,United States,Trinidad and Tobago,2,0,Gold Cup,Carson,United States,FALSE
+2007-06-10,Honduras,Mexico,2,1,Gold Cup,East Rutherford,United States,TRUE
 2007-06-10,Hong Kong,Macau,2,1,Friendly,So Kon Po,Hong Kong,FALSE
 2007-06-10,Kenya,Rwanda,2,0,Friendly,Nairobi,Kenya,FALSE
 2007-06-10,Malawi,Senegal,2,3,Friendly,Blantyre,Malawi,FALSE
-2007-06-10,Panama,Cuba,2,2,Gold Cup,East Rutherford,USA,TRUE
-2007-06-11,Costa Rica,Guadeloupe,1,0,Gold Cup,Miami,USA,TRUE
-2007-06-11,Haiti,Canada,0,2,Gold Cup,Miami,USA,TRUE
+2007-06-10,Panama,Cuba,2,2,Gold Cup,East Rutherford,United States,TRUE
+2007-06-11,Costa Rica,Guadeloupe,1,0,Gold Cup,Miami,United States,TRUE
+2007-06-11,Haiti,Canada,0,2,Gold Cup,Miami,United States,TRUE
 2007-06-12,Jordan,Iraq,0,0,Friendly,Amman,Jordan,FALSE
 2007-06-12,Kuwait,Egypt,1,1,Friendly,Kuwait City,Kuwait,FALSE
 2007-06-12,Réunion,Gabon,0,3,Friendly,Saint-Pierre,Réunion,FALSE
-2007-06-12,Trinidad and Tobago,Guatemala,1,1,Gold Cup,Foxborough,USA,TRUE
-2007-06-12,USA,El Salvador,4,0,Gold Cup,Foxborough,USA,FALSE
-2007-06-13,Cuba,Honduras,0,5,Gold Cup,Houston,USA,TRUE
-2007-06-13,Mexico,Panama,1,0,Gold Cup,Houston,USA,TRUE
+2007-06-12,Trinidad and Tobago,Guatemala,1,1,Gold Cup,Foxborough,United States,TRUE
+2007-06-12,United States,El Salvador,4,0,Gold Cup,Foxborough,United States,FALSE
+2007-06-13,Cuba,Honduras,0,5,Gold Cup,Houston,United States,TRUE
+2007-06-13,Mexico,Panama,1,0,Gold Cup,Houston,United States,TRUE
 2007-06-16,Algeria,Guinea,0,2,African Cup of Nations qualification,Algiers,Algeria,FALSE
 2007-06-16,Botswana,Mauritania,2,1,African Cup of Nations qualification,Gaborone,Botswana,FALSE
 2007-06-16,Burkina Faso,Tanzania,0,1,African Cup of Nations qualification,Ouagadougou,Burkina Faso,FALSE
-2007-06-16,Canada,Guatemala,3,0,Gold Cup,Foxborough,USA,TRUE
+2007-06-16,Canada,Guatemala,3,0,Gold Cup,Foxborough,United States,TRUE
 2007-06-16,Cape Verde,Gambia,0,0,African Cup of Nations qualification,Praia,Cape Verde,FALSE
 2007-06-16,Eritrea,Kenya,1,0,African Cup of Nations qualification,Asmara,Eritrea,FALSE
 2007-06-16,Iran,Iraq,0,0,WAFF Championship,Amman,Jordan,TRUE
@@ -29601,20 +29601,20 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-06-16,Namibia,DR Congo,1,1,African Cup of Nations qualification,Windhoek,Namibia,FALSE
 2007-06-16,Seychelles,Sudan,0,2,African Cup of Nations qualification,Victoria,Seychelles,FALSE
 2007-06-16,Tunisia,Mauritius,2,0,African Cup of Nations qualification,Radès,Tunisia,FALSE
-2007-06-16,USA,Panama,2,1,Gold Cup,Foxborough,USA,FALSE
+2007-06-16,United States,Panama,2,1,Gold Cup,Foxborough,United States,FALSE
 2007-06-16,Zambia,Chad,1,1,African Cup of Nations qualification,Chililabombwe,Zambia,FALSE
 2007-06-17,Angola,Eswatini,3,0,African Cup of Nations qualification,Luanda,Angola,FALSE
 2007-06-17,Benin,Togo,4,1,African Cup of Nations qualification,Cotonou,Benin,FALSE
 2007-06-17,Cameroon,Rwanda,2,1,African Cup of Nations qualification,Garoua,Cameroon,FALSE
 2007-06-17,Congo,South Africa,1,1,African Cup of Nations qualification,Pointe-Noire,Congo,FALSE
 2007-06-17,Guam,Taiwan,0,10,EAFF Championship,Macau,Macau,TRUE
-2007-06-17,Honduras,Guadeloupe,1,2,Gold Cup,Houston,USA,TRUE
+2007-06-17,Honduras,Guadeloupe,1,2,Gold Cup,Houston,United States,TRUE
 2007-06-17,Liberia,Equatorial Guinea,0,0,African Cup of Nations qualification,Monrovia,Liberia,FALSE
 2007-06-17,Libya,Ethiopia,3,1,African Cup of Nations qualification,Tripoli,Libya,FALSE
 2007-06-17,Macau,Mongolia,0,0,EAFF Championship,Macau,Macau,FALSE
 2007-06-17,Madagascar,Gabon,0,2,African Cup of Nations qualification,Antananarivo,Madagascar,FALSE
 2007-06-17,Mali,Sierra Leone,6,0,African Cup of Nations qualification,Bamako,Mali,FALSE
-2007-06-17,Mexico,Costa Rica,1,0,Gold Cup,Houston,USA,TRUE
+2007-06-17,Mexico,Costa Rica,1,0,Gold Cup,Houston,United States,TRUE
 2007-06-17,Mozambique,Senegal,0,0,African Cup of Nations qualification,Maputo,Mozambique,FALSE
 2007-06-17,Niger,Nigeria,1,3,African Cup of Nations qualification,Niamey,Niger,FALSE
 2007-06-18,Jordan,Syria,0,1,WAFF Championship,Amman,Jordan,FALSE
@@ -29631,8 +29631,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-06-21,Indonesia,Jamaica,2,1,Friendly,Jakarta,Indonesia,FALSE
 2007-06-21,Macau,North Korea,1,7,EAFF Championship,Macau,Macau,FALSE
 2007-06-21,Malaysia,United Arab Emirates,1,3,Friendly,Petaling Jaya,Malaysia,FALSE
-2007-06-21,Mexico,Guadeloupe,1,0,Gold Cup,Chicago,USA,TRUE
-2007-06-21,USA,Canada,2,1,Gold Cup,Chicago,USA,FALSE
+2007-06-21,Mexico,Guadeloupe,1,0,Gold Cup,Chicago,United States,TRUE
+2007-06-21,United States,Canada,2,1,Gold Cup,Chicago,United States,FALSE
 2007-06-22,Jordan,Iran,0,1,WAFF Championship,Amman,Jordan,FALSE
 2007-06-22,Syria,Iraq,0,3,WAFF Championship,Amman,Jordan,TRUE
 2007-06-23,Colombia,Ecuador,3,1,Friendly,Barranquilla,Colombia,FALSE
@@ -29641,7 +29641,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-06-24,Iraq,Iran,1,2,WAFF Championship,Amman,Jordan,TRUE
 2007-06-24,North Korea,Hong Kong,1,0,EAFF Championship,Macau,Macau,TRUE
 2007-06-24,United Arab Emirates,Saudi Arabia,0,2,Friendly,Singapore,Singapore,TRUE
-2007-06-24,USA,Mexico,2,1,Gold Cup,Chicago,USA,FALSE
+2007-06-24,United States,Mexico,2,1,Gold Cup,Chicago,United States,FALSE
 2007-06-24,Vietnam,Jamaica,3,0,Friendly,Hanoi,Vietnam,FALSE
 2007-06-25,Qatar,Turkmenistan,1,0,Friendly,Doha,Qatar,FALSE
 2007-06-26,Uruguay,Peru,0,3,Copa América,Mérida,Venezuela,TRUE
@@ -29650,7 +29650,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-06-27,Ecuador,Chile,2,3,Copa América,Puerto Ordaz,Venezuela,TRUE
 2007-06-27,Singapore,Saudi Arabia,1,2,Friendly,Singapore,Singapore,FALSE
 2007-06-27,United Arab Emirates,Bahrain,2,2,Friendly,Petaling Jaya,Malaysia,TRUE
-2007-06-28,Argentina,USA,4,1,Copa América,Maracaibo,Venezuela,TRUE
+2007-06-28,Argentina,United States,4,1,Copa América,Maracaibo,Venezuela,TRUE
 2007-06-28,Malaysia,Jamaica,0,2,Friendly,Kuala Lumpur,Malaysia,FALSE
 2007-06-28,Oman,North Korea,2,2,Friendly,Singapore,Singapore,TRUE
 2007-06-28,Paraguay,Colombia,5,0,Copa América,Barinas,Venezuela,TRUE
@@ -29675,7 +29675,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-07-02,Iran,Jamaica,8,1,Friendly,Tehran,Iran,FALSE
 2007-07-02,Iraq,Uzbekistan,0,2,Friendly,Paju,South Korea,TRUE
 2007-07-02,Thailand,Qatar,2,0,Friendly,Bangkok,Thailand,FALSE
-2007-07-02,USA,Paraguay,1,3,Copa América,Barinas,Venezuela,TRUE
+2007-07-02,United States,Paraguay,1,3,Copa América,Barinas,Venezuela,TRUE
 2007-07-02,Gibraltar,Menorca,2,1,Island Games,Rhodes,Greece,TRUE
 2007-07-02,Ynys Môn,Åland Islands,0,2,Island Games,Rhodes,Greece,TRUE
 2007-07-02,Saare County,Frøya,2,3,Island Games,Rhodes,Greece,TRUE
@@ -29691,7 +29691,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-07-04,Gibraltar,Bermuda,2,0,Island Games,Rhodes,Greece,TRUE
 2007-07-04,Rhodes,Western Isles,1,0,Island Games,Rhodes,Greece,FALSE
 2007-07-05,Argentina,Paraguay,1,0,Copa América,Barquisimeto,Venezuela,TRUE
-2007-07-05,Colombia,USA,1,0,Copa América,Barquisimeto,Venezuela,TRUE
+2007-07-05,Colombia,United States,1,0,Copa América,Barquisimeto,Venezuela,TRUE
 2007-07-05,South Korea,Uzbekistan,2,1,Friendly,Seoul,South Korea,FALSE
 2007-07-05,Menorca,Saare County,4,1,Island Games,Rhodes,Greece,TRUE
 2007-07-05,Åland Islands,Frøya,3,1,Island Games,Rhodes,Greece,TRUE
@@ -29787,7 +29787,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-08-22,Luxembourg,Georgia,0,0,Friendly,Luxembourg,Luxembourg,FALSE
 2007-08-22,North Macedonia,Nigeria,0,0,Friendly,Skopje,North Macedonia,FALSE
 2007-08-22,Mali,Burkina Faso,3,2,Friendly,Paris,France,TRUE
-2007-08-22,Mexico,Colombia,0,1,Friendly,Commerce City,USA,TRUE
+2007-08-22,Mexico,Colombia,0,1,Friendly,Commerce City,United States,TRUE
 2007-08-22,Montenegro,Slovenia,1,1,Friendly,Podgorica,Montenegro,FALSE
 2007-08-22,Northern Ireland,Liechtenstein,3,1,UEFA Euro qualification,Belfast,Northern Ireland,FALSE
 2007-08-22,Norway,Argentina,2,1,Friendly,Oslo,Norway,FALSE
@@ -29799,7 +29799,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-08-22,Scotland,South Africa,1,0,Friendly,Aberdeen,Scotland,FALSE
 2007-08-22,Slovakia,France,0,1,Friendly,Trnava,Slovakia,FALSE
 2007-08-22,Sudan,Libya,1,0,Friendly,Khartoum,Sudan,FALSE
-2007-08-22,Sweden,USA,1,0,Friendly,Gothenburg,Sweden,FALSE
+2007-08-22,Sweden,United States,1,0,Friendly,Gothenburg,Sweden,FALSE
 2007-08-22,Switzerland,Netherlands,2,1,Friendly,Geneva,Switzerland,FALSE
 2007-08-22,Tajikistan,Azerbaijan,2,3,Friendly,Dushanbe,Tajikistan,FALSE
 2007-08-22,Togo,Zambia,3,1,Friendly,Lomé,Togo,FALSE
@@ -29879,7 +29879,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-09-08,Wales,Germany,0,2,UEFA Euro qualification,Cardiff,Wales,FALSE
 2007-09-09,Burundi,Egypt,0,0,African Cup of Nations qualification,Bujumbura,Burundi,FALSE
 2007-09-09,Chad,Congo,1,1,African Cup of Nations qualification,N'Djamena,Chad,FALSE
-2007-09-09,Costa Rica,Honduras,0,0,Friendly,East Hartford,USA,TRUE
+2007-09-09,Costa Rica,Honduras,0,0,Friendly,East Hartford,United States,TRUE
 2007-09-09,Equatorial Guinea,Cameroon,1,0,African Cup of Nations qualification,Malabo,Equatorial Guinea,FALSE
 2007-09-09,Gambia,Algeria,2,1,African Cup of Nations qualification,Bakau,Gambia,FALSE
 2007-09-09,Guinea,Cape Verde,4,0,African Cup of Nations qualification,Conakry,Guinea,FALSE
@@ -29888,7 +29888,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-09-09,South Africa,Zambia,1,3,African Cup of Nations qualification,Cape Town,South Africa,FALSE
 2007-09-09,Sudan,Tunisia,3,2,African Cup of Nations qualification,Khartoum,Sudan,FALSE
 2007-09-09,Eswatini,Eritrea,0,0,African Cup of Nations qualification,Manzini,Eswatini,FALSE
-2007-09-09,USA,Brazil,2,4,Friendly,Chicago,USA,FALSE
+2007-09-09,United States,Brazil,2,4,Friendly,Chicago,United States,FALSE
 2007-09-09,Zimbabwe,Malawi,3,1,African Cup of Nations qualification,Bulawayo,Zimbabwe,FALSE
 2007-09-11,Australia,Argentina,0,1,Friendly,Melbourne,Australia,FALSE
 2007-09-11,Austria,Chile,0,2,Friendly,Vienna,Austria,FALSE
@@ -29914,7 +29914,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-09-12,Lithuania,Faroe Islands,2,1,UEFA Euro qualification,Kaunas,Lithuania,FALSE
 2007-09-12,North Macedonia,Estonia,1,1,UEFA Euro qualification,Skopje,North Macedonia,FALSE
 2007-09-12,Malta,Armenia,0,1,Friendly,Attard,Malta,FALSE
-2007-09-12,Mexico,Brazil,1,3,Friendly,Foxborough,USA,TRUE
+2007-09-12,Mexico,Brazil,1,3,Friendly,Foxborough,United States,TRUE
 2007-09-12,Montenegro,Sweden,1,2,Friendly,Podgorica,Montenegro,FALSE
 2007-09-12,Norway,Greece,2,2,UEFA Euro qualification,Oslo,Norway,FALSE
 2007-09-12,Peru,Bolivia,2,0,Friendly,Lima,Peru,FALSE
@@ -30011,7 +30011,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-10-17,Luxembourg,Romania,0,2,UEFA Euro qualification,Luxembourg,Luxembourg,FALSE
 2007-10-17,North Macedonia,Andorra,3,0,UEFA Euro qualification,Skopje,North Macedonia,FALSE
 2007-10-17,Malta,Moldova,2,3,UEFA Euro qualification,Attard,Malta,FALSE
-2007-10-17,Mexico,Guatemala,2,3,Friendly,Los Angeles,USA,TRUE
+2007-10-17,Mexico,Guatemala,2,3,Friendly,Los Angeles,United States,TRUE
 2007-10-17,Morocco,Namibia,2,0,Friendly,Tangier,Morocco,FALSE
 2007-10-17,Netherlands,Slovenia,2,0,UEFA Euro qualification,Eindhoven,Netherlands,FALSE
 2007-10-17,Paraguay,Uruguay,1,0,FIFA World Cup qualification,Asunción,Paraguay,FALSE
@@ -30020,7 +30020,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-10-17,San Marino,Wales,1,2,UEFA Euro qualification,Serravalle,San Marino,FALSE
 2007-10-17,Sierra Leone,Guinea-Bissau,1,0,FIFA World Cup qualification,Freetown,Sierra Leone,FALSE
 2007-10-17,Sweden,Northern Ireland,1,1,UEFA Euro qualification,Solna,Sweden,FALSE
-2007-10-17,Switzerland,USA,0,1,Friendly,Basel,Switzerland,FALSE
+2007-10-17,Switzerland,United States,0,1,Friendly,Basel,Switzerland,FALSE
 2007-10-17,Turkey,Greece,0,1,UEFA Euro qualification,Istanbul,Turkey,FALSE
 2007-10-17,Ukraine,Faroe Islands,5,0,UEFA Euro qualification,Kyiv,Ukraine,FALSE
 2007-10-17,United Arab Emirates,Tunisia,0,1,Friendly,Abu Dhabi,United Arab Emirates,FALSE
@@ -30073,7 +30073,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-11-17,Finland,Azerbaijan,2,1,UEFA Euro qualification,Helsinki,Finland,FALSE
 2007-11-17,Germany,Cyprus,4,0,UEFA Euro qualification,Hanover,Germany,FALSE
 2007-11-17,Greece,Malta,5,0,UEFA Euro qualification,Athens,Greece,FALSE
-2007-11-17,Guatemala,Honduras,0,1,Friendly,Miami Gardens,USA,TRUE
+2007-11-17,Guatemala,Honduras,0,1,Friendly,Miami Gardens,United States,TRUE
 2007-11-17,Guinea-Bissau,Sierra Leone,0,0,FIFA World Cup qualification,Bissau,Guinea-Bissau,FALSE
 2007-11-17,Israel,Russia,2,1,UEFA Euro qualification,Ramat-Gan,Israel,FALSE
 2007-11-17,Latvia,Liechtenstein,4,1,UEFA Euro qualification,Riga,Latvia,FALSE
@@ -30088,7 +30088,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2007-11-17,Portugal,Armenia,1,0,UEFA Euro qualification,Leiria,Portugal,FALSE
 2007-11-17,Scotland,Italy,1,2,UEFA Euro qualification,Glasgow,Scotland,FALSE
 2007-11-17,Senegal,Mali,3,2,Friendly,Évry/Bondoufle,France,TRUE
-2007-11-17,South Africa,USA,0,1,Friendly,Johannesburg,South Africa,FALSE
+2007-11-17,South Africa,United States,0,1,Friendly,Johannesburg,South Africa,FALSE
 2007-11-17,Spain,Sweden,3,0,UEFA Euro qualification,Madrid,Spain,FALSE
 2007-11-17,Tunisia,Namibia,2,0,Friendly,Radès,Tunisia,FALSE
 2007-11-17,Vanuatu,New Zealand,1,2,FIFA World Cup qualification,Port Vila,Vanuatu,FALSE
@@ -30214,7 +30214,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-01-16,South Africa,Botswana,2,1,Friendly,Umlazi,South Africa,FALSE
 2008-01-18,Bermuda,Puerto Rico,0,1,Friendly,Hamilton,Bermuda,FALSE
 2008-01-18,Dominica,Guadeloupe,0,3,Friendly,Roseau,Dominica,FALSE
-2008-01-19,USA,Sweden,2,0,Friendly,Carson,USA,FALSE
+2008-01-19,United States,Sweden,2,0,Friendly,Carson,United States,FALSE
 2008-01-20,China PR,Lebanon,0,0,Friendly,Zhongshan,China PR,FALSE
 2008-01-20,Ghana,Guinea,2,1,African Cup of Nations,Accra,Ghana,FALSE
 2008-01-20,Guyana,Grenada,1,2,Friendly,Georgetown,Guyana,FALSE
@@ -30314,7 +30314,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-02-06,Turks and Caicos Islands,Saint Lucia,2,1,FIFA World Cup qualification,Providenciales,Turks and Caicos Islands,FALSE
 2008-02-06,United Arab Emirates,Kuwait,2,0,FIFA World Cup qualification,Abu Dhabi,United Arab Emirates,FALSE
 2008-02-06,Uruguay,Colombia,2,2,Friendly,Montevideo,Uruguay,FALSE
-2008-02-06,USA,Mexico,2,2,Friendly,Houston,USA,FALSE
+2008-02-06,United States,Mexico,2,2,Friendly,Houston,United States,FALSE
 2008-02-06,Venezuela,Haiti,1,1,Friendly,Puerto la Cruz,Venezuela,FALSE
 2008-02-06,Wales,Norway,3,0,Friendly,Wrexham,Wales,FALSE
 2008-02-07,Ghana,Cameroon,0,1,African Cup of Nations,Accra,Ghana,FALSE
@@ -30338,8 +30338,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-03-04,Qatar,Bahrain,1,2,Friendly,Doha,Qatar,FALSE
 2008-03-09,Mauritius,Madagascar,1,2,Friendly,Curepipe,Mauritius,FALSE
 2008-03-11,South Africa,Zimbabwe,2,1,Friendly,Germiston,South Africa,FALSE
-2008-03-14,British Virgin Islands,USA Virgin Islands,0,0,Friendly,Road Town,British Virgin Islands,FALSE
-2008-03-15,British Virgin Islands,USA Virgin Islands,1,1,Friendly,Road Town,British Virgin Islands,FALSE
+2008-03-14,British Virgin Islands,United States Virgin Islands,0,0,Friendly,Road Town,British Virgin Islands,FALSE
+2008-03-15,British Virgin Islands,United States Virgin Islands,1,1,Friendly,Road Town,British Virgin Islands,FALSE
 2008-03-15,China PR,Thailand,3,3,Friendly,Kunming,China PR,FALSE
 2008-03-16,Iceland,Faroe Islands,3,0,Friendly,Kópavogur,Iceland,FALSE
 2008-03-16,Qatar,Jordan,2,1,Friendly,Doha,Qatar,FALSE
@@ -30355,7 +30355,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-03-25,Togo,Guinea,0,2,Friendly,Paris,France,TRUE
 2008-03-26,Algeria,DR Congo,1,1,Friendly,Nanterre,France,TRUE
 2008-03-26,Andorra,Latvia,0,3,Friendly,Sant Julià de Lòria,Andorra,FALSE
-2008-03-26,Anguilla,El Salvador,0,4,FIFA World Cup qualification,Washington,USA,TRUE
+2008-03-26,Anguilla,El Salvador,0,4,FIFA World Cup qualification,Washington,United States,TRUE
 2008-03-26,Antigua and Barbuda,Aruba,1,0,FIFA World Cup qualification,St. John's,Antigua and Barbuda,FALSE
 2008-03-26,Armenia,Kazakhstan,1,0,Friendly,Pernis,Netherlands,TRUE
 2008-03-26,Austria,Netherlands,3,4,Friendly,Vienna,Austria,FALSE
@@ -30376,8 +30376,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-03-26,Estonia,Canada,2,0,Friendly,Tallinn,Estonia,FALSE
 2008-03-26,France,England,1,0,Friendly,Saint-Denis,France,FALSE
 2008-03-26,Ghana,Mexico,1,2,Friendly,London,England,TRUE
-2008-03-26,Grenada,USA Virgin Islands,10,0,FIFA World Cup qualification,St. George's,Grenada,FALSE
-2008-03-26,Honduras,Colombia,2,1,Friendly,Fort Lauderdale,USA,TRUE
+2008-03-26,Grenada,United States Virgin Islands,10,0,FIFA World Cup qualification,St. George's,Grenada,FALSE
+2008-03-26,Honduras,Colombia,2,1,Friendly,Fort Lauderdale,United States,TRUE
 2008-03-26,Hungary,Slovenia,0,1,Friendly,Zalaegerszeg,Hungary,FALSE
 2008-03-26,Israel,Chile,1,0,Friendly,Ramat-Gan,Israel,FALSE
 2008-03-26,Ivory Coast,Tunisia,0,2,Friendly,Évry/Bondoufle,France,TRUE
@@ -30392,7 +30392,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-03-26,Namibia,Malawi,1,3,Friendly,Windhoek,Namibia,FALSE
 2008-03-26,Northern Ireland,Georgia,4,1,Friendly,Belfast,Northern Ireland,FALSE
 2008-03-26,Peru,Costa Rica,3,1,Friendly,Iquitos,Peru,FALSE
-2008-03-26,Poland,USA,0,3,Friendly,Kraków,Poland,FALSE
+2008-03-26,Poland,United States,0,3,Friendly,Kraków,Poland,FALSE
 2008-03-26,Portugal,Greece,1,2,Friendly,Düsseldorf,Germany,TRUE
 2008-03-26,Puerto Rico,Dominican Republic,1,0,FIFA World Cup qualification,Bayamón,Puerto Rico,FALSE
 2008-03-26,Qatar,Iraq,2,0,FIFA World Cup qualification,Doha,Qatar,FALSE
@@ -30423,8 +30423,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-04-06,Pakistan,Guam,9,2,AFC Challenge Cup qualification,Taipei,Taiwan,TRUE
 2008-04-06,Taiwan,Sri Lanka,2,2,AFC Challenge Cup qualification,Taipei,Taiwan,FALSE
 2008-04-09,Lebanon,Maldives,4,0,AFC Asian Cup qualification,Beirut,Lebanon,FALSE
-2008-04-16,Mexico,China PR,1,0,Friendly,Seattle,USA,TRUE
-2008-04-23,El Salvador,China PR,2,2,Friendly,Los Angeles,USA,TRUE
+2008-04-16,Mexico,China PR,1,0,Friendly,Seattle,United States,TRUE
+2008-04-23,El Salvador,China PR,2,2,Friendly,Los Angeles,United States,TRUE
 2008-04-23,Guatemala,Haiti,1,0,Friendly,Guatemala,Guatemala,FALSE
 2008-04-23,Maldives,Lebanon,1,2,AFC Asian Cup qualification,Malé,Maldives,FALSE
 2008-04-24,Oman,Liberia,1,0,Friendly,Muscat,Oman,FALSE
@@ -30497,7 +30497,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-05-27,Qatar,Lebanon,2,1,Friendly,Doha,Qatar,FALSE
 2008-05-27,Saudi Arabia,Kuwait,2,1,Friendly,Dammam,Saudi Arabia,FALSE
 2008-05-28,Cambodia,Macau,3,1,AFC Challenge Cup qualification,Phnom Penh,Cambodia,FALSE
-2008-05-28,England,USA,2,0,Friendly,London,England,FALSE
+2008-05-28,England,United States,2,0,Friendly,London,England,FALSE
 2008-05-28,Iceland,Wales,0,1,Friendly,Reykjavík,Iceland,FALSE
 2008-05-28,Moldova,Armenia,2,2,Friendly,Tiraspol,Moldova,FALSE
 2008-05-28,Norway,Uruguay,2,2,Friendly,Oslo,Norway,FALSE
@@ -30508,13 +30508,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-05-29,Netherlands,Denmark,1,1,Friendly,Eindhoven,Netherlands,FALSE
 2008-05-30,Austria,Malta,5,1,Friendly,Graz,Austria,FALSE
 2008-05-30,Czech Republic,Scotland,3,1,Friendly,Prague,Czech Republic,FALSE
-2008-05-30,Guatemala,El Salvador,0,0,Friendly,Washington,USA,TRUE
+2008-05-30,Guatemala,El Salvador,0,0,Friendly,Washington,United States,TRUE
 2008-05-30,Italy,Belgium,3,1,Friendly,Florence,Italy,FALSE
 2008-05-30,Latvia,Estonia,1,0,Baltic Cup,Riga,Latvia,FALSE
 2008-05-30,Switzerland,Liechtenstein,3,0,Friendly,St. Gallen,Switzerland,FALSE
-2008-05-30,Venezuela,Honduras,1,1,Friendly,Fort Lauderdale,USA,TRUE
+2008-05-30,Venezuela,Honduras,1,1,Friendly,Fort Lauderdale,United States,TRUE
 2008-05-31,Botswana,Madagascar,0,0,FIFA World Cup qualification,Gaborone,Botswana,FALSE
-2008-05-31,Brazil,Canada,3,2,Friendly,Seattle,USA,TRUE
+2008-05-31,Brazil,Canada,3,2,Friendly,Seattle,United States,TRUE
 2008-05-31,Cameroon,Cape Verde,2,0,FIFA World Cup qualification,Yaoundé,Cameroon,FALSE
 2008-05-31,Estonia,Lithuania,0,1,Baltic Cup,Jūrmala,Latvia,TRUE
 2008-05-31,France,Paraguay,0,0,Friendly,Toulouse,France,FALSE
@@ -30540,7 +30540,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-06-01,Egypt,DR Congo,2,1,FIFA World Cup qualification,Cairo,Egypt,FALSE
 2008-06-01,Equatorial Guinea,Sierra Leone,2,0,FIFA World Cup qualification,Malabo,Equatorial Guinea,FALSE
 2008-06-01,Ghana,Libya,3,0,FIFA World Cup qualification,Kumasi,Ghana,FALSE
-2008-06-01,Guatemala,Panama,0,1,Friendly,Fort Lauderdale,USA,TRUE
+2008-06-01,Guatemala,Panama,0,1,Friendly,Fort Lauderdale,United States,TRUE
 2008-06-01,Guinea,Zimbabwe,0,0,FIFA World Cup qualification,Conakry,Guinea,FALSE
 2008-06-01,Ivory Coast,Mozambique,1,0,FIFA World Cup qualification,Abidjan,Ivory Coast,FALSE
 2008-06-01,Latvia,Lithuania,2,1,Baltic Cup,Riga,Latvia,FALSE
@@ -30570,16 +30570,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-06-04,Estonia,Faroe Islands,4,3,Friendly,Tallinn,Estonia,FALSE
 2008-06-04,Honduras,Puerto Rico,4,0,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2008-06-04,Lithuania,Russia,1,4,Friendly,Burghausen,Germany,TRUE
-2008-06-04,Mexico,Argentina,1,4,Friendly,San Diego,USA,TRUE
-2008-06-04,Panama,Canada,2,2,Friendly,Fort Lauderdale,USA,TRUE
-2008-06-04,Spain,USA,1,0,Friendly,Santander,Spain,FALSE
+2008-06-04,Mexico,Argentina,1,4,Friendly,San Diego,United States,TRUE
+2008-06-04,Panama,Canada,2,2,Friendly,Fort Lauderdale,United States,TRUE
+2008-06-04,Spain,United States,1,0,Friendly,Santander,Spain,FALSE
 2008-06-04,Sri Lanka,Afghanistan,2,2,SAFF Cup,Colombo,Sri Lanka,FALSE
 2008-06-05,India,Pakistan,2,1,SAFF Cup,Malé,Maldives,TRUE
 2008-06-05,Maldives,Nepal,4,1,SAFF Cup,Malé,Maldives,FALSE
 2008-06-06,Algeria,Liberia,3,0,FIFA World Cup qualification,Blida,Algeria,FALSE
 2008-06-06,Bangladesh,Afghanistan,2,2,SAFF Cup,Colombo,Sri Lanka,TRUE
 2008-06-06,Bermuda,Barbados,2,1,Friendly,Hamilton,Bermuda,FALSE
-2008-06-06,Brazil,Venezuela,0,2,Friendly,Foxborough,USA,TRUE
+2008-06-06,Brazil,Venezuela,0,2,Friendly,Foxborough,United States,TRUE
 2008-06-06,Indonesia,Malaysia,1,1,Friendly,Jakarta,Indonesia,FALSE
 2008-06-06,Sri Lanka,Bhutan,2,0,SAFF Cup,Colombo,Sri Lanka,FALSE
 2008-06-07,Bahrain,Thailand,1,1,FIFA World Cup qualification,Riffa,Bahrain,FALSE
@@ -30620,12 +30620,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-06-08,Lesotho,Ghana,2,3,FIFA World Cup qualification,Bloemfontein,South Africa,TRUE
 2008-06-08,Madagascar,Ivory Coast,0,0,FIFA World Cup qualification,Antananarivo,Madagascar,FALSE
 2008-06-08,Mauritius,Cameroon,0,3,FIFA World Cup qualification,Curepipe,Mauritius,FALSE
-2008-06-08,Mexico,Peru,4,0,Friendly,Chicago,USA,TRUE
+2008-06-08,Mexico,Peru,4,0,Friendly,Chicago,United States,TRUE
 2008-06-08,Mozambique,Botswana,1,2,FIFA World Cup qualification,Maputo,Mozambique,FALSE
 2008-06-08,Niger,Angola,1,2,FIFA World Cup qualification,Niamey,Niger,FALSE
 2008-06-08,Sri Lanka,Bangladesh,1,0,SAFF Cup,Colombo,Sri Lanka,FALSE
 2008-06-08,Eswatini,Togo,2,1,FIFA World Cup qualification,Lobamba,Eswatini,FALSE
-2008-06-08,USA,Argentina,0,0,Friendly,East Rutherford,USA,FALSE
+2008-06-08,United States,Argentina,0,0,Friendly,East Rutherford,United States,FALSE
 2008-06-08,Zimbabwe,Namibia,2,0,FIFA World Cup qualification,Harare,Zimbabwe,FALSE
 2008-06-09,Bermuda,Barbados,3,0,Friendly,Hamilton,Bermuda,FALSE
 2008-06-09,Curaçao,Venezuela,0,1,Friendly,Willemstad,Netherlands Antilles,FALSE
@@ -30680,7 +30680,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-06-14,Uzbekistan,Lebanon,3,0,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2008-06-14,Vanuatu,New Caledonia,1,1,FIFA World Cup qualification,Port Vila,Vanuatu,FALSE
 2008-06-15,Argentina,Ecuador,1,1,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
-2008-06-15,Belize,Mexico,0,2,FIFA World Cup qualification,Houston,USA,TRUE
+2008-06-15,Belize,Mexico,0,2,FIFA World Cup qualification,Houston,United States,TRUE
 2008-06-15,Bolivia,Chile,0,2,FIFA World Cup qualification,La Paz,Bolivia,FALSE
 2008-06-15,Burundi,Tunisia,0,1,FIFA World Cup qualification,Bujumbura,Burundi,FALSE
 2008-06-15,Equatorial Guinea,Nigeria,0,1,FIFA World Cup qualification,Malabo,Equatorial Guinea,FALSE
@@ -30697,7 +30697,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-06-15,Switzerland,Portugal,2,0,UEFA Euro,Basel,Switzerland,FALSE
 2008-06-15,Trinidad and Tobago,Bermuda,1,2,FIFA World Cup qualification,Macoya,Trinidad and Tobago,FALSE
 2008-06-15,Turkey,Czech Republic,3,2,UEFA Euro,Geneva,Switzerland,TRUE
-2008-06-15,USA,Barbados,8,0,FIFA World Cup qualification,Carson,USA,FALSE
+2008-06-15,United States,Barbados,8,0,FIFA World Cup qualification,Carson,United States,FALSE
 2008-06-16,Austria,Germany,0,1,UEFA Euro,Vienna,Austria,FALSE
 2008-06-16,Poland,Croatia,0,1,UEFA Euro,Klagenfurt,Austria,TRUE
 2008-06-17,Antigua and Barbuda,Cuba,3,4,FIFA World Cup qualification,St. John's,Antigua and Barbuda,FALSE
@@ -30726,11 +30726,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-06-21,Nigeria,Equatorial Guinea,2,0,FIFA World Cup qualification,Abuja,Nigeria,FALSE
 2008-06-21,Senegal,Liberia,3,1,FIFA World Cup qualification,Dakar,Senegal,FALSE
 2008-06-21,South Africa,Sierra Leone,0,0,FIFA World Cup qualification,Atteridgeville,South Africa,FALSE
-2008-06-21,Saint Lucia,Guatemala,1,3,FIFA World Cup qualification,Los Angeles,USA,TRUE
+2008-06-21,Saint Lucia,Guatemala,1,3,FIFA World Cup qualification,Los Angeles,United States,TRUE
 2008-06-21,Tunisia,Burundi,2,1,FIFA World Cup qualification,Radès,Tunisia,FALSE
 2008-06-21,Zambia,Eswatini,1,0,FIFA World Cup qualification,Chililabombwe,Zambia,FALSE
 2008-06-22,Australia,China PR,0,1,FIFA World Cup qualification,Sydney,Australia,FALSE
-2008-06-22,Barbados,USA,0,1,FIFA World Cup qualification,Bridgetown,Barbados,FALSE
+2008-06-22,Barbados,United States,0,1,FIFA World Cup qualification,Bridgetown,Barbados,FALSE
 2008-06-22,Benin,Niger,2,0,FIFA World Cup qualification,Cotonou,Benin,FALSE
 2008-06-22,Bermuda,Trinidad and Tobago,0,2,FIFA World Cup qualification,Hamilton,Bermuda,FALSE
 2008-06-22,Cape Verde,Mauritius,3,1,FIFA World Cup qualification,Praia,Cape Verde,FALSE
@@ -30781,7 +30781,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-07-19,Madagascar,Eswatini,1,1,COSAFA Cup qualification,Witbank,South Africa,TRUE
 2008-07-19,Mauritius,Seychelles,0,7,COSAFA Cup qualification,Witbank,South Africa,TRUE
 2008-07-20,Comoros,Namibia,0,3,COSAFA Cup qualification,Secunda,South Africa,TRUE
-2008-07-20,El Salvador,Guatemala,0,0,Friendly,Los Angeles,USA,TRUE
+2008-07-20,El Salvador,Guatemala,0,0,Friendly,Los Angeles,United States,TRUE
 2008-07-20,Lesotho,Malawi,0,1,COSAFA Cup qualification,Secunda,South Africa,TRUE
 2008-07-21,Madagascar,Seychelles,1,1,COSAFA Cup qualification,Witbank,South Africa,TRUE
 2008-07-21,Mauritius,Eswatini,1,1,COSAFA Cup qualification,Witbank,South Africa,TRUE
@@ -30792,7 +30792,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-07-23,Seychelles,Eswatini,0,1,COSAFA Cup qualification,Witbank,South Africa,TRUE
 2008-07-24,Comoros,Lesotho,0,1,COSAFA Cup qualification,Secunda,South Africa,TRUE
 2008-07-24,Malawi,Namibia,0,1,COSAFA Cup qualification,Secunda,South Africa,TRUE
-2008-07-26,El Salvador,Jamaica,0,0,Friendly,Frisco,USA,TRUE
+2008-07-26,El Salvador,Jamaica,0,0,Friendly,Frisco,United States,TRUE
 2008-07-26,South Africa,Namibia,1,0,COSAFA Cup,Witbank,South Africa,FALSE
 2008-07-27,Botswana,Mozambique,0,2,COSAFA Cup,Secunda,South Africa,TRUE
 2008-07-27,Curaçao,Aruba,0,0,CFU Caribbean Cup qualification,Willemstad,Netherlands Antilles,TRUE
@@ -30816,7 +30816,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-08-03,South Africa,Mozambique,2,1,COSAFA Cup,Bushbuckridge,South Africa,FALSE
 2008-08-04,North Korea,Myanmar,1,0,AFC Challenge Cup,Hyderabad,India,TRUE
 2008-08-04,Nepal,Sri Lanka,3,0,AFC Challenge Cup,Hyderabad,India,TRUE
-2008-08-06,Guatemala,Bolivia,3,0,Friendly,Washington,USA,TRUE
+2008-08-06,Guatemala,Bolivia,3,0,Friendly,Washington,United States,TRUE
 2008-08-07,India,Myanmar,1,0,AFC Challenge Cup,Hyderabad,India,FALSE
 2008-08-07,Iran,Palestine,3,0,WAFF Championship,Tehran,Iran,FALSE
 2008-08-07,North Korea,Tajikistan,0,1,AFC Challenge Cup,Hyderabad,India,TRUE
@@ -30832,7 +30832,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-08-13,India,Tajikistan,4,1,AFC Challenge Cup,New Delhi,India,FALSE
 2008-08-13,Iran,Syria,2,0,WAFF Championship,Tehran,Iran,FALSE
 2008-08-13,Jordan,Qatar,3,0,WAFF Championship,Tehran,Iran,TRUE
-2008-08-14,El Salvador,Trinidad and Tobago,1,3,Friendly,Washington,USA,TRUE
+2008-08-14,El Salvador,Trinidad and Tobago,1,3,Friendly,Washington,United States,TRUE
 2008-08-15,Iran,Jordan,2,1,WAFF Championship,Tehran,Iran,FALSE
 2008-08-19,Australia,South Africa,2,2,Friendly,London,England,TRUE
 2008-08-19,Gabon,Mali,1,0,Friendly,Mantes-la-Ville,France,TRUE
@@ -30843,7 +30843,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-08-20,Bolivia,Panama,1,0,Friendly,Santa Cruz,Bolivia,FALSE
 2008-08-20,Bosnia and Herzegovina,Bulgaria,1,2,Friendly,Zenica,Bosnia and Herzegovina,FALSE
 2008-08-20,Canada,Jamaica,1,1,FIFA World Cup qualification,Toronto,Canada,FALSE
-2008-08-20,Colombia,Ecuador,0,1,Friendly,East Rutherford,USA,TRUE
+2008-08-20,Colombia,Ecuador,0,1,Friendly,East Rutherford,United States,TRUE
 2008-08-20,DR Congo,Togo,2,1,Friendly,Dreux,France,TRUE
 2008-08-20,Costa Rica,El Salvador,1,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2008-08-20,Cuba,Trinidad and Tobago,1,3,FIFA World Cup qualification,Havana,Cuba,FALSE
@@ -30852,7 +30852,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-08-20,Estonia,Malta,2,1,Friendly,Tallinn,Estonia,FALSE
 2008-08-20,Finland,Israel,2,0,Friendly,Tampere,Finland,FALSE
 2008-08-20,Germany,Belgium,2,0,Friendly,Nuremberg,Germany,FALSE
-2008-08-20,Guatemala,USA,0,1,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
+2008-08-20,Guatemala,United States,0,1,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
 2008-08-20,Guinea,Ivory Coast,1,2,Friendly,Chantilly,France,TRUE
 2008-08-20,Haiti,Suriname,2,2,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
 2008-08-20,Hungary,Montenegro,3,3,Friendly,Budapest,Hungary,FALSE
@@ -30919,7 +30919,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-09-06,Cape Verde,Cameroon,1,2,FIFA World Cup qualification,Praia,Cape Verde,FALSE
 2008-09-06,Colombia,Uruguay,0,1,FIFA World Cup qualification,Bogotá,Colombia,FALSE
 2008-09-06,Croatia,Kazakhstan,3,0,FIFA World Cup qualification,Zagreb,Croatia,FALSE
-2008-09-06,Cuba,USA,0,1,FIFA World Cup qualification,Havana,Cuba,FALSE
+2008-09-06,Cuba,United States,0,1,FIFA World Cup qualification,Havana,Cuba,FALSE
 2008-09-06,Cyprus,Italy,1,2,FIFA World Cup qualification,Larnaca,Cyprus,FALSE
 2008-09-06,Ecuador,Bolivia,3,1,FIFA World Cup qualification,Quito,Ecuador,FALSE
 2008-09-06,Fiji,Vanuatu,2,0,FIFA World Cup qualification,Ba,Fiji,FALSE
@@ -31008,14 +31008,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-09-10,Turkey,Belgium,1,1,FIFA World Cup qualification,Istanbul,Turkey,FALSE
 2008-09-10,United Arab Emirates,Saudi Arabia,1,2,FIFA World Cup qualification,Abu Dhabi,United Arab Emirates,FALSE
 2008-09-10,Uruguay,Ecuador,0,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2008-09-10,USA,Trinidad and Tobago,3,0,FIFA World Cup qualification,Bridgeview,USA,FALSE
+2008-09-10,United States,Trinidad and Tobago,3,0,FIFA World Cup qualification,Bridgeview,United States,FALSE
 2008-09-10,Uzbekistan,Australia,0,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2008-09-10,Vanuatu,Fiji,2,1,FIFA World Cup qualification,Port Vila,Vanuatu,FALSE
 2008-09-10,Zambia,Togo,1,0,FIFA World Cup qualification,Chililabombwe,Zambia,FALSE
 2008-09-19,Martinique,Anguilla,3,1,CFU Caribbean Cup qualification,Fort-de-France,Martinique,FALSE
 2008-09-21,Antigua and Barbuda,Guyana,3,0,Friendly,St. John's,Antigua and Barbuda,FALSE
 2008-09-24,Guadeloupe,Martinique,0,1,African Nations Championship,La Courneuve,France,TRUE
-2008-09-24,Mexico,Chile,0,1,Friendly,Los Angeles,USA,TRUE
+2008-09-24,Mexico,Chile,0,1,Friendly,Los Angeles,United States,TRUE
 2008-09-24,Saint Kitts and Nevis,British Virgin Islands,4,0,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
 2008-09-24,Tahiti,New Caledonia,0,1,African Nations Championship,La Courneuve,France,TRUE
 2008-09-25,Mayotte,Réunion,1,6,African Nations Championship,Franconville,France,TRUE
@@ -31087,7 +31087,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-10-11,Tunisia,Seychelles,5,0,FIFA World Cup qualification,Radès,Tunisia,FALSE
 2008-10-11,Turkey,Bosnia and Herzegovina,2,1,FIFA World Cup qualification,Istanbul,Turkey,FALSE
 2008-10-11,Ukraine,Croatia,0,0,FIFA World Cup qualification,Kharkiv,Ukraine,FALSE
-2008-10-11,USA,Cuba,6,1,FIFA World Cup qualification,Washington,USA,FALSE
+2008-10-11,United States,Cuba,6,1,FIFA World Cup qualification,Washington,United States,FALSE
 2008-10-11,Wales,Liechtenstein,2,0,FIFA World Cup qualification,Cardiff,Wales,FALSE
 2008-10-12,Angola,Niger,3,1,FIFA World Cup qualification,Luanda,Angola,FALSE
 2008-10-12,Burundi,Burkina Faso,1,3,FIFA World Cup qualification,Bujumbura,Burundi,FALSE
@@ -31140,7 +31140,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-10-15,Russia,Finland,3,0,FIFA World Cup qualification,Moscow,Russia,FALSE
 2008-10-15,Slovakia,Poland,2,1,FIFA World Cup qualification,Bratislava,Slovakia,FALSE
 2008-10-15,South Africa,Ghana,2,1,Friendly,Bloemfontein,South Africa,FALSE
-2008-10-15,Trinidad and Tobago,USA,2,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
+2008-10-15,Trinidad and Tobago,United States,2,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2008-10-15,Venezuela,Ecuador,3,1,FIFA World Cup qualification,Puerto la Cruz,Venezuela,FALSE
 2008-10-17,Cambodia,Laos,3,2,AFF Championship,Phnom Penh,Cambodia,FALSE
 2008-10-17,Nepal,Afghanistan,2,2,Merdeka Tournament,Petaling Jaya,Malaysia,TRUE
@@ -31151,7 +31151,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-10-20,Malaysia,Afghanistan,6,0,Merdeka Tournament,Kuala Lumpur,Malaysia,FALSE
 2008-10-21,Timor-Leste,Brunei,1,4,AFF Championship,Phnom Penh,Cambodia,TRUE
 2008-10-21,Philippines,Laos,1,2,AFF Championship,Phnom Penh,Cambodia,TRUE
-2008-10-22,Bolivia,El Salvador,0,2,Friendly,Washington,USA,TRUE
+2008-10-22,Bolivia,El Salvador,0,2,Friendly,Washington,United States,TRUE
 2008-10-23,Barbados,Suriname,3,2,CFU Caribbean Cup qualification,Havana,Cuba,TRUE
 2008-10-23,Cambodia,Philippines,2,3,AFF Championship,Phnom Penh,Cambodia,FALSE
 2008-10-23,Cuba,Curaçao,7,1,CFU Caribbean Cup qualification,Havana,Cuba,FALSE
@@ -31178,7 +31178,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-11-09,Trinidad and Tobago,Guyana,1,1,CFU Caribbean Cup qualification,Macoya,Trinidad and Tobago,FALSE
 2008-11-11,Myanmar,Bangladesh,0,0,Friendly,Yangon,Myanmar,FALSE
 2008-11-12,Estonia,Latvia,1,1,Friendly,Tallinn,Estonia,FALSE
-2008-11-12,Mexico,Ecuador,2,1,Friendly,Phoenix,USA,TRUE
+2008-11-12,Mexico,Ecuador,2,1,Friendly,Phoenix,United States,TRUE
 2008-11-12,Saudi Arabia,Bahrain,4,0,Friendly,Riyadh,Saudi Arabia,FALSE
 2008-11-13,Bangladesh,Indonesia,0,2,Friendly,Yangon,Myanmar,TRUE
 2008-11-13,Japan,Syria,3,1,Friendly,Kobe,Japan,FALSE
@@ -31232,7 +31232,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2008-11-19,Trinidad and Tobago,Cuba,3,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2008-11-19,Ukraine,Norway,1,0,Friendly,Dnipropetrovs'k,Ukraine,FALSE
 2008-11-19,United Arab Emirates,Iran,1,1,FIFA World Cup qualification,Dubai,United Arab Emirates,FALSE
-2008-11-19,USA,Guatemala,2,0,FIFA World Cup qualification,Commerce City,USA,FALSE
+2008-11-19,United States,Guatemala,2,0,FIFA World Cup qualification,Commerce City,United States,FALSE
 2008-11-19,Venezuela,Angola,0,0,Friendly,Barinas,Venezuela,FALSE
 2008-11-21,Myanmar,Indonesia,2,1,Friendly,Yangon,Myanmar,FALSE
 2008-11-22,Estonia,Lithuania,1,1,Friendly,Kuressaare,Estonia,FALSE
@@ -31327,9 +31327,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-01-14,Oman,Qatar,1,0,Gulf Cup,Muscat,Oman,FALSE
 2009-01-14,Syria,China PR,3,2,AFC Asian Cup qualification,Aleppo,Syria,FALSE
 2009-01-14,Vietnam,Lebanon,3,1,AFC Asian Cup qualification,Hanoi,Vietnam,FALSE
-2009-01-17,Guatemala,Haiti,1,0,Friendly,Fort Pierce,USA,TRUE
+2009-01-17,Guatemala,Haiti,1,0,Friendly,Fort Pierce,United States,TRUE
 2009-01-17,Oman,Saudi Arabia,0,0,Gulf Cup,Muscat,Oman,FALSE
-2009-01-18,Honduras,Chile,2,0,Friendly,Fort Lauderdale,USA,TRUE
+2009-01-18,Honduras,Chile,2,0,Friendly,Fort Lauderdale,United States,TRUE
 2009-01-18,Syria,Turkmenistan,5,1,Friendly,Kuwait City,Kuwait,TRUE
 2009-01-19,Oman,Indonesia,0,0,AFC Asian Cup qualification,Muscat,Oman,FALSE
 2009-01-20,Japan,Yemen,2,1,AFC Asian Cup qualification,Kumamoto,Japan,FALSE
@@ -31346,7 +31346,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-01-23,Kuwait,Syria,2,3,Friendly,Kuwait City,Kuwait,FALSE
 2009-01-24,Belize,El Salvador,1,4,UNCAF Cup,Tegucigalpa,Honduras,TRUE
 2009-01-24,Honduras,Nicaragua,4,1,UNCAF Cup,Tegucigalpa,Honduras,FALSE
-2009-01-24,USA,Sweden,3,2,Friendly,Carson,USA,FALSE
+2009-01-24,United States,Sweden,3,2,Friendly,Carson,United States,FALSE
 2009-01-25,Guatemala,Costa Rica,1,3,UNCAF Cup,Tegucigalpa,Honduras,TRUE
 2009-01-26,Honduras,El Salvador,2,0,UNCAF Cup,Tegucigalpa,Honduras,FALSE
 2009-01-26,Nicaragua,Belize,1,1,UNCAF Cup,Tegucigalpa,Honduras,TRUE
@@ -31356,7 +31356,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-01-28,Indonesia,Australia,0,0,AFC Asian Cup qualification,Jakarta,Indonesia,FALSE
 2009-01-28,Kuwait,Oman,0,1,AFC Asian Cup qualification,Kuwait City,Kuwait,FALSE
 2009-01-28,Lebanon,Syria,0,2,AFC Asian Cup qualification,Sidon,Lebanon,FALSE
-2009-01-28,Mexico,Sweden,0,1,Friendly,Oakland,USA,TRUE
+2009-01-28,Mexico,Sweden,0,1,Friendly,Oakland,United States,TRUE
 2009-01-28,Singapore,Jordan,2,1,AFC Asian Cup qualification,Singapore,Singapore,FALSE
 2009-01-28,Thailand,Iran,0,0,AFC Asian Cup qualification,Bangkok,Thailand,FALSE
 2009-01-28,United Arab Emirates,Uzbekistan,0,1,AFC Asian Cup qualification,Sharjah,United Arab Emirates,FALSE
@@ -31371,7 +31371,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-02-04,Bahrain,South Korea,2,2,Friendly,Dubai,United Arab Emirates,TRUE
 2009-02-04,Japan,Finland,5,1,Friendly,Tokyo,Japan,FALSE
 2009-02-05,Saudi Arabia,Thailand,2,1,Friendly,Sendai,Japan,TRUE
-2009-02-06,El Salvador,Peru,1,0,Friendly,Los Angeles,USA,TRUE
+2009-02-06,El Salvador,Peru,1,0,Friendly,Los Angeles,United States,TRUE
 2009-02-07,Lithuania,Poland,1,1,Friendly,Faro,Portugal,TRUE
 2009-02-08,Barbados,Grenada,5,0,Friendly,Bridgetown,Barbados,FALSE
 2009-02-10,Brazil,Italy,2,0,Friendly,London,England,TRUE
@@ -31418,7 +31418,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-02-11,Tanzania,Zimbabwe,0,0,Friendly,Dar es Salaam,Tanzania,FALSE
 2009-02-11,Tunisia,Netherlands,1,1,Friendly,Radès,Tunisia,FALSE
 2009-02-11,Turkey,Ivory Coast,1,1,Friendly,İzmir,Turkey,FALSE
-2009-02-11,USA,Mexico,2,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2009-02-11,United States,Mexico,2,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2009-02-11,Uzbekistan,Bahrain,0,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2009-02-11,Venezuela,Guatemala,2,1,Friendly,Maturín,Venezuela,FALSE
 2009-02-11,Wales,Poland,0,1,Friendly,Vila Real de Santo António,Portugal,TRUE
@@ -31426,7 +31426,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-03-07,Sudan,Uganda,0,2,Friendly,Khartoum,Sudan,FALSE
 2009-03-11,Guam,Mongolia,1,0,EAFF Championship,Yona,Guam,FALSE
 2009-03-11,Macau,Northern Mariana Islands,6,1,EAFF Championship,Yona,Guam,TRUE
-2009-03-11,Mexico,Bolivia,5,1,Friendly,Commerce City,USA,TRUE
+2009-03-11,Mexico,Bolivia,5,1,Friendly,Commerce City,United States,TRUE
 2009-03-11,Nepal,Pakistan,1,0,Friendly,Kathmandu,Nepal,FALSE
 2009-03-13,Guam,Northern Mariana Islands,2,1,EAFF Championship,Yona,Guam,FALSE
 2009-03-13,Macau,Mongolia,1,2,EAFF Championship,Yona,Guam,TRUE
@@ -31453,7 +31453,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-03-28,Cape Verde,Equatorial Guinea,5,0,Friendly,Espargos,Cape Verde,FALSE
 2009-03-28,Colombia,Bolivia,2,0,FIFA World Cup qualification,Bogotá,Colombia,FALSE
 2009-03-28,Cyprus,Georgia,2,1,FIFA World Cup qualification,Larnaca,Cyprus,FALSE
-2009-03-28,El Salvador,USA,2,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
+2009-03-28,El Salvador,United States,2,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2009-03-28,England,Slovakia,4,0,Friendly,London,England,FALSE
 2009-03-28,Germany,Liechtenstein,4,0,FIFA World Cup qualification,Leipzig,Germany,FALSE
 2009-03-28,Iran,Saudi Arabia,1,2,FIFA World Cup qualification,Tehran,Iran,FALSE
@@ -31530,7 +31530,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-04-01,Serbia,Sweden,2,0,Friendly,Belgrade,Serbia,FALSE
 2009-04-01,Switzerland,Moldova,2,0,FIFA World Cup qualification,Geneva,Switzerland,FALSE
 2009-04-01,Turkey,Spain,1,2,FIFA World Cup qualification,Istanbul,Turkey,FALSE
-2009-04-01,USA,Trinidad and Tobago,3,0,FIFA World Cup qualification,Nashville,USA,FALSE
+2009-04-01,United States,Trinidad and Tobago,3,0,FIFA World Cup qualification,Nashville,United States,FALSE
 2009-04-01,Wales,Germany,0,2,FIFA World Cup qualification,Cardiff,Wales,FALSE
 2009-04-01,Bolivia,Argentina,6,1,FIFA World Cup qualification,La Paz,Bolivia,FALSE
 2009-04-01,Ecuador,Paraguay,1,1,FIFA World Cup qualification,Quito,Ecuador,FALSE
@@ -31561,9 +31561,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-05-13,Jordan,Zimbabwe,2,0,Friendly,Amman,Jordan,FALSE
 2009-05-13,Venezuela,Costa Rica,1,1,Friendly,San Cristóbal,Venezuela,FALSE
 2009-05-20,Argentina,Panama,3,1,Friendly,Santa Fe,Argentina,FALSE
-2009-05-23,Jamaica,Haiti,2,2,Friendly,Fort Lauderdale,USA,TRUE
+2009-05-23,Jamaica,Haiti,2,2,Friendly,Fort Lauderdale,United States,TRUE
 2009-05-26,Qatar,Saudi Arabia,2,1,Friendly,Doha,Qatar,FALSE
-2009-05-27,El Salvador,Ecuador,3,1,Friendly,Los Angeles,USA,TRUE
+2009-05-27,El Salvador,Ecuador,3,1,Friendly,Los Angeles,United States,TRUE
 2009-05-27,Japan,Chile,4,0,Kirin Cup,Osaka,Japan,FALSE
 2009-05-27,Jordan,Congo,1,1,Friendly,Amman,Jordan,FALSE
 2009-05-28,Tunisia,Sudan,4,0,Friendly,Radès,Tunisia,FALSE
@@ -31572,7 +31572,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-05-29,Republic of Ireland,Nigeria,1,1,Friendly,London,England,TRUE
 2009-05-29,Wales,Estonia,1,0,Friendly,Llanelli,Wales,FALSE
 2009-05-30,Cyprus,Canada,0,1,Friendly,Larnaca,Cyprus,FALSE
-2009-05-30,El Salvador,Jamaica,0,0,Friendly,Washington,USA,TRUE
+2009-05-30,El Salvador,Jamaica,0,0,Friendly,Washington,United States,TRUE
 2009-05-30,Oman,Egypt,0,1,Friendly,Muscat,Oman,FALSE
 2009-05-31,Bahrain,Congo,3,1,Friendly,Riffa,Bahrain,FALSE
 2009-05-31,Ghana,Uganda,2,1,Friendly,Tamale,Ghana,FALSE
@@ -31587,7 +31587,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-06-02,United Arab Emirates,Germany,2,7,Friendly,Dubai,United Arab Emirates,FALSE
 2009-06-03,Antigua and Barbuda,Guyana,2,1,Friendly,Paramaribo,Suriname,TRUE
 2009-06-03,Bahrain,Jordan,4,0,Friendly,Riffa,Bahrain,FALSE
-2009-06-03,Costa Rica,USA,3,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
+2009-06-03,Costa Rica,United States,3,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2009-06-03,Tanzania,New Zealand,2,1,Friendly,Dar es Salaam,Tanzania,FALSE
 2009-06-04,China PR,Saudi Arabia,1,4,Friendly,Tianjin,China PR,FALSE
 2009-06-05,Antigua and Barbuda,French Guiana,1,2,Friendly,Paramaribo,Suriname,TRUE
@@ -31625,7 +31625,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-06-06,Tunisia,Mozambique,2,0,FIFA World Cup qualification,Radès,Tunisia,FALSE
 2009-06-06,United Arab Emirates,South Korea,0,2,FIFA World Cup qualification,Dubai,United Arab Emirates,FALSE
 2009-06-06,Uruguay,Brazil,0,4,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2009-06-06,USA,Honduras,2,1,FIFA World Cup qualification,Chicago,USA,FALSE
+2009-06-06,United States,Honduras,2,1,FIFA World Cup qualification,Chicago,United States,FALSE
 2009-06-06,Uzbekistan,Japan,0,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2009-06-06,Zambia,Rwanda,1,0,FIFA World Cup qualification,Chililabombwe,Zambia,FALSE
 2009-06-06,Corsica,Congo,1,1,Friendly,Ajaccio,France,FALSE
@@ -31665,7 +31665,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-06-14,New Zealand,Spain,0,5,Confederations Cup,Rustenburg,South Africa,TRUE
 2009-06-14,South Africa,Iraq,0,0,Confederations Cup,Johannesburg,South Africa,FALSE
 2009-06-15,Brazil,Egypt,4,3,Confederations Cup,Bloemfontein,South Africa,TRUE
-2009-06-15,USA,Italy,1,3,Confederations Cup,Pretoria,South Africa,TRUE
+2009-06-15,United States,Italy,1,3,Confederations Cup,Pretoria,South Africa,TRUE
 2009-06-17,Australia,Japan,2,1,FIFA World Cup qualification,Melbourne,Australia,FALSE
 2009-06-17,Bahrain,Uzbekistan,1,0,FIFA World Cup qualification,Riffa,Bahrain,FALSE
 2009-06-17,South Korea,Iran,1,1,FIFA World Cup qualification,Seoul,South Korea,FALSE
@@ -31673,7 +31673,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-06-17,South Africa,New Zealand,2,0,Confederations Cup,Rustenburg,South Africa,FALSE
 2009-06-17,Spain,Iraq,1,0,Confederations Cup,Bloemfontein,South Africa,TRUE
 2009-06-18,Egypt,Italy,1,0,Confederations Cup,Johannesburg,South Africa,TRUE
-2009-06-18,USA,Brazil,0,3,Confederations Cup,Pretoria,South Africa,TRUE
+2009-06-18,United States,Brazil,0,3,Confederations Cup,Pretoria,South Africa,TRUE
 2009-06-19,Haiti,Panama,1,1,Friendly,Port-au-Prince,Haiti,FALSE
 2009-06-19,Eswatini,Lesotho,1,1,Friendly,Manzini,Eswatini,FALSE
 2009-06-20,Burkina Faso,Ivory Coast,2,3,FIFA World Cup qualification,Ouagadougou,Burkina Faso,FALSE
@@ -31684,7 +31684,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-06-20,Sudan,Ghana,0,2,FIFA World Cup qualification,Omdurman,Sudan,FALSE
 2009-06-20,Tunisia,Nigeria,0,0,FIFA World Cup qualification,Radès,Tunisia,FALSE
 2009-06-20,Zambia,Algeria,0,2,FIFA World Cup qualification,Chililabombwe,Zambia,FALSE
-2009-06-21,Egypt,USA,0,3,Confederations Cup,Rustenburg,South Africa,TRUE
+2009-06-21,Egypt,United States,0,3,Confederations Cup,Rustenburg,South Africa,TRUE
 2009-06-21,Italy,Brazil,0,3,Confederations Cup,Pretoria,South Africa,TRUE
 2009-06-21,Eswatini,Lesotho,1,1,Friendly,Lobamba,Eswatini,FALSE
 2009-06-22,Padania,Occitania,1,0,Viva World Cup,Novara,Italy,FALSE
@@ -31692,8 +31692,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-06-23,Haiti,Martinique,0,0,Friendly,Saint-Marc,Haiti,FALSE
 2009-06-23,Occitania,Iraqi Kurdistan,0,4,Viva World Cup,Varese,Italy,TRUE
 2009-06-23,Sápmi,Provence,1,2,Viva World Cup,Varese,Italy,TRUE
-2009-06-24,Mexico,Venezuela,4,0,Friendly,Atlanta,USA,TRUE
-2009-06-24,Spain,USA,0,2,Confederations Cup,Bloemfontein,South Africa,TRUE
+2009-06-24,Mexico,Venezuela,4,0,Friendly,Atlanta,United States,TRUE
+2009-06-24,Spain,United States,0,2,Confederations Cup,Bloemfontein,South Africa,TRUE
 2009-06-24,Padania,Iraqi Kurdistan,2,1,Viva World Cup,Brescia,Italy,FALSE
 2009-06-24,Sápmi,Gozo,7,2,Viva World Cup,Brescia,Italy,TRUE
 2009-06-25,South Africa,Brazil,0,1,Confederations Cup,Johannesburg,South Africa,FALSE
@@ -31706,10 +31706,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-06-27,Padania,Iraqi Kurdistan,2,0,Viva World Cup,Verona,Italy,FALSE
 2009-06-28,Cayman Islands,Jamaica,1,4,Friendly,George Town,Cayman Islands,FALSE
 2009-06-28,Grenada,Antigua and Barbuda,2,2,Friendly,St. George's,Grenada,FALSE
-2009-06-28,Mexico,Guatemala,0,0,Friendly,San Diego,USA,TRUE
-2009-06-28,Panama,Honduras,0,2,Friendly,Cary,USA,TRUE
+2009-06-28,Mexico,Guatemala,0,0,Friendly,San Diego,United States,TRUE
+2009-06-28,Panama,Honduras,0,2,Friendly,Cary,United States,TRUE
 2009-06-28,South Africa,Spain,2,3,Confederations Cup,Rustenburg,South Africa,FALSE
-2009-06-28,USA,Brazil,2,3,Confederations Cup,Johannesburg,South Africa,TRUE
+2009-06-28,United States,Brazil,2,3,Confederations Cup,Johannesburg,South Africa,TRUE
 2009-06-28,Åland Islands,Greenland,4,2,Island Games,Mariehamn,Sweden,FALSE
 2009-06-28,Shetland,Menorca,2,2,Island Games,Hammarland,Sweden,TRUE
 2009-06-28,Gibraltar,Guernsey,0,0,Island Games,Eckerö,Sweden,TRUE
@@ -31726,7 +31726,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-06-29,Isle of Wight,Saare County,5,1,Island Games,Hammarland,Sweden,TRUE
 2009-06-29,Isle of Man,Western Isles,5,0,Island Games,Finström,Sweden,TRUE
 2009-06-29,Gotland,Falkland Islands,2,0,Island Games,Jomala,Sweden,TRUE
-2009-06-30,Guatemala,Canada,0,3,Friendly,Oxnard,USA,TRUE
+2009-06-30,Guatemala,Canada,0,3,Friendly,Oxnard,United States,TRUE
 2009-06-30,Greenland,Shetland,3,1,Island Games,Sund,Sweden,TRUE
 2009-06-30,Åland Islands,Menorca,1,1,Island Games,Finström,Sweden,FALSE
 2009-06-30,Gibraltar,Ynys Môn,1,3,Island Games,Hammarland,Sweden,TRUE
@@ -31740,46 +31740,46 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-07-02,Gotland,Greenland,4,2,Island Games,Jomala,Sweden,TRUE
 2009-07-02,Åland Islands,Isle of Man,2,1,Island Games,Jomala,Sweden,FALSE
 2009-07-02,Guernsey,Jersey,0,2,Island Games,Sund,Sweden,TRUE
-2009-07-03,Canada,Jamaica,1,0,Gold Cup,Carson,USA,TRUE
-2009-07-03,Costa Rica,El Salvador,1,2,Gold Cup,Carson,USA,TRUE
+2009-07-03,Canada,Jamaica,1,0,Gold Cup,Carson,United States,TRUE
+2009-07-03,Costa Rica,El Salvador,1,2,Gold Cup,Carson,United States,TRUE
 2009-07-03,Gibraltar,Isle of Wight,3,0,Island Games,Jomala,Sweden,TRUE
 2009-07-03,Menorca,Western Isles,4,1,Island Games,Jomala,Sweden,TRUE
 2009-07-03,Rhodes,Ynys Môn,4,0,Island Games,Eckerö,Sweden,TRUE
 2009-07-03,Isle of Man,Guernsey,0,5,Island Games,Eckerö,Sweden,TRUE
 2009-07-03,Åland Islands,Jersey,1,2,Island Games,Mariehamn,Sweden,FALSE
-2009-07-04,Honduras,Haiti,1,0,Gold Cup,Seattle,USA,TRUE
-2009-07-04,USA,Grenada,4,0,Gold Cup,Seattle,USA,FALSE
+2009-07-04,Honduras,Haiti,1,0,Gold Cup,Seattle,United States,TRUE
+2009-07-04,United States,Grenada,4,0,Gold Cup,Seattle,United States,FALSE
 2009-07-05,Botswana,Iran,1,1,Friendly,Gaborone,Botswana,FALSE
 2009-07-05,Egypt,Rwanda,3,0,FIFA World Cup qualification,Cairo,Egypt,FALSE
-2009-07-05,Nicaragua,Mexico,0,2,Gold Cup,Oakland,USA,TRUE
-2009-07-05,Panama,Guadeloupe,1,2,Gold Cup,Oakland,USA,TRUE
+2009-07-05,Nicaragua,Mexico,0,2,Gold Cup,Oakland,United States,TRUE
+2009-07-05,Panama,Guadeloupe,1,2,Gold Cup,Oakland,United States,TRUE
 2009-07-06,Malawi,Eswatini,3,1,Friendly,Blantyre,Malawi,FALSE
-2009-07-07,El Salvador,Canada,0,1,Gold Cup,Columbus,USA,TRUE
-2009-07-07,Jamaica,Costa Rica,0,1,Gold Cup,Columbus,USA,TRUE
-2009-07-08,Haiti,Grenada,2,0,Gold Cup,Washington,USA,TRUE
-2009-07-08,USA,Honduras,2,0,Gold Cup,Washington,USA,FALSE
-2009-07-09,Guadeloupe,Nicaragua,2,0,Gold Cup,Houston,USA,TRUE
-2009-07-09,Mexico,Panama,1,1,Gold Cup,Houston,USA,TRUE
-2009-07-10,Costa Rica,Canada,2,2,Gold Cup,Miami,USA,TRUE
-2009-07-10,El Salvador,Jamaica,0,1,Gold Cup,Miami,USA,TRUE
+2009-07-07,El Salvador,Canada,0,1,Gold Cup,Columbus,United States,TRUE
+2009-07-07,Jamaica,Costa Rica,0,1,Gold Cup,Columbus,United States,TRUE
+2009-07-08,Haiti,Grenada,2,0,Gold Cup,Washington,United States,TRUE
+2009-07-08,United States,Honduras,2,0,Gold Cup,Washington,United States,FALSE
+2009-07-09,Guadeloupe,Nicaragua,2,0,Gold Cup,Houston,United States,TRUE
+2009-07-09,Mexico,Panama,1,1,Gold Cup,Houston,United States,TRUE
+2009-07-10,Costa Rica,Canada,2,2,Gold Cup,Miami,United States,TRUE
+2009-07-10,El Salvador,Jamaica,0,1,Gold Cup,Miami,United States,TRUE
 2009-07-10,Iraq,Palestine,3,0,Friendly,Erbil,Iraq,FALSE
-2009-07-11,Honduras,Grenada,4,0,Gold Cup,Foxborough,USA,TRUE
-2009-07-11,USA,Haiti,2,2,Gold Cup,Foxborough,USA,FALSE
+2009-07-11,Honduras,Grenada,4,0,Gold Cup,Foxborough,United States,TRUE
+2009-07-11,United States,Haiti,2,2,Gold Cup,Foxborough,United States,FALSE
 2009-07-12,Mayotte,Madagascar,2,2,Friendly,Mamoudzou,Mayotte,FALSE
-2009-07-12,Mexico,Guadeloupe,2,0,Gold Cup,Glendale,USA,TRUE
-2009-07-12,Panama,Nicaragua,4,0,Gold Cup,Glendale,USA,TRUE
+2009-07-12,Mexico,Guadeloupe,2,0,Gold Cup,Glendale,United States,TRUE
+2009-07-12,Panama,Nicaragua,4,0,Gold Cup,Glendale,United States,TRUE
 2009-07-12,Saint Kitts and Nevis,Trinidad and Tobago,2,3,Friendly,Basseterre,Saint Kitts and Nevis,FALSE
 2009-07-13,Iraq,Palestine,4,0,Friendly,Baghdad,Iraq,FALSE
-2009-07-18,Canada,Honduras,0,1,Gold Cup,Philadelphia,USA,TRUE
+2009-07-18,Canada,Honduras,0,1,Gold Cup,Philadelphia,United States,TRUE
 2009-07-18,China PR,Palestine,3,1,Friendly,Tianjin,China PR,FALSE
-2009-07-18,USA,Panama,2,1,Gold Cup,Philadelphia,USA,FALSE
-2009-07-19,Guadeloupe,Costa Rica,1,5,Gold Cup,Arlington,USA,TRUE
-2009-07-19,Mexico,Haiti,4,0,Gold Cup,Arlington,USA,TRUE
-2009-07-23,Costa Rica,Mexico,1,1,Gold Cup,Chicago,USA,TRUE
-2009-07-23,USA,Honduras,2,0,Gold Cup,Chicago,USA,FALSE
+2009-07-18,United States,Panama,2,1,Gold Cup,Philadelphia,United States,FALSE
+2009-07-19,Guadeloupe,Costa Rica,1,5,Gold Cup,Arlington,United States,TRUE
+2009-07-19,Mexico,Haiti,4,0,Gold Cup,Arlington,United States,TRUE
+2009-07-23,Costa Rica,Mexico,1,1,Gold Cup,Chicago,United States,TRUE
+2009-07-23,United States,Honduras,2,0,Gold Cup,Chicago,United States,FALSE
 2009-07-25,China PR,Kyrgyzstan,3,0,Friendly,Tianjin,China PR,FALSE
-2009-07-26,USA,Mexico,0,5,Gold Cup,East Rutherford,USA,FALSE
-2009-08-07,Colombia,El Salvador,2,1,Friendly,Houston,USA,TRUE
+2009-07-26,United States,Mexico,0,5,Gold Cup,East Rutherford,United States,FALSE
+2009-08-07,Colombia,El Salvador,2,1,Friendly,Houston,United States,TRUE
 2009-08-11,Benin,Gabon,1,1,Friendly,Dieppe,France,TRUE
 2009-08-12,Albania,Cyprus,6,1,Friendly,Tirana,Albania,FALSE
 2009-08-12,Algeria,Uruguay,1,0,Friendly,Algiers,Algeria,FALSE
@@ -31789,11 +31789,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-08-12,Belarus,Croatia,1,3,FIFA World Cup qualification,Minsk,Belarus,FALSE
 2009-08-12,Bosnia and Herzegovina,Iran,2,3,Friendly,Sarajevo,Bosnia and Herzegovina,FALSE
 2009-08-12,Bulgaria,Latvia,1,0,Friendly,Sofia,Bulgaria,FALSE
-2009-08-12,Colombia,Venezuela,1,2,Friendly,East Rutherford,USA,TRUE
+2009-08-12,Colombia,Venezuela,1,2,Friendly,East Rutherford,United States,TRUE
 2009-08-12,DR Congo,Senegal,1,2,Friendly,Blois,France,TRUE
 2009-08-12,Czech Republic,Belgium,3,1,Friendly,Teplice,Czech Republic,FALSE
 2009-08-12,Denmark,Chile,1,2,Friendly,Brøndby,Denmark,FALSE
-2009-08-12,Ecuador,Jamaica,0,0,Friendly,East Rutherford,USA,TRUE
+2009-08-12,Ecuador,Jamaica,0,0,Friendly,East Rutherford,United States,TRUE
 2009-08-12,Egypt,Guinea,3,3,Friendly,Cairo,Egypt,FALSE
 2009-08-12,Estonia,Brazil,0,1,Friendly,Tallinn,Estonia,FALSE
 2009-08-12,Faroe Islands,France,0,1,FIFA World Cup qualification,Tórshavn,Faroe Islands,FALSE
@@ -31809,7 +31809,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-08-12,Malaysia,Kenya,0,0,Friendly,Kuala Lumpur,Malaysia,FALSE
 2009-08-12,Mali,Burkina Faso,3,0,Friendly,Le Petit-Quevilly,France,TRUE
 2009-08-12,Malta,Georgia,2,0,Friendly,Attard,Malta,FALSE
-2009-08-12,Mexico,USA,2,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+2009-08-12,Mexico,United States,2,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2009-08-12,Montenegro,Wales,2,1,Friendly,Podgorica,Montenegro,FALSE
 2009-08-12,Morocco,Congo,1,1,Friendly,Rabat,Morocco,FALSE
 2009-08-12,Mozambique,Eswatini,1,0,Friendly,Maputo,Mozambique,FALSE
@@ -31891,7 +31891,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-09-05,Switzerland,Greece,2,0,FIFA World Cup qualification,Basel,Switzerland,FALSE
 2009-09-05,Turkey,Estonia,4,2,FIFA World Cup qualification,Kayseri,Turkey,FALSE
 2009-09-05,Ukraine,Andorra,5,0,FIFA World Cup qualification,Kyiv,Ukraine,FALSE
-2009-09-05,USA,El Salvador,2,1,FIFA World Cup qualification,Sandy City,USA,FALSE
+2009-09-05,United States,El Salvador,2,1,FIFA World Cup qualification,Sandy City,United States,FALSE
 2009-09-05,Uzbekistan,Iran,0,0,Friendly,Tashkent,Uzbekistan,FALSE
 2009-09-06,Algeria,Zambia,1,0,FIFA World Cup qualification,Blida,Algeria,FALSE
 2009-09-06,Benin,Mali,1,1,FIFA World Cup qualification,Cotonou,Benin,FALSE
@@ -31934,7 +31934,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-09-09,Serbia,France,1,1,FIFA World Cup qualification,Belgrade,Serbia,FALSE
 2009-09-09,Slovenia,Poland,3,0,FIFA World Cup qualification,Maribor,Slovenia,FALSE
 2009-09-09,Spain,Estonia,3,0,FIFA World Cup qualification,Mérida,Spain,FALSE
-2009-09-09,Trinidad and Tobago,USA,0,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
+2009-09-09,Trinidad and Tobago,United States,0,1,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2009-09-09,Wales,Russia,1,3,FIFA World Cup qualification,Cardiff,Wales,FALSE
 2009-09-09,Uruguay,Colombia,3,1,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 2009-09-09,Paraguay,Argentina,1,0,FIFA World Cup qualification,Asunción,Paraguay,FALSE
@@ -31945,7 +31945,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-09-20,Saint Kitts and Nevis,Saint Vincent and the Grenadines,1,1,Friendly,Basseterre,Saint Kitts and Nevis,FALSE
 2009-09-30,Argentina,Ghana,2,0,Friendly,Córdoba,Argentina,FALSE
 2009-09-30,China PR,Botswana,4,1,Friendly,Hohhot,China PR,FALSE
-2009-09-30,Mexico,Colombia,1,2,Friendly,Dallas,USA,TRUE
+2009-09-30,Mexico,Colombia,1,2,Friendly,Dallas,United States,TRUE
 2009-10-02,Egypt,Mauritius,4,0,Friendly,Cairo,Egypt,FALSE
 2009-10-05,Kuwait,Libya,1,1,Friendly,Cairo,Egypt,TRUE
 2009-10-08,Croatia,Qatar,3,2,Friendly,Rijeka,Croatia,FALSE
@@ -31969,7 +31969,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-10-10,France,Faroe Islands,5,0,FIFA World Cup qualification,Guingamp,France,FALSE
 2009-10-10,Gabon,Morocco,3,1,FIFA World Cup qualification,Libreville,Gabon,FALSE
 2009-10-10,Greece,Latvia,5,2,FIFA World Cup qualification,Athens,Greece,FALSE
-2009-10-10,Honduras,USA,2,3,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
+2009-10-10,Honduras,United States,2,3,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2009-10-10,Republic of Ireland,Italy,2,2,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
 2009-10-10,Israel,Moldova,3,1,FIFA World Cup qualification,Ramat-Gan,Israel,FALSE
 2009-10-10,Japan,Scotland,2,0,Friendly,Yokohama,Japan,FALSE
@@ -32036,7 +32036,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-10-14,Turkey,Armenia,2,0,FIFA World Cup qualification,Bursa,Turkey,FALSE
 2009-10-14,United Arab Emirates,Jordan,3,1,Friendly,Dubai,United Arab Emirates,FALSE
 2009-10-14,Uruguay,Argentina,0,1,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2009-10-14,USA,Costa Rica,2,2,FIFA World Cup qualification,Washington,USA,FALSE
+2009-10-14,United States,Costa Rica,2,2,FIFA World Cup qualification,Washington,United States,FALSE
 2009-10-17,Zimbabwe,Mauritius,3,0,COSAFA Cup,Harare,Zimbabwe,FALSE
 2009-10-18,Comoros,Botswana,0,0,COSAFA Cup,Bulawayo,Zimbabwe,TRUE
 2009-10-18,Eswatini,Seychelles,2,1,COSAFA Cup,Bulawayo,Zimbabwe,TRUE
@@ -32105,7 +32105,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-11-14,Rwanda,Zambia,0,0,FIFA World Cup qualification,Kigali,Rwanda,FALSE
 2009-11-14,Saudi Arabia,Belarus,1,1,Friendly,Dammam,Saudi Arabia,FALSE
 2009-11-14,Singapore,Thailand,1,3,AFC Asian Cup qualification,Singapore,Singapore,FALSE
-2009-11-14,Slovakia,USA,1,0,Friendly,Bratislava,Slovakia,FALSE
+2009-11-14,Slovakia,United States,1,0,Friendly,Bratislava,Slovakia,FALSE
 2009-11-14,South Africa,Japan,0,0,Friendly,Port Elizabeth,South Africa,FALSE
 2009-11-14,Spain,Argentina,2,1,Friendly,Madrid,Spain,FALSE
 2009-11-14,Sudan,Benin,1,2,FIFA World Cup qualification,Omdurman,Sudan,FALSE
@@ -32127,10 +32127,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2009-11-18,Azerbaijan,Czech Republic,2,0,Friendly,Al Ain,United Arab Emirates,TRUE
 2009-11-18,Bahrain,Yemen,4,0,AFC Asian Cup qualification,Riffa,Bahrain,FALSE
 2009-11-18,Bosnia and Herzegovina,Portugal,0,1,FIFA World Cup qualification,Zenica,Bosnia and Herzegovina,FALSE
-2009-11-18,Denmark,USA,3,1,Friendly,Aarhus,Denmark,FALSE
+2009-11-18,Denmark,United States,3,1,Friendly,Aarhus,Denmark,FALSE
 2009-11-18,France,Republic of Ireland,1,1,FIFA World Cup qualification,Saint-Denis,France,FALSE
 2009-11-18,Germany,Ivory Coast,2,2,Friendly,Gelsenkirchen,Germany,FALSE
-2009-11-18,Honduras,Peru,1,2,Friendly,Miami Gardens,USA,TRUE
+2009-11-18,Honduras,Peru,1,2,Friendly,Miami Gardens,United States,TRUE
 2009-11-18,Hong Kong,Japan,0,4,AFC Asian Cup qualification,So Kon Po,Hong Kong,FALSE
 2009-11-18,Indonesia,Kuwait,1,1,AFC Asian Cup qualification,Jakarta,Indonesia,FALSE
 2009-11-18,Iran,North Macedonia,1,1,Friendly,Tehran,Iran,FALSE
@@ -32252,7 +32252,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-01-22,Latvia,South Korea,0,1,Friendly,Málaga,Spain,TRUE
 2010-01-23,Poland,Singapore,6,1,King's Cup,Nakhon Ratchasima,Thailand,TRUE
 2010-01-23,Syria,Sweden,1,1,Friendly,Damascus,Syria,FALSE
-2010-01-23,USA,Honduras,1,3,Friendly,Carson,USA,FALSE
+2010-01-23,United States,Honduras,1,3,Friendly,Carson,United States,FALSE
 2010-01-24,Angola,Ghana,0,1,African Cup of Nations,Luanda,Angola,FALSE
 2010-01-24,Ivory Coast,Algeria,2,3,African Cup of Nations,Cabinda,Angola,TRUE
 2010-01-25,Egypt,Cameroon,3,1,African Cup of Nations,Benguela,Angola,TRUE
@@ -32283,9 +32283,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-02-20,Tajikistan,Myanmar,3,0,AFC Challenge Cup,Colombo,Sri Lanka,TRUE
 2010-02-21,Turkmenistan,Kyrgyzstan,1,0,AFC Challenge Cup,Colombo,Sri Lanka,TRUE
 2010-02-24,North Korea,Myanmar,5,0,AFC Challenge Cup,Colombo,Sri Lanka,TRUE
-2010-02-24,Mexico,Bolivia,5,0,Friendly,San Francisco,USA,TRUE
+2010-02-24,Mexico,Bolivia,5,0,Friendly,San Francisco,United States,TRUE
 2010-02-24,Tajikistan,Turkmenistan,0,2,AFC Challenge Cup,Colombo,Sri Lanka,TRUE
-2010-02-24,USA,El Salvador,2,1,Friendly,Tampa,USA,FALSE
+2010-02-24,United States,El Salvador,2,1,Friendly,Tampa,United States,FALSE
 2010-02-25,Jordan,Azerbaijan,0,2,Friendly,Amman,Jordan,FALSE
 2010-02-25,Kuwait,Bahrain,4,1,Friendly,Al Ain,United Arab Emirates,TRUE
 2010-02-25,Turkmenistan,North Korea,1,1,AFC Challenge Cup,Colombo,Sri Lanka,TRUE
@@ -32302,7 +32302,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-03-03,Belgium,Croatia,0,1,Friendly,Brussels,Belgium,FALSE
 2010-03-03,Bosnia and Herzegovina,Ghana,2,1,Friendly,Sarajevo,Bosnia and Herzegovina,FALSE
 2010-03-03,Cyprus,Iceland,0,0,Friendly,Larnaca,Cyprus,FALSE
-2010-03-03,El Salvador,Guatemala,1,2,Friendly,Los Angeles,USA,TRUE
+2010-03-03,El Salvador,Guatemala,1,2,Friendly,Los Angeles,United States,TRUE
 2010-03-03,England,Egypt,3,1,Friendly,London,England,FALSE
 2010-03-03,France,Spain,0,2,Friendly,Saint-Denis,France,FALSE
 2010-03-03,Georgia,Estonia,2,1,Friendly,Tbilisi,Georgia,FALSE
@@ -32320,9 +32320,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-03-03,Luxembourg,Azerbaijan,1,2,Friendly,Luxembourg,Luxembourg,FALSE
 2010-03-03,North Macedonia,Montenegro,2,1,Friendly,Skopje,North Macedonia,FALSE
 2010-03-03,Malta,Finland,1,2,Friendly,Attard,Malta,FALSE
-2010-03-03,Mexico,New Zealand,2,0,Friendly,Pasadena,USA,TRUE
+2010-03-03,Mexico,New Zealand,2,0,Friendly,Pasadena,United States,TRUE
 2010-03-03,Mozambique,Botswana,0,1,Friendly,Maputo,Mozambique,FALSE
-2010-03-03,Netherlands,USA,2,1,Friendly,Amsterdam,Netherlands,FALSE
+2010-03-03,Netherlands,United States,2,1,Friendly,Amsterdam,Netherlands,FALSE
 2010-03-03,Nigeria,DR Congo,5,2,Friendly,Abuja,Nigeria,FALSE
 2010-03-03,Oman,Kuwait,0,0,AFC Asian Cup qualification,Muscat,Oman,FALSE
 2010-03-03,Poland,Bulgaria,2,0,Friendly,Warsaw,Poland,FALSE
@@ -32346,7 +32346,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-03-21,Iceland,Faroe Islands,2,0,Friendly,Kópavogur,Iceland,FALSE
 2010-03-21,Namibia,Botswana,0,0,Friendly,Windhoek,Namibia,FALSE
 2010-03-24,Martinique,Haiti,0,0,Friendly,Fort-de-France,Martinique,FALSE
-2010-03-24,Mexico,Iceland,0,0,Friendly,Charlotte,USA,TRUE
+2010-03-24,Mexico,Iceland,0,0,Friendly,Charlotte,United States,TRUE
 2010-03-31,Chile,Venezuela,0,0,Friendly,Temuco,Chile,FALSE
 2010-03-31,Paraguay,South Africa,1,1,Friendly,Asunción,Paraguay,FALSE
 2010-04-03,Saint Kitts and Nevis,Guadeloupe,3,0,Friendly,Basseterre,Saint Kitts and Nevis,FALSE
@@ -32356,11 +32356,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-04-28,South Africa,Jamaica,2,0,Friendly,Offenbach am Main,Germany,TRUE
 2010-05-05,Argentina,Haiti,4,0,Friendly,Cutral Có,Argentina,FALSE
 2010-05-05,Chile,Trinidad and Tobago,2,0,Friendly,Iquique,Chile,FALSE
-2010-05-07,Mexico,Ecuador,0,0,Friendly,East Rutherford,USA,TRUE
-2010-05-10,Mexico,Senegal,1,0,Friendly,Chicago,USA,TRUE
+2010-05-07,Mexico,Ecuador,0,0,Friendly,East Rutherford,United States,TRUE
+2010-05-10,Mexico,Senegal,1,0,Friendly,Chicago,United States,TRUE
 2010-05-12,Yemen,Malawi,1,0,Friendly,Sana'a,Yemen,FALSE
 2010-05-13,Germany,Malta,3,0,Friendly,Aachen,Germany,FALSE
-2010-05-13,Mexico,Angola,1,0,Friendly,Houston,USA,TRUE
+2010-05-13,Mexico,Angola,1,0,Friendly,Houston,United States,TRUE
 2010-05-15,Paraguay,North Korea,1,0,Friendly,Nyon,Switzerland,TRUE
 2010-05-16,South Korea,Ecuador,2,0,Friendly,Seoul,South Korea,FALSE
 2010-05-16,Mexico,Chile,1,0,Friendly,Mexico City,Mexico,FALSE
@@ -32375,7 +32375,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-05-21,Estonia,Finland,2,0,Friendly,Tallinn,Estonia,FALSE
 2010-05-21,Brittany,Togo,2,1,Friendly,Bastia,France,FALSE
 2010-05-21,Corsica,Gabon,1,1,Friendly,Bastia,France,FALSE
-2010-05-22,Turkey,Czech Republic,2,1,Friendly,Harrison,USA,TRUE
+2010-05-22,Turkey,Czech Republic,2,1,Friendly,Harrison,United States,TRUE
 2010-05-23,Croatia,Wales,2,0,Friendly,Osijek,Croatia,FALSE
 2010-05-24,Argentina,Canada,5,0,Friendly,Buenos Aires,Argentina,FALSE
 2010-05-24,Australia,New Zealand,2,1,Friendly,Melbourne,Australia,FALSE
@@ -32390,13 +32390,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-05-25,Montenegro,Albania,0,1,Friendly,Podgorica,Montenegro,FALSE
 2010-05-25,Nigeria,Saudi Arabia,0,0,Friendly,Wattens,Austria,TRUE
 2010-05-25,Ukraine,Lithuania,4,0,Friendly,Kharkiv,Ukraine,FALSE
-2010-05-25,USA,Czech Republic,2,4,Friendly,East Hartford,USA,FALSE
+2010-05-25,United States,Czech Republic,2,4,Friendly,East Hartford,United States,FALSE
 2010-05-26,Azerbaijan,Moldova,1,1,Friendly,Seekirchen am Wallersee,Austria,TRUE
 2010-05-26,Chile,Zambia,3,0,Friendly,Calama,Chile,FALSE
 2010-05-26,Estonia,Croatia,0,0,Friendly,Tallinn,Estonia,FALSE
 2010-05-26,France,Costa Rica,2,1,Friendly,Lens,France,FALSE
 2010-05-26,Netherlands,Mexico,2,1,Friendly,Freiburg,Germany,TRUE
-2010-05-26,Northern Ireland,Turkey,0,2,Friendly,New Britain,USA,TRUE
+2010-05-26,Northern Ireland,Turkey,0,2,Friendly,New Britain,United States,TRUE
 2010-05-26,Uruguay,Israel,4,1,Friendly,Montevideo,Uruguay,FALSE
 2010-05-27,Belarus,Honduras,2,2,Friendly,Villach,Austria,TRUE
 2010-05-27,Denmark,Senegal,2,0,Friendly,Aalborg,Denmark,FALSE
@@ -32413,7 +32413,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-05-29,Spain,Saudi Arabia,3,2,Friendly,Innsbruck,Austria,TRUE
 2010-05-29,Sweden,Bosnia and Herzegovina,4,2,Friendly,Solna,Sweden,FALSE
 2010-05-29,Ukraine,Romania,3,2,Friendly,Lviv,Ukraine,FALSE
-2010-05-29,USA,Turkey,2,1,Friendly,Philadelphia,USA,FALSE
+2010-05-29,United States,Turkey,2,1,Friendly,Philadelphia,United States,FALSE
 2010-05-29,Venezuela,Canada,1,1,Friendly,Mérida,Venezuela,FALSE
 2010-05-30,Belarus,South Korea,1,0,Friendly,Kufstein,Austria,TRUE
 2010-05-30,Chile,Northern Ireland,1,0,Friendly,Chillán,Chile,FALSE
@@ -32455,7 +32455,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-06-04,Padania,Two Sicilies,2,0,Viva World Cup,Xewkija,Malta,TRUE
 2010-06-04,Gozo,Provence,2,1,Viva World Cup,Xewkija,Malta,FALSE
 2010-06-05,Algeria,United Arab Emirates,1,0,Friendly,Fürth,Germany,TRUE
-2010-06-05,Australia,USA,1,3,Friendly,Roodepoort,South Africa,TRUE
+2010-06-05,Australia,United States,1,3,Friendly,Roodepoort,South Africa,TRUE
 2010-06-05,Ghana,Latvia,1,0,Friendly,Milton Keynes,England,TRUE
 2010-06-05,Netherlands,Hungary,6,1,Friendly,Amsterdam,Netherlands,FALSE
 2010-06-05,Romania,Honduras,3,0,Friendly,Sankt Veit an der Glan,Austria,TRUE
@@ -32472,7 +32472,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-06-11,South Africa,Mexico,1,1,FIFA World Cup,Johannesburg,South Africa,FALSE
 2010-06-11,Uruguay,France,0,0,FIFA World Cup,Cape Town,South Africa,TRUE
 2010-06-12,Argentina,Nigeria,1,0,FIFA World Cup,Johannesburg,South Africa,TRUE
-2010-06-12,England,USA,1,1,FIFA World Cup,Rustenburg,South Africa,TRUE
+2010-06-12,England,United States,1,1,FIFA World Cup,Rustenburg,South Africa,TRUE
 2010-06-12,South Korea,Greece,2,0,FIFA World Cup,Port Elizabeth,South Africa,TRUE
 2010-06-13,Algeria,Slovenia,0,1,FIFA World Cup,Polokwane,South Africa,TRUE
 2010-06-13,Germany,Australia,4,0,FIFA World Cup,Durban,South Africa,TRUE
@@ -32492,7 +32492,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-06-18,England,Algeria,0,0,FIFA World Cup,Cape Town,South Africa,TRUE
 2010-06-18,Germany,Serbia,0,1,FIFA World Cup,Port Elizabeth,South Africa,TRUE
 2010-06-18,Lithuania,Latvia,0,0,Baltic Cup,Kaunas,Lithuania,FALSE
-2010-06-18,Slovenia,USA,2,2,FIFA World Cup,Johannesburg,South Africa,TRUE
+2010-06-18,Slovenia,United States,2,2,FIFA World Cup,Johannesburg,South Africa,TRUE
 2010-06-19,Cameroon,Denmark,1,2,FIFA World Cup,Pretoria,South Africa,TRUE
 2010-06-19,Estonia,Latvia,0,0,Baltic Cup,Kaunas,Lithuania,TRUE
 2010-06-19,Ghana,Australia,1,1,FIFA World Cup,Rustenburg,South Africa,TRUE
@@ -32514,7 +32514,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-06-23,Australia,Serbia,2,1,FIFA World Cup,Nelspruit,South Africa,TRUE
 2010-06-23,Ghana,Germany,0,1,FIFA World Cup,Johannesburg,South Africa,TRUE
 2010-06-23,Slovenia,England,0,1,FIFA World Cup,Port Elizabeth,South Africa,TRUE
-2010-06-23,USA,Algeria,1,0,FIFA World Cup,Pretoria,South Africa,TRUE
+2010-06-23,United States,Algeria,1,0,FIFA World Cup,Pretoria,South Africa,TRUE
 2010-06-24,Cameroon,Netherlands,1,2,FIFA World Cup,Cape Town,South Africa,TRUE
 2010-06-24,Denmark,Japan,1,3,FIFA World Cup,Rustenburg,South Africa,TRUE
 2010-06-24,Paraguay,New Zealand,0,0,FIFA World Cup,Polokwane,South Africa,TRUE
@@ -32525,7 +32525,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-06-25,Switzerland,Honduras,0,0,FIFA World Cup,Bloemfontein,South Africa,TRUE
 2010-06-26,China PR,Tajikistan,4,0,Friendly,Kunming,China PR,FALSE
 2010-06-26,Uruguay,South Korea,2,1,FIFA World Cup,Port Elizabeth,South Africa,TRUE
-2010-06-26,USA,Ghana,1,2,FIFA World Cup,Rustenburg,South Africa,TRUE
+2010-06-26,United States,Ghana,1,2,FIFA World Cup,Rustenburg,South Africa,TRUE
 2010-06-27,Argentina,Mexico,3,1,FIFA World Cup,Johannesburg,South Africa,TRUE
 2010-06-27,Germany,England,4,1,FIFA World Cup,Bloemfontein,South Africa,TRUE
 2010-06-28,Brazil,Chile,3,0,FIFA World Cup,Johannesburg,South Africa,TRUE
@@ -32548,7 +32548,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-08-08,Anguilla,Saint Martin,1,3,Friendly,The Valley,Anguilla,FALSE
 2010-08-10,Bosnia and Herzegovina,Qatar,1,1,Friendly,Sarajevo,Bosnia and Herzegovina,FALSE
 2010-08-10,Italy,Ivory Coast,0,1,Friendly,London,England,TRUE
-2010-08-10,USA,Brazil,0,2,Friendly,East Rutherford,USA,FALSE
+2010-08-10,United States,Brazil,0,2,Friendly,East Rutherford,United States,FALSE
 2010-08-11,Albania,Uzbekistan,1,0,Friendly,Durrës,Albania,FALSE
 2010-08-11,Algeria,Gabon,1,2,Friendly,Algiers,Algeria,FALSE
 2010-08-11,Angola,Uruguay,0,2,Friendly,Lisbon,Portugal,TRUE
@@ -32641,8 +32641,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-09-04,Botswana,Togo,2,1,African Cup of Nations qualification,Gaborone,Botswana,FALSE
 2010-09-04,Canada,Peru,0,2,Friendly,Toronto,Canada,FALSE
 2010-09-04,Cape Verde,Mali,1,0,African Cup of Nations qualification,Praia,Cape Verde,FALSE
-2010-09-04,El Salvador,Honduras,2,2,Friendly,Los Angeles,USA,TRUE
-2010-09-04,Guatemala,Nicaragua,5,0,Friendly,Fort Lauderdale,USA,TRUE
+2010-09-04,El Salvador,Honduras,2,2,Friendly,Los Angeles,United States,TRUE
+2010-09-04,Guatemala,Nicaragua,5,0,Friendly,Fort Lauderdale,United States,TRUE
 2010-09-04,Guinea-Bissau,Kenya,1,0,African Cup of Nations qualification,Bissau,Guinea-Bissau,FALSE
 2010-09-04,Ivory Coast,Rwanda,3,0,African Cup of Nations qualification,Abidjan,Ivory Coast,FALSE
 2010-09-04,Japan,Paraguay,1,0,Friendly,Yokohama,Japan,FALSE
@@ -32677,14 +32677,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-09-07,Croatia,Greece,0,0,UEFA Euro qualification,Zagreb,Croatia,FALSE
 2010-09-07,Czech Republic,Lithuania,0,1,UEFA Euro qualification,Olomouc,Czech Republic,FALSE
 2010-09-07,Denmark,Iceland,1,0,UEFA Euro qualification,Copenhagen,Denmark,FALSE
-2010-09-07,El Salvador,Guatemala,0,2,Friendly,Washington,USA,TRUE
+2010-09-07,El Salvador,Guatemala,0,2,Friendly,Washington,United States,TRUE
 2010-09-07,Estonia,Uzbekistan,3,3,Friendly,Tallinn,Estonia,FALSE
 2010-09-07,Georgia,Israel,0,0,UEFA Euro qualification,Tbilisi,Georgia,FALSE
 2010-09-07,Germany,Azerbaijan,6,1,UEFA Euro qualification,Cologne,Germany,FALSE
 2010-09-07,Hungary,Moldova,2,1,UEFA Euro qualification,Budapest,Hungary,FALSE
 2010-09-07,Republic of Ireland,Andorra,3,1,UEFA Euro qualification,Dublin,Republic of Ireland,FALSE
 2010-09-07,Italy,Faroe Islands,5,0,UEFA Euro qualification,Florence,Italy,FALSE
-2010-09-07,Jamaica,Peru,1,2,Friendly,Fort Lauderdale,USA,TRUE
+2010-09-07,Jamaica,Peru,1,2,Friendly,Fort Lauderdale,United States,TRUE
 2010-09-07,Japan,Guatemala,2,1,Friendly,Osaka,Japan,FALSE
 2010-09-07,South Korea,Iran,0,1,Friendly,Seoul,South Korea,FALSE
 2010-09-07,North Macedonia,Armenia,2,2,UEFA Euro qualification,Skopje,North Macedonia,FALSE
@@ -32762,7 +32762,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-10-08,Armenia,Slovakia,3,1,UEFA Euro qualification,Yerevan,Armenia,FALSE
 2010-10-08,Austria,Azerbaijan,3,0,UEFA Euro qualification,Vienna,Austria,FALSE
 2010-10-08,China PR,Syria,2,1,Friendly,Kunming,China PR,FALSE
-2010-10-08,Colombia,Ecuador,1,0,Friendly,Harrison,USA,TRUE
+2010-10-08,Colombia,Ecuador,1,0,Friendly,Harrison,United States,TRUE
 2010-10-08,Cyprus,Norway,1,2,UEFA Euro qualification,Larnaca,Cyprus,FALSE
 2010-10-08,Czech Republic,Scotland,1,0,UEFA Euro qualification,Prague,Czech Republic,FALSE
 2010-10-08,Georgia,Malta,1,0,UEFA Euro qualification,Tbilisi,Georgia,FALSE
@@ -32808,7 +32808,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-10-09,Senegal,Mauritius,7,0,African Cup of Nations qualification,Dakar,Senegal,FALSE
 2010-10-09,Tanzania,Morocco,0,1,African Cup of Nations qualification,Dar es Salaam,Tanzania,FALSE
 2010-10-09,United Arab Emirates,Chile,0,2,Friendly,Abu Dhabi,United Arab Emirates,FALSE
-2010-10-09,USA,Poland,2,2,Friendly,Chicago,USA,FALSE
+2010-10-09,United States,Poland,2,2,Friendly,Chicago,United States,FALSE
 2010-10-10,Central African Republic,Algeria,2,0,African Cup of Nations qualification,Bangui,Central African Republic,FALSE
 2010-10-10,Congo,Eswatini,3,1,African Cup of Nations qualification,Brazzaville,Congo,FALSE
 2010-10-10,Ghana,Sudan,0,0,African Cup of Nations qualification,Kumasi,Ghana,FALSE
@@ -32840,7 +32840,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-10-12,Finland,Hungary,1,2,UEFA Euro qualification,Helsinki,Finland,FALSE
 2010-10-12,France,Luxembourg,2,0,UEFA Euro qualification,Metz,France,FALSE
 2010-10-12,Greece,Israel,2,1,UEFA Euro qualification,Piraeus,Greece,FALSE
-2010-10-12,Guatemala,Honduras,0,2,Friendly,Los Angeles,USA,TRUE
+2010-10-12,Guatemala,Honduras,0,2,Friendly,Los Angeles,United States,TRUE
 2010-10-12,Iceland,Portugal,1,3,UEFA Euro qualification,Reykjavík,Iceland,FALSE
 2010-10-12,Indonesia,Maldives,3,0,Friendly,Jakarta,Indonesia,FALSE
 2010-10-12,Italy,Serbia,3,0,UEFA Euro qualification,Genoa,Italy,FALSE
@@ -32863,7 +32863,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-10-12,Slovakia,Republic of Ireland,1,1,UEFA Euro qualification,Žilina,Slovakia,FALSE
 2010-10-12,Switzerland,Wales,4,1,UEFA Euro qualification,Basel,Switzerland,FALSE
 2010-10-12,United Arab Emirates,Angola,0,2,Friendly,Abu Dhabi,United Arab Emirates,FALSE
-2010-10-12,USA,Colombia,0,0,Friendly,Chester,USA,FALSE
+2010-10-12,United States,Colombia,0,0,Friendly,Chester,United States,FALSE
 2010-10-13,Guyana,Saint Lucia,1,0,CFU Caribbean Cup qualification,Paramaribo,Suriname,TRUE
 2010-10-13,India,Yemen,3,6,Friendly,Pune,India,FALSE
 2010-10-13,Suriname,Curaçao,2,1,CFU Caribbean Cup qualification,Paramaribo,Suriname,FALSE
@@ -32931,14 +32931,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-11-17,Estonia,Liechtenstein,1,1,Friendly,Tallinn,Estonia,FALSE
 2010-11-17,Finland,San Marino,8,0,UEFA Euro qualification,Helsinki,Finland,FALSE
 2010-11-17,Gabon,Senegal,1,2,Friendly,Saint-Gratien,France,TRUE
-2010-11-17,Guatemala,Guyana,3,0,Friendly,Kennesaw,USA,TRUE
+2010-11-17,Guatemala,Guyana,3,0,Friendly,Kennesaw,United States,TRUE
 2010-11-17,Hong Kong,Paraguay,0,7,Friendly,So Kon Po,Hong Kong,FALSE
 2010-11-17,Hungary,Lithuania,2,0,Friendly,Székesfehérvár,Hungary,FALSE
 2010-11-17,Iraq,Kuwait,1,1,Friendly,Abu Dhabi,United Arab Emirates,TRUE
 2010-11-17,Republic of Ireland,Norway,1,2,Friendly,Dublin,Republic of Ireland,FALSE
 2010-11-17,Israel,Iceland,3,2,Friendly,Jaffa,Israel,FALSE
 2010-11-17,Italy,Romania,1,1,Friendly,Klagenfurt,Austria,TRUE
-2010-11-17,Jamaica,Costa Rica,0,0,Friendly,Fort Lauderdale,USA,TRUE
+2010-11-17,Jamaica,Costa Rica,0,0,Friendly,Fort Lauderdale,United States,TRUE
 2010-11-17,Libya,Niger,1,1,Friendly,Tripoli,Libya,FALSE
 2010-11-17,Luxembourg,Algeria,0,0,Friendly,Luxembourg,Luxembourg,FALSE
 2010-11-17,Malawi,Rwanda,2,1,Friendly,Blantyre,Malawi,FALSE
@@ -32955,7 +32955,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2010-11-17,Saudi Arabia,Ghana,0,0,Friendly,Dubai,United Arab Emirates,TRUE
 2010-11-17,Slovakia,Bosnia and Herzegovina,2,3,Friendly,Bratislava,Slovakia,FALSE
 2010-11-17,Slovenia,Georgia,1,2,Friendly,Koper,Slovenia,FALSE
-2010-11-17,South Africa,USA,0,1,Friendly,Cape Town,South Africa,FALSE
+2010-11-17,South Africa,United States,0,1,Friendly,Cape Town,South Africa,FALSE
 2010-11-17,Sweden,Germany,0,0,Friendly,Gothenburg,Sweden,FALSE
 2010-11-17,Switzerland,Ukraine,2,2,Friendly,Geneva,Switzerland,FALSE
 2010-11-17,Tajikistan,Afghanistan,1,0,Friendly,Dushanbe,Tajikistan,FALSE
@@ -33113,7 +33113,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-01-21,Uzbekistan,Jordan,2,1,AFC Asian Cup,Doha,Qatar,TRUE
 2011-01-22,Australia,Iraq,1,0,AFC Asian Cup,Doha,Qatar,TRUE
 2011-01-22,Iran,South Korea,0,1,AFC Asian Cup,Doha,Qatar,TRUE
-2011-01-22,USA,Chile,1,1,Friendly,Carson,USA,FALSE
+2011-01-22,United States,Chile,1,1,Friendly,Carson,United States,FALSE
 2011-01-23,Honduras,Costa Rica,2,1,UNCAF Cup,Panama City,Panama,TRUE
 2011-01-23,Panama,El Salvador,0,0,UNCAF Cup,Panama City,Panama,FALSE
 2011-01-24,Vanuatu,New Caledonia,0,0,Friendly,Port Vila,Vanuatu,FALSE
@@ -33155,7 +33155,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-02-09,North Macedonia,Cameroon,0,1,Friendly,Skopje,North Macedonia,FALSE
 2011-02-09,Malaysia,Hong Kong,2,0,Friendly,Kuala Lumpur,Malaysia,FALSE
 2011-02-09,Malta,Switzerland,0,0,Friendly,Attard,Malta,FALSE
-2011-02-09,Mexico,Bosnia and Herzegovina,2,0,Friendly,Atlanta,USA,TRUE
+2011-02-09,Mexico,Bosnia and Herzegovina,2,0,Friendly,Atlanta,United States,TRUE
 2011-02-09,Morocco,Niger,3,0,Friendly,Marrakech,Morocco,FALSE
 2011-02-09,Mozambique,Botswana,1,1,Friendly,Maputo,Mozambique,FALSE
 2011-02-09,Namibia,Malawi,1,2,Friendly,Windhoek,Namibia,FALSE
@@ -33235,13 +33235,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-03-26,Malawi,Togo,1,0,African Cup of Nations qualification,Blantyre,Malawi,FALSE
 2011-03-26,Mali,Zimbabwe,1,0,African Cup of Nations qualification,Bamako,Mali,FALSE
 2011-03-26,Malta,Greece,0,1,UEFA Euro qualification,Attard,Malta,FALSE
-2011-03-26,Mexico,Paraguay,3,1,Friendly,Oakland,USA,TRUE
+2011-03-26,Mexico,Paraguay,3,1,Friendly,Oakland,United States,TRUE
 2011-03-26,Norway,Denmark,1,1,UEFA Euro qualification,Oslo,Norway,FALSE
 2011-03-26,Portugal,Chile,1,1,Friendly,Leiria,Portugal,FALSE
 2011-03-26,Rwanda,Burundi,3,1,African Cup of Nations qualification,Kigali,Rwanda,FALSE
 2011-03-26,Senegal,Cameroon,1,0,African Cup of Nations qualification,Dakar,Senegal,FALSE
 2011-03-26,South Africa,Egypt,1,0,African Cup of Nations qualification,Johannesburg,South Africa,FALSE
-2011-03-26,USA,Argentina,1,1,Friendly,East Rutherford,USA,FALSE
+2011-03-26,United States,Argentina,1,1,Friendly,East Rutherford,United States,FALSE
 2011-03-26,Wales,England,0,2,UEFA Euro qualification,Cardiff,Wales,FALSE
 2011-03-27,Algeria,Morocco,1,0,African Cup of Nations qualification,Annaba,Algeria,FALSE
 2011-03-27,Brazil,Scotland,2,0,Friendly,London,England,TRUE
@@ -33277,7 +33277,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-03-29,Jordan,North Korea,1,1,Friendly,Sharjah,United Arab Emirates,TRUE
 2011-03-29,Kuwait,Iraq,1,0,Friendly,Sharjah,United Arab Emirates,TRUE
 2011-03-29,Lithuania,Spain,1,3,UEFA Euro qualification,Kaunas,Lithuania,FALSE
-2011-03-29,Mexico,Venezuela,1,1,Friendly,San Diego,USA,TRUE
+2011-03-29,Mexico,Venezuela,1,1,Friendly,San Diego,United States,TRUE
 2011-03-29,Netherlands,Hungary,5,3,UEFA Euro qualification,Amsterdam,Netherlands,FALSE
 2011-03-29,Nigeria,Kenya,3,0,Friendly,Abuja,Nigeria,FALSE
 2011-03-29,Northern Ireland,Slovenia,0,0,UEFA Euro qualification,Belfast,Northern Ireland,FALSE
@@ -33290,7 +33290,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-03-29,Sweden,Moldova,2,1,UEFA Euro qualification,Solna,Sweden,FALSE
 2011-03-29,Turkey,Austria,2,0,UEFA Euro qualification,Istanbul,Turkey,FALSE
 2011-03-29,Ukraine,Italy,0,2,Friendly,Kyiv,Ukraine,FALSE
-2011-03-29,USA,Paraguay,0,1,Friendly,Nashville,USA,FALSE
+2011-03-29,United States,Paraguay,0,1,Friendly,Nashville,United States,FALSE
 2011-04-02,Grenada,Saint Kitts and Nevis,0,1,Friendly,St. George's,Grenada,FALSE
 2011-04-03,Tahiti,New Caledonia,1,3,Friendly,Papeete,French Polynesia,FALSE
 2011-04-07,North Korea,Sri Lanka,4,0,AFC Challenge Cup qualification,Kathmandu,Nepal,TRUE
@@ -33317,9 +33317,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-05-27,Grenada,Antigua and Barbuda,2,2,Friendly,St. George's,Grenada,FALSE
 2011-05-27,Wales,Northern Ireland,2,0,Nations Cup,Dublin,Republic of Ireland,TRUE
 2011-05-28,Cuba,Nicaragua,2,1,Friendly,Havana,Cuba,FALSE
-2011-05-28,Mexico,Ecuador,1,1,Friendly,Seattle,USA,TRUE
+2011-05-28,Mexico,Ecuador,1,1,Friendly,Seattle,United States,TRUE
 2011-05-29,Barbados,Guyana,1,0,Friendly,Bridgetown,Barbados,FALSE
-2011-05-29,El Salvador,Honduras,2,2,Friendly,Houston,USA,TRUE
+2011-05-29,El Salvador,Honduras,2,2,Friendly,Houston,United States,TRUE
 2011-05-29,Ethiopia,Sudan,1,2,Friendly,Addis Ababa,Ethiopia,FALSE
 2011-05-29,Germany,Uruguay,2,1,Friendly,Sinsheim,Germany,FALSE
 2011-05-29,Republic of Ireland,Scotland,1,0,Nations Cup,Dublin,Republic of Ireland,FALSE
@@ -33330,7 +33330,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-06-01,Canada,Ecuador,2,2,Friendly,Toronto,Canada,FALSE
 2011-06-01,Guatemala,Venezuela,0,2,Friendly,Guatemala,Guatemala,FALSE
 2011-06-01,Japan,Peru,0,0,Kirin Cup,Niigata,Japan,FALSE
-2011-06-01,Mexico,New Zealand,3,0,Friendly,Denver,USA,TRUE
+2011-06-01,Mexico,New Zealand,3,0,Friendly,Denver,United States,TRUE
 2011-06-01,Nigeria,Argentina,4,1,Friendly,Abuja,Nigeria,FALSE
 2011-06-01,Ukraine,Uzbekistan,2,0,Friendly,Kyiv,Ukraine,FALSE
 2011-06-02,Brittany,Equatorial Guinea,0,1,Friendly,Saint-Nazaire,France,FALSE
@@ -33365,7 +33365,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-06-04,Sierra Leone,Niger,1,0,African Cup of Nations qualification,Freetown,Sierra Leone,FALSE
 2011-06-04,Slovakia,Andorra,1,0,UEFA Euro qualification,Bratislava,Slovakia,FALSE
 2011-06-04,Uganda,Guinea-Bissau,2,0,African Cup of Nations qualification,Kampala,Uganda,FALSE
-2011-06-04,USA,Spain,0,4,Friendly,Foxborough,USA,FALSE
+2011-06-04,United States,Spain,0,4,Friendly,Foxborough,United States,FALSE
 2011-06-04,Zambia,Mozambique,3,0,African Cup of Nations qualification,Lusaka,Zambia,FALSE
 2011-06-05,Angola,Kenya,1,0,African Cup of Nations qualification,Luanda,Angola,FALSE
 2011-06-05,Australia,New Zealand,3,0,Friendly,Adelaide,Australia,FALSE
@@ -33374,19 +33374,19 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-06-05,Burundi,Rwanda,3,1,African Cup of Nations qualification,Bujumbura,Burundi,FALSE
 2011-06-05,China PR,Uzbekistan,1,0,Friendly,Guangzhou,China PR,FALSE
 2011-06-05,Comoros,Libya,1,1,African Cup of Nations qualification,Mitsamiouli,Comoros,FALSE
-2011-06-05,Costa Rica,Cuba,5,0,Gold Cup,Arlington,USA,TRUE
+2011-06-05,Costa Rica,Cuba,5,0,Gold Cup,Arlington,United States,TRUE
 2011-06-05,Egypt,South Africa,0,0,African Cup of Nations qualification,Cairo,Egypt,FALSE
 2011-06-05,Ethiopia,Nigeria,2,2,African Cup of Nations qualification,Addis Ababa,Ethiopia,FALSE
 2011-06-05,Guinea,Madagascar,4,1,African Cup of Nations qualification,Conakry,Guinea,FALSE
 2011-06-05,Liberia,Cape Verde,1,0,African Cup of Nations qualification,Paynesville,Liberia,FALSE
 2011-06-05,Mauritius,DR Congo,1,2,African Cup of Nations qualification,Mapou,Mauritius,FALSE
-2011-06-05,Mexico,El Salvador,5,0,Gold Cup,Arlington,USA,TRUE
+2011-06-05,Mexico,El Salvador,5,0,Gold Cup,Arlington,United States,TRUE
 2011-06-05,Poland,Argentina,2,1,Friendly,Warsaw,Poland,FALSE
 2011-06-05,Eswatini,Sudan,1,2,African Cup of Nations qualification,Lobamba,Eswatini,FALSE
 2011-06-05,Tunisia,Chad,5,0,African Cup of Nations qualification,Sousse,Tunisia,FALSE
 2011-06-05,Zimbabwe,Mali,2,1,African Cup of Nations qualification,Harare,Zimbabwe,FALSE
-2011-06-06,Honduras,Guatemala,0,0,Gold Cup,Carson,USA,TRUE
-2011-06-06,Jamaica,Grenada,4,0,Gold Cup,Carson,USA,TRUE
+2011-06-06,Honduras,Guatemala,0,0,Gold Cup,Carson,United States,TRUE
+2011-06-06,Jamaica,Grenada,4,0,Gold Cup,Carson,United States,TRUE
 2011-06-06,Ukraine,France,1,4,Friendly,Donets'k,Ukraine,FALSE
 2011-06-07,Australia,Serbia,0,0,Friendly,Melbourne,Australia,FALSE
 2011-06-07,Austria,Latvia,3,1,Friendly,Graz,Austria,FALSE
@@ -33394,54 +33394,54 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-06-07,Belarus,Luxembourg,2,0,UEFA Euro qualification,Minsk,Belarus,FALSE
 2011-06-07,Bosnia and Herzegovina,Albania,2,0,UEFA Euro qualification,Zenica,Bosnia and Herzegovina,FALSE
 2011-06-07,Brazil,Romania,1,0,Friendly,São Paulo,Brazil,FALSE
-2011-06-07,Ecuador,Greece,1,1,Friendly,New York,USA,TRUE
+2011-06-07,Ecuador,Greece,1,1,Friendly,New York,United States,TRUE
 2011-06-07,Faroe Islands,Estonia,2,0,UEFA Euro qualification,Toftir,Faroe Islands,FALSE
 2011-06-07,Gabon,Gambia,0,1,Friendly,Franceville,Gabon,FALSE
 2011-06-07,Italy,Republic of Ireland,0,2,Friendly,Liège,Belgium,TRUE
 2011-06-07,Japan,Czech Republic,0,0,Kirin Cup,Yokohama,Japan,FALSE
 2011-06-07,South Korea,Ghana,2,1,Friendly,Jeonju,South Korea,FALSE
 2011-06-07,Norway,Lithuania,1,0,Friendly,Oslo,Norway,FALSE
-2011-06-07,Panama,Guadeloupe,3,2,Gold Cup,Detroit,USA,TRUE
+2011-06-07,Panama,Guadeloupe,3,2,Gold Cup,Detroit,United States,TRUE
 2011-06-07,Paraguay,Bolivia,0,0,Copa Paz del Chaco,Luque,Paraguay,FALSE
 2011-06-07,Russia,Cameroon,0,0,Friendly,Salzburg,Austria,TRUE
 2011-06-07,San Marino,Hungary,0,3,UEFA Euro qualification,Serravalle,San Marino,FALSE
 2011-06-07,Sweden,Finland,5,0,UEFA Euro qualification,Solna,Sweden,FALSE
-2011-06-07,USA,Canada,2,0,Gold Cup,Detroit,USA,FALSE
+2011-06-07,United States,Canada,2,0,Gold Cup,Detroit,United States,FALSE
 2011-06-07,Venezuela,Spain,0,3,Friendly,Puerto la Cruz,Venezuela,FALSE
 2011-06-08,China PR,North Korea,2,0,Friendly,Guiyang,China PR,FALSE
 2011-06-08,Uruguay,Netherlands,1,1,Copa Confraternidad,Montevideo,Uruguay,FALSE
-2011-06-09,Costa Rica,El Salvador,1,1,Gold Cup,Charlotte,USA,TRUE
-2011-06-09,Cuba,Mexico,0,5,Gold Cup,Charlotte,USA,TRUE
+2011-06-09,Costa Rica,El Salvador,1,1,Gold Cup,Charlotte,United States,TRUE
+2011-06-09,Cuba,Mexico,0,5,Gold Cup,Charlotte,United States,TRUE
 2011-06-09,Poland,France,0,1,Friendly,Warsaw,Poland,FALSE
-2011-06-10,Grenada,Honduras,1,7,Gold Cup,Miami,USA,TRUE
-2011-06-10,Jamaica,Guatemala,2,0,Gold Cup,Miami,USA,TRUE
-2011-06-11,Canada,Guadeloupe,1,0,Gold Cup,Tampa,USA,TRUE
-2011-06-11,Mexico,Venezuela,0,3,Friendly,Las Vegas,USA,TRUE
+2011-06-10,Grenada,Honduras,1,7,Gold Cup,Miami,United States,TRUE
+2011-06-10,Jamaica,Guatemala,2,0,Gold Cup,Miami,United States,TRUE
+2011-06-11,Canada,Guadeloupe,1,0,Gold Cup,Tampa,United States,TRUE
+2011-06-11,Mexico,Venezuela,0,3,Friendly,Las Vegas,United States,TRUE
 2011-06-11,Paraguay,Romania,2,0,Friendly,Asunción,Paraguay,FALSE
-2011-06-11,USA,Panama,1,2,Gold Cup,Tampa,USA,FALSE
-2011-06-12,El Salvador,Cuba,6,1,Gold Cup,Chicago,USA,TRUE
-2011-06-12,Mexico,Costa Rica,4,1,Gold Cup,Chicago,USA,TRUE
+2011-06-11,United States,Panama,1,2,Gold Cup,Tampa,United States,FALSE
+2011-06-12,El Salvador,Cuba,6,1,Gold Cup,Chicago,United States,TRUE
+2011-06-12,Mexico,Costa Rica,4,1,Gold Cup,Chicago,United States,TRUE
 2011-06-12,Palestine,Vatican City,9,1,Friendly,Al-Khader,Palestine,FALSE
-2011-06-13,Guatemala,Grenada,4,0,Gold Cup,Harrison,USA,TRUE
-2011-06-13,Honduras,Jamaica,0,1,Gold Cup,Harrison,USA,TRUE
-2011-06-14,Canada,Panama,1,1,Gold Cup,Kansas City,USA,TRUE
-2011-06-14,USA,Guadeloupe,1,0,Gold Cup,Kansas City,USA,FALSE
+2011-06-13,Guatemala,Grenada,4,0,Gold Cup,Harrison,United States,TRUE
+2011-06-13,Honduras,Jamaica,0,1,Gold Cup,Harrison,United States,TRUE
+2011-06-14,Canada,Panama,1,1,Gold Cup,Kansas City,United States,TRUE
+2011-06-14,United States,Guadeloupe,1,0,Gold Cup,Kansas City,United States,FALSE
 2011-06-15,Montserrat,Belize,2,5,FIFA World Cup qualification,Couva,Trinidad and Tobago,TRUE
-2011-06-18,Costa Rica,Honduras,1,1,Gold Cup,East Rutherford,USA,TRUE
+2011-06-18,Costa Rica,Honduras,1,1,Gold Cup,East Rutherford,United States,TRUE
 2011-06-18,Malaysia,Myanmar,2,0,Friendly,Kota Bharu,Malaysia,FALSE
-2011-06-18,Mexico,Guatemala,2,1,Gold Cup,East Rutherford,USA,TRUE
+2011-06-18,Mexico,Guatemala,2,1,Gold Cup,East Rutherford,United States,TRUE
 2011-06-19,Chile,Estonia,4,0,Friendly,Santiago,Chile,FALSE
-2011-06-19,Anguilla,USA Virgin Islands,0,0,Friendly,The Valley,Anguilla,FALSE
-2011-06-19,Panama,El Salvador,1,1,Gold Cup,Washington,USA,TRUE
-2011-06-19,USA,Jamaica,2,0,Gold Cup,Washington,USA,FALSE
+2011-06-19,Anguilla,United States Virgin Islands,0,0,Friendly,The Valley,Anguilla,FALSE
+2011-06-19,Panama,El Salvador,1,1,Gold Cup,Washington,United States,TRUE
+2011-06-19,United States,Jamaica,2,0,Gold Cup,Washington,United States,FALSE
 2011-06-20,Argentina,Albania,4,0,Friendly,Buenos Aires,Argentina,FALSE
-2011-06-22,Honduras,Mexico,0,2,Gold Cup,Houston,USA,TRUE
-2011-06-22,USA,Panama,1,0,Gold Cup,Houston,USA,FALSE
+2011-06-22,Honduras,Mexico,0,2,Gold Cup,Houston,United States,TRUE
+2011-06-22,United States,Panama,1,0,Gold Cup,Houston,United States,FALSE
 2011-06-23,Uruguay,Estonia,3,0,Friendly,Rivera,Uruguay,FALSE
 2011-06-23,Paraguay,Chile,0,0,Friendly,Asunción,Paraguay,FALSE
 2011-06-25,Colombia,Senegal,2,0,Friendly,Medellín,Colombia,FALSE
 2011-06-25,Kenya,Sudan,1,2,Friendly,Nairobi,Kenya,FALSE
-2011-06-25,USA,Mexico,2,4,Gold Cup,Pasadena,USA,FALSE
+2011-06-25,United States,Mexico,2,4,Gold Cup,Pasadena,United States,FALSE
 2011-06-26,Rhodes,Greenland,2,1,Island Games,Brading,England,TRUE
 2011-06-26,Jersey,Menorca,2,0,Island Games,Cowes,England,TRUE
 2011-06-26,Alderney,Gibraltar,1,6,Island Games,Newport,England,TRUE
@@ -33495,7 +33495,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-07-03,Palestine,Afghanistan,1,1,FIFA World Cup qualification,Al-Ram,Palestine,FALSE
 2011-07-03,Paraguay,Ecuador,0,0,Copa América,Santa Fe,Argentina,TRUE
 2011-07-03,Philippines,Sri Lanka,4,0,FIFA World Cup qualification,Manila,Philippines,FALSE
-2011-07-03,USA Virgin Islands,British Virgin Islands,2,0,FIFA World Cup qualification,Charlotte Amalie,USA Virgin Islands,FALSE
+2011-07-03,United States Virgin Islands,British Virgin Islands,2,0,FIFA World Cup qualification,Charlotte Amalie,United States Virgin Islands,FALSE
 2011-07-04,Chile,Mexico,2,1,Copa América,San Juan,Argentina,TRUE
 2011-07-04,Uruguay,Peru,1,1,Copa América,San Juan,Argentina,TRUE
 2011-07-05,Jordan,Syria,1,3,Friendly,Istanbul,Turkey,TRUE
@@ -33514,7 +33514,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-07-09,Lebanon,Oman,0,1,Friendly,Beirut,Lebanon,FALSE
 2011-07-09,Solomon Islands,Vanuatu,0,0,Friendly,Honiara,Solomon Islands,FALSE
 2011-07-09,Venezuela,Ecuador,1,0,Copa América,Salta,Argentina,TRUE
-2011-07-10,British Virgin Islands,USA Virgin Islands,1,2,FIFA World Cup qualification,Road Town,British Virgin Islands,FALSE
+2011-07-10,British Virgin Islands,United States Virgin Islands,1,2,FIFA World Cup qualification,Road Town,British Virgin Islands,FALSE
 2011-07-10,Colombia,Bolivia,2,0,Copa América,Santa Fe,Argentina,TRUE
 2011-07-10,Dominican Republic,Anguilla,4,0,FIFA World Cup qualification,San Cristóbal,Dominican Republic,FALSE
 2011-07-10,Maldives,India,1,1,Friendly,Malé,Maldives,FALSE
@@ -33579,7 +33579,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-07-28,Yemen,Iraq,0,0,FIFA World Cup qualification,Al Ain,United Arab Emirates,TRUE
 2011-07-30,Vanuatu,Solomon Islands,2,0,Friendly,Port Vila,Vanuatu,FALSE
 2011-07-31,Eswatini,Botswana,0,2,Friendly,Pretoria,South Africa,TRUE
-2011-08-07,El Salvador,Venezuela,2,1,Friendly,Washington,USA,TRUE
+2011-08-07,El Salvador,Venezuela,2,1,Friendly,Washington,United States,TRUE
 2011-08-10,Albania,Montenegro,3,2,Friendly,Shkodër,Albania,FALSE
 2011-08-10,Austria,Slovakia,1,2,Friendly,Klagenfurt,Austria,FALSE
 2011-08-10,Azerbaijan,North Macedonia,0,1,Friendly,Baku,Azerbaijan,FALSE
@@ -33595,7 +33595,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-08-10,Gabon,Guinea,1,1,Friendly,Saint-Leu-la-Forêt,France,TRUE
 2011-08-10,Gambia,DR Congo,3,0,Friendly,Banjul,Gambia,FALSE
 2011-08-10,Germany,Brazil,3,2,Friendly,Stuttgart,Germany,FALSE
-2011-08-10,Honduras,Venezuela,2,0,Friendly,Fort Lauderdale,USA,TRUE
+2011-08-10,Honduras,Venezuela,2,0,Friendly,Fort Lauderdale,United States,TRUE
 2011-08-10,Hungary,Iceland,4,0,Friendly,Budapest,Hungary,FALSE
 2011-08-10,Republic of Ireland,Croatia,0,0,Friendly,Dublin,Republic of Ireland,FALSE
 2011-08-10,Israel,Ivory Coast,3,4,Friendly,Geneva,Switzerland,TRUE
@@ -33623,7 +33623,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-08-10,Tunisia,Mali,4,2,Friendly,Monastir,Tunisia,FALSE
 2011-08-10,Turkey,Estonia,3,0,Friendly,Istanbul,Turkey,FALSE
 2011-08-10,Ukraine,Sweden,0,1,Friendly,Kharkiv,Ukraine,FALSE
-2011-08-10,USA,Mexico,1,1,Friendly,Philadelphia,USA,FALSE
+2011-08-10,United States,Mexico,1,1,Friendly,Philadelphia,United States,FALSE
 2011-08-10,Wales,Australia,1,2,Friendly,Cardiff,Wales,FALSE
 2011-08-10,Zimbabwe,Zambia,2,0,Friendly,Harare,Zimbabwe,FALSE
 2011-08-14,Liberia,Niger,0,0,Friendly,Paynesville,Liberia,FALSE
@@ -33686,7 +33686,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-09-02,Ghana,Eswatini,2,0,African Cup of Nations qualification,Accra,Ghana,FALSE
 2011-09-02,Grenada,Belize,0,3,FIFA World Cup qualification,St. George's,Grenada,FALSE
 2011-09-02,Guyana,Barbados,2,0,FIFA World Cup qualification,Providence,Guyana,FALSE
-2011-09-02,Haiti,USA Virgin Islands,6,0,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
+2011-09-02,Haiti,United States Virgin Islands,6,0,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
 2011-09-02,Hungary,Sweden,2,1,UEFA Euro qualification,Budapest,Hungary,FALSE
 2011-09-02,Iran,Indonesia,3,0,FIFA World Cup qualification,Tehran,Iran,FALSE
 2011-09-02,Iraq,Jordan,0,2,FIFA World Cup qualification,Erbil,Iraq,FALSE
@@ -33714,13 +33714,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-09-02,Turkey,Kazakhstan,2,1,UEFA Euro qualification,Istanbul,Turkey,FALSE
 2011-09-02,Ukraine,Uruguay,2,3,Friendly,Kharkiv,Ukraine,FALSE
 2011-09-02,United Arab Emirates,Kuwait,2,3,FIFA World Cup qualification,Al Ain,United Arab Emirates,FALSE
-2011-09-02,USA,Costa Rica,0,1,Friendly,Carson,USA,FALSE
+2011-09-02,United States,Costa Rica,0,1,Friendly,Carson,United States,FALSE
 2011-09-02,Wales,Montenegro,2,1,UEFA Euro qualification,Cardiff,Wales,FALSE
 2011-09-03,Burkina Faso,Equatorial Guinea,1,0,Friendly,Bobo Dioulasso,Burkina Faso,FALSE
 2011-09-03,Cameroon,Mauritius,6,0,African Cup of Nations qualification,Yaoundé,Cameroon,FALSE
 2011-09-03,Cook Islands,Fiji,1,4,Pacific Games,Boulari,New Caledonia,TRUE
 2011-09-03,Guam,Vanuatu,1,4,Pacific Games,Nouméa,New Caledonia,TRUE
-2011-09-03,Honduras,Colombia,0,2,Friendly,Harrison,USA,TRUE
+2011-09-03,Honduras,Colombia,0,2,Friendly,Harrison,United States,TRUE
 2011-09-03,Kenya,Guinea-Bissau,2,1,African Cup of Nations qualification,Nairobi,Kenya,FALSE
 2011-09-03,Kiribati,Papua New Guinea,1,17,Pacific Games,Boulari,New Caledonia,TRUE
 2011-09-03,Malawi,Tunisia,0,0,African Cup of Nations qualification,Blantyre,Malawi,FALSE
@@ -33754,7 +33754,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-09-06,Austria,Turkey,0,0,UEFA Euro qualification,Vienna,Austria,FALSE
 2011-09-06,Azerbaijan,Kazakhstan,3,2,UEFA Euro qualification,Baku,Azerbaijan,FALSE
 2011-09-06,Barbados,Trinidad and Tobago,0,2,FIFA World Cup qualification,Bridgetown,Barbados,FALSE
-2011-09-06,Belgium,USA,1,0,Friendly,Brussels,Belgium,FALSE
+2011-09-06,Belgium,United States,1,0,Friendly,Brussels,Belgium,FALSE
 2011-09-06,Belize,Guatemala,1,2,FIFA World Cup qualification,Belmopan,Belize,FALSE
 2011-09-06,Bosnia and Herzegovina,Belarus,1,0,UEFA Euro qualification,Zenica,Bosnia and Herzegovina,FALSE
 2011-09-06,Cayman Islands,El Salvador,1,4,FIFA World Cup qualification,George Town,Cayman Islands,FALSE
@@ -33773,7 +33773,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-09-06,Iceland,Cyprus,1,0,UEFA Euro qualification,Reykjavík,Iceland,FALSE
 2011-09-06,Indonesia,Bahrain,0,2,FIFA World Cup qualification,Jakarta,Indonesia,FALSE
 2011-09-06,Italy,Slovenia,1,0,UEFA Euro qualification,Florence,Italy,FALSE
-2011-09-06,Jamaica,Colombia,0,2,Friendly,Fort Lauderdale,USA,TRUE
+2011-09-06,Jamaica,Colombia,0,2,Friendly,Fort Lauderdale,United States,TRUE
 2011-09-06,Jordan,China PR,2,1,FIFA World Cup qualification,Amman,Jordan,FALSE
 2011-09-06,North Korea,Tajikistan,1,0,FIFA World Cup qualification,Pyongyang,North Korea,FALSE
 2011-09-06,Kuwait,South Korea,1,1,FIFA World Cup qualification,Kuwait City,Kuwait,FALSE
@@ -33801,7 +33801,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-09-06,Thailand,Oman,3,0,FIFA World Cup qualification,Bangkok,Thailand,FALSE
 2011-09-06,Uzbekistan,Japan,1,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2011-09-06,Venezuela,Guinea,2,1,Friendly,Caracas,Venezuela,FALSE
-2011-09-06,USA Virgin Islands,Antigua and Barbuda,1,8,FIFA World Cup qualification,Frederiksted,USA Virgin Islands,FALSE
+2011-09-06,United States Virgin Islands,Antigua and Barbuda,1,8,FIFA World Cup qualification,Frederiksted,United States Virgin Islands,FALSE
 2011-09-07,Equatorial Guinea,Central African Republic,3,0,Friendly,Malabo,Equatorial Guinea,FALSE
 2011-09-07,New Caledonia,Tahiti,3,1,Pacific Games,Koné,New Caledonia,FALSE
 2011-09-07,Solomon Islands,Fiji,2,1,Pacific Games,Lifou,New Caledonia,TRUE
@@ -33863,7 +33863,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-10-07,Turkey,Germany,1,3,UEFA Euro qualification,Istanbul,Turkey,FALSE
 2011-10-07,Ukraine,Bulgaria,3,0,Friendly,Kyiv,Ukraine,FALSE
 2011-10-07,Uruguay,Bolivia,4,2,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2011-10-07,USA Virgin Islands,Haiti,0,7,FIFA World Cup qualification,Frederiksted,USA Virgin Islands,FALSE
+2011-10-07,United States Virgin Islands,Haiti,0,7,FIFA World Cup qualification,Frederiksted,United States Virgin Islands,FALSE
 2011-10-07,Wales,Switzerland,2,0,UEFA Euro qualification,Swansea,Wales,FALSE
 2011-10-08,Cape Verde,Zimbabwe,2,1,African Cup of Nations qualification,Praia,Cape Verde,FALSE
 2011-10-08,Chad,Malawi,2,2,African Cup of Nations qualification,N'Djamena,Chad,FALSE
@@ -33880,7 +33880,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-10-08,Eswatini,Congo,0,1,African Cup of Nations qualification,Lobamba,Eswatini,FALSE
 2011-10-08,Tunisia,Togo,2,0,African Cup of Nations qualification,Radès,Tunisia,FALSE
 2011-10-08,Uganda,Kenya,0,0,African Cup of Nations qualification,Kampala,Uganda,FALSE
-2011-10-08,USA,Honduras,1,0,Friendly,Miami Gardens,USA,FALSE
+2011-10-08,United States,Honduras,1,0,Friendly,Miami Gardens,United States,FALSE
 2011-10-08,Zambia,Libya,0,0,African Cup of Nations qualification,Chingola,Zambia,FALSE
 2011-10-09,Algeria,Central African Republic,2,0,African Cup of Nations qualification,Algiers,Algeria,FALSE
 2011-10-09,Benin,Rwanda,0,1,African Cup of Nations qualification,Cotonou,Benin,FALSE
@@ -33888,7 +33888,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-10-09,Mauritius,Senegal,0,2,African Cup of Nations qualification,Mapou,Mauritius,FALSE
 2011-10-09,Morocco,Tanzania,3,1,African Cup of Nations qualification,Marrakech,Morocco,FALSE
 2011-10-11,Albania,Romania,1,1,UEFA Euro qualification,Tirana,Albania,FALSE
-2011-10-11,Antigua and Barbuda,USA Virgin Islands,10,0,FIFA World Cup qualification,St. John's,Antigua and Barbuda,FALSE
+2011-10-11,Antigua and Barbuda,United States Virgin Islands,10,0,FIFA World Cup qualification,St. John's,Antigua and Barbuda,FALSE
 2011-10-11,Australia,Oman,3,0,FIFA World Cup qualification,Sydney,Australia,FALSE
 2011-10-11,Belarus,Poland,0,2,Friendly,Wiesbaden,Germany,TRUE
 2011-10-11,Bermuda,Guyana,1,1,FIFA World Cup qualification,Hamilton,Bermuda,FALSE
@@ -33939,7 +33939,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-10-11,Thailand,Saudi Arabia,0,0,FIFA World Cup qualification,Bangkok,Thailand,FALSE
 2011-10-11,Trinidad and Tobago,Barbados,4,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2011-10-11,Turkey,Azerbaijan,1,0,UEFA Euro qualification,Istanbul,Turkey,FALSE
-2011-10-11,USA,Ecuador,0,1,Friendly,Harrison,USA,FALSE
+2011-10-11,United States,Ecuador,0,1,Friendly,Harrison,United States,FALSE
 2011-10-11,Venezuela,Argentina,1,0,FIFA World Cup qualification,Puerto la Cruz,Venezuela,FALSE
 2011-10-31,Namibia,Lesotho,0,0,Friendly,Windhoek,Namibia,FALSE
 2011-11-04,Kuwait,Bahrain,0,1,Friendly,Kuwait City,Kuwait,FALSE
@@ -33968,7 +33968,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-11-11,Equatorial Guinea,Madagascar,2,0,FIFA World Cup qualification,Malabo,Equatorial Guinea,FALSE
 2011-11-11,Eritrea,Rwanda,1,1,FIFA World Cup qualification,Asmara,Eritrea,FALSE
 2011-11-11,Estonia,Republic of Ireland,0,4,UEFA Euro qualification,Tallinn,Estonia,FALSE
-2011-11-11,France,USA,1,0,Friendly,Saint-Denis,France,FALSE
+2011-11-11,France,United States,1,0,Friendly,Saint-Denis,France,FALSE
 2011-11-11,Georgia,Moldova,2,0,Friendly,Tbilisi,Georgia,FALSE
 2011-11-11,Greece,Russia,1,1,Friendly,Piraeus,Greece,FALSE
 2011-11-11,Guatemala,Grenada,3,0,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
@@ -34001,7 +34001,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-11-11,United Arab Emirates,South Korea,0,2,FIFA World Cup qualification,Dubai,United Arab Emirates,FALSE
 2011-11-11,Uruguay,Chile,4,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 2011-11-11,Uzbekistan,North Korea,1,0,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
-2011-11-11,USA Virgin Islands,Curaçao,0,3,FIFA World Cup qualification,Frederiksted,USA Virgin Islands,FALSE
+2011-11-11,United States Virgin Islands,Curaçao,0,3,FIFA World Cup qualification,Frederiksted,United States Virgin Islands,FALSE
 2011-11-12,Algeria,Tunisia,1,0,Friendly,Algiers,Algeria,FALSE
 2011-11-12,England,Spain,1,0,Friendly,London,England,FALSE
 2011-11-12,Nigeria,Botswana,0,0,Friendly,Abuja,Nigeria,FALSE
@@ -34025,7 +34025,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-11-15,DR Congo,Eswatini,5,1,FIFA World Cup qualification,Kinshasa,DR Congo,FALSE
 2011-11-15,Costa Rica,Spain,2,2,Friendly,San José,Costa Rica,FALSE
 2011-11-15,Croatia,Turkey,0,0,UEFA Euro qualification,Zagreb,Croatia,FALSE
-2011-11-15,Curaçao,USA Virgin Islands,6,1,FIFA World Cup qualification,Willemstad,Curaçao,FALSE
+2011-11-15,Curaçao,United States Virgin Islands,6,1,FIFA World Cup qualification,Willemstad,Curaçao,FALSE
 2011-11-15,Denmark,Finland,2,1,Friendly,Esbjerg,Denmark,FALSE
 2011-11-15,Ecuador,Peru,2,0,FIFA World Cup qualification,Quito,Ecuador,FALSE
 2011-11-15,El Salvador,Suriname,4,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
@@ -34060,7 +34060,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2011-11-15,Rwanda,Eritrea,3,1,FIFA World Cup qualification,Kigali,Rwanda,FALSE
 2011-11-15,Saudi Arabia,Oman,0,0,FIFA World Cup qualification,Riyadh,Saudi Arabia,FALSE
 2011-11-15,Singapore,China PR,0,4,FIFA World Cup qualification,Singapore,Singapore,FALSE
-2011-11-15,Slovenia,USA,2,3,Friendly,Ljubljana,Slovenia,FALSE
+2011-11-15,Slovenia,United States,2,3,Friendly,Ljubljana,Slovenia,FALSE
 2011-11-15,Tanzania,Chad,0,1,FIFA World Cup qualification,Dar es Salaam,Tanzania,FALSE
 2011-11-15,Thailand,Australia,0,1,FIFA World Cup qualification,Bangkok,Thailand,FALSE
 2011-11-15,Togo,Guinea-Bissau,1,0,FIFA World Cup qualification,Lomé,Togo,FALSE
@@ -34152,7 +34152,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-01-18,Thailand,Norway,0,1,King's Cup,Bangkok,Thailand,FALSE
 2012-01-21,Equatorial Guinea,Libya,1,0,African Cup of Nations,Bata,Equatorial Guinea,FALSE
 2012-01-21,Senegal,Zambia,1,2,African Cup of Nations,Bata,Equatorial Guinea,TRUE
-2012-01-21,USA,Venezuela,1,0,Friendly,Glendale,USA,FALSE
+2012-01-21,United States,Venezuela,1,0,Friendly,Glendale,United States,FALSE
 2012-01-22,Burkina Faso,Angola,1,2,African Cup of Nations,Malabo,Equatorial Guinea,TRUE
 2012-01-22,Ivory Coast,Sudan,1,0,African Cup of Nations,Malabo,Equatorial Guinea,TRUE
 2012-01-22,Lebanon,Iraq,1,0,Friendly,Beirut,Lebanon,FALSE
@@ -34164,8 +34164,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-01-24,Mali,Guinea,1,0,African Cup of Nations,Franceville,Gabon,TRUE
 2012-01-25,Equatorial Guinea,Senegal,2,1,African Cup of Nations,Bata,Equatorial Guinea,FALSE
 2012-01-25,Libya,Zambia,2,2,African Cup of Nations,Bata,Equatorial Guinea,TRUE
-2012-01-25,Mexico,Venezuela,3,1,Friendly,Houston,USA,TRUE
-2012-01-25,Panama,USA,0,1,Friendly,Panama City,Panama,FALSE
+2012-01-25,Mexico,Venezuela,3,1,Friendly,Houston,United States,TRUE
+2012-01-25,Panama,United States,0,1,Friendly,Panama City,Panama,FALSE
 2012-01-26,Ivory Coast,Burkina Faso,2,0,African Cup of Nations,Malabo,Equatorial Guinea,TRUE
 2012-01-26,Sudan,Angola,2,2,African Cup of Nations,Malabo,Equatorial Guinea,TRUE
 2012-01-27,Gabon,Morocco,3,2,African Cup of Nations,Libreville,Gabon,FALSE
@@ -34220,7 +34220,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-02-29,Bolivia,Cuba,1,0,Friendly,Cochabamba,Bolivia,FALSE
 2012-02-29,Burundi,Zimbabwe,2,1,African Cup of Nations qualification,Bujumbura,Burundi,FALSE
 2012-02-29,Chad,Malawi,3,2,African Cup of Nations qualification,N'Djamena,Chad,FALSE
-2012-02-29,Chile,Ghana,1,1,Friendly,Chester,USA,TRUE
+2012-02-29,Chile,Ghana,1,1,Friendly,Chester,United States,TRUE
 2012-02-29,China PR,Jordan,3,1,FIFA World Cup qualification,Guangzhou,China PR,FALSE
 2012-02-29,Congo,Uganda,3,1,African Cup of Nations qualification,Brazzaville,Congo,FALSE
 2012-02-29,Croatia,Sweden,1,3,Friendly,Zagreb,Croatia,FALSE
@@ -34228,7 +34228,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-02-29,Denmark,Russia,0,2,Friendly,Copenhagen,Denmark,FALSE
 2012-02-29,Ecuador,Honduras,2,0,Friendly,Guayaquil,Ecuador,FALSE
 2012-02-29,Egypt,Niger,1,0,Friendly,Doha,Qatar,TRUE
-2012-02-29,El Salvador,Estonia,0,2,Friendly,Los Angeles,USA,TRUE
+2012-02-29,El Salvador,Estonia,0,2,Friendly,Los Angeles,United States,TRUE
 2012-02-29,England,Netherlands,2,3,Friendly,London,England,FALSE
 2012-02-29,Ethiopia,Benin,0,0,African Cup of Nations qualification,Addis Ababa,Ethiopia,FALSE
 2012-02-29,Gambia,Algeria,1,2,African Cup of Nations qualification,Bakau,Gambia,FALSE
@@ -34243,7 +34243,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-02-29,Iraq,Singapore,7,1,FIFA World Cup qualification,Doha,Qatar,TRUE
 2012-02-29,Republic of Ireland,Czech Republic,1,1,Friendly,Dublin,Republic of Ireland,FALSE
 2012-02-29,Israel,Ukraine,2,3,Friendly,Petah Tikva,Israel,FALSE
-2012-02-29,Italy,USA,0,1,Friendly,Genoa,Italy,FALSE
+2012-02-29,Italy,United States,0,1,Friendly,Genoa,Italy,FALSE
 2012-02-29,Ivory Coast,Guinea,0,0,Friendly,Abidjan,Ivory Coast,FALSE
 2012-02-29,Japan,Uzbekistan,0,1,FIFA World Cup qualification,Toyota,Japan,FALSE
 2012-02-29,Kenya,Togo,2,1,African Cup of Nations qualification,Nairobi,Kenya,FALSE
@@ -34253,7 +34253,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-02-29,Luxembourg,North Macedonia,2,1,Friendly,Luxembourg,Luxembourg,FALSE
 2012-02-29,Madagascar,Cape Verde,0,4,African Cup of Nations qualification,Antananarivo,Madagascar,FALSE
 2012-02-29,Malta,Liechtenstein,2,1,Friendly,Attard,Malta,FALSE
-2012-02-29,Mexico,Colombia,0,2,Friendly,Miami Gardens,USA,TRUE
+2012-02-29,Mexico,Colombia,0,2,Friendly,Miami Gardens,United States,TRUE
 2012-02-29,Moldova,Belarus,0,0,Friendly,Antalya,Turkey,TRUE
 2012-02-29,Montenegro,Iceland,2,1,Friendly,Podgorica,Montenegro,FALSE
 2012-02-29,Morocco,Burkina Faso,2,0,Friendly,Marrakech,Morocco,FALSE
@@ -34325,7 +34325,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-05-22,Egypt,Togo,3,0,Friendly,Omdurman,Sudan,TRUE
 2012-05-22,Latvia,Poland,0,1,Friendly,Klagenfurt,Austria,TRUE
 2012-05-23,Botswana,Lesotho,3,0,Friendly,Gaborone,Botswana,FALSE
-2012-05-23,El Salvador,New Zealand,2,2,Friendly,Houston,USA,TRUE
+2012-05-23,El Salvador,New Zealand,2,2,Friendly,Houston,United States,TRUE
 2012-05-23,Iraq,Sierra Leone,1,0,Friendly,Istanbul,Turkey,TRUE
 2012-05-23,Japan,Azerbaijan,2,0,Friendly,Shizuoka,Japan,FALSE
 2012-05-23,Libya,Rwanda,2,0,Friendly,Tunis,Tunisia,TRUE
@@ -34341,11 +34341,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-05-26,Burkina Faso,Benin,2,2,Friendly,Ouagadougou,Burkina Faso,FALSE
 2012-05-26,Czech Republic,Israel,2,1,Friendly,Graz,Austria,TRUE
 2012-05-26,Denmark,Brazil,1,3,Friendly,Hamburg,Germany,TRUE
-2012-05-26,El Salvador,Moldova,2,0,Friendly,Dallas,USA,TRUE
+2012-05-26,El Salvador,Moldova,2,0,Friendly,Dallas,United States,TRUE
 2012-05-26,Finland,Turkey,3,2,Friendly,Salzburg,Austria,TRUE
 2012-05-26,Greece,Slovenia,1,1,Friendly,Kufstein,Austria,TRUE
 2012-05-26,Guinea,Cameroon,1,2,Friendly,Amanvillers,France,TRUE
-2012-05-26,Honduras,New Zealand,0,1,Friendly,Dallas,USA,TRUE
+2012-05-26,Honduras,New Zealand,0,1,Friendly,Dallas,United States,TRUE
 2012-05-26,Republic of Ireland,Bosnia and Herzegovina,1,0,Friendly,Dublin,Republic of Ireland,FALSE
 2012-05-26,Jordan,Sierra Leone,4,0,Friendly,Amman,Jordan,FALSE
 2012-05-26,Mozambique,Namibia,0,0,Friendly,Würzburg,Germany,TRUE
@@ -34356,12 +34356,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-05-26,Spain,Serbia,2,0,Friendly,St. Gallen,Switzerland,TRUE
 2012-05-26,Switzerland,Germany,5,3,Friendly,Basel,Switzerland,FALSE
 2012-05-26,Tanzania,Malawi,0,0,Friendly,Dar es Salaam,Tanzania,FALSE
-2012-05-26,USA,Scotland,5,1,Friendly,Jacksonville,USA,FALSE
+2012-05-26,United States,Scotland,5,1,Friendly,Jacksonville,United States,FALSE
 2012-05-27,Albania,Iran,1,0,Friendly,Istanbul,Turkey,TRUE
 2012-05-27,Chad,Libya,0,1,Friendly,Tunis,Tunisia,TRUE
 2012-05-27,France,Iceland,3,2,Friendly,Valenciennes,France,FALSE
 2012-05-27,Jamaica,Panama,0,1,Friendly,Kingston,Jamaica,FALSE
-2012-05-27,Mexico,Wales,2,0,Friendly,East Rutherford,USA,TRUE
+2012-05-27,Mexico,Wales,2,0,Friendly,East Rutherford,United States,TRUE
 2012-05-27,Oman,Lebanon,1,1,Friendly,Muscat,Oman,FALSE
 2012-05-27,Tunisia,Rwanda,5,1,Friendly,Monastir,Tunisia,FALSE
 2012-05-28,Iraq,Botswana,1,1,Friendly,Istanbul,Turkey,TRUE
@@ -34376,11 +34376,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-05-30,Spain,South Korea,4,1,Friendly,Berne,Switzerland,TRUE
 2012-05-30,Sweden,Iceland,3,2,Friendly,Gothenburg,Sweden,FALSE
 2012-05-30,Switzerland,Romania,0,1,Friendly,Lucerne,Switzerland,FALSE
-2012-05-30,USA,Brazil,1,4,Friendly,Washington,USA,FALSE
+2012-05-30,United States,Brazil,1,4,Friendly,Washington,United States,FALSE
 2012-05-31,Armenia,Greece,0,1,Friendly,Kufstein,Austria,TRUE
 2012-05-31,France,Serbia,2,0,Friendly,Reims,France,FALSE
 2012-05-31,Germany,Israel,2,0,Friendly,Leipzig,Germany,FALSE
-2012-05-31,Mexico,Bosnia and Herzegovina,2,1,Friendly,Chicago,USA,TRUE
+2012-05-31,Mexico,Bosnia and Herzegovina,2,1,Friendly,Chicago,United States,TRUE
 2012-06-01,Austria,Ukraine,3,2,Friendly,Innsbruck,Austria,FALSE
 2012-06-01,Czech Republic,Hungary,1,2,Friendly,Prague,Czech Republic,FALSE
 2012-06-01,Egypt,Mozambique,2,0,FIFA World Cup qualification,Alexandria,Egypt,FALSE
@@ -34403,7 +34403,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-06-02,Cameroon,DR Congo,1,0,FIFA World Cup qualification,Yaoundé,Cameroon,FALSE
 2012-06-02,Central African Republic,Botswana,2,0,FIFA World Cup qualification,Bangui,Central African Republic,FALSE
 2012-06-02,Denmark,Australia,2,0,Friendly,Copenhagen,Denmark,FALSE
-2012-06-02,El Salvador,Honduras,0,3,Friendly,Washington,USA,TRUE
+2012-06-02,El Salvador,Honduras,0,3,Friendly,Washington,United States,TRUE
 2012-06-02,England,Belgium,1,0,Friendly,London,England,FALSE
 2012-06-02,Fiji,New Zealand,0,1,Oceania Nations Cup,Honiara,Solomon Islands,TRUE
 2012-06-02,Gambia,Morocco,1,1,FIFA World Cup qualification,Bakau,Gambia,FALSE
@@ -34422,13 +34422,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-06-02,Uruguay,Venezuela,1,1,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 2012-06-03,Angola,Uganda,1,1,FIFA World Cup qualification,Luanda,Angola,FALSE
 2012-06-03,Benin,Mali,1,0,FIFA World Cup qualification,Cotonou,Benin,FALSE
-2012-06-03,Canada,USA,0,0,Friendly,Toronto,Canada,FALSE
+2012-06-03,Canada,United States,0,0,Friendly,Toronto,Canada,FALSE
 2012-06-03,Estonia,Lithuania,1,0,Baltic Cup,Tartu,Estonia,FALSE
 2012-06-03,Finland,Latvia,1,1,Baltic Cup,Võru,Estonia,TRUE
 2012-06-03,Japan,Oman,3,0,FIFA World Cup qualification,Saitama,Japan,FALSE
 2012-06-03,Jordan,Iraq,1,1,FIFA World Cup qualification,Amman,Jordan,FALSE
 2012-06-03,Lebanon,Qatar,0,1,FIFA World Cup qualification,Beirut,Lebanon,FALSE
-2012-06-03,Mexico,Brazil,2,0,Friendly,Arlington,USA,TRUE
+2012-06-03,Mexico,Brazil,2,0,Friendly,Arlington,United States,TRUE
 2012-06-03,Niger,Gabon,3,0,FIFA World Cup qualification,Niamey,Niger,FALSE
 2012-06-03,Nigeria,Namibia,1,0,FIFA World Cup qualification,Calabar,Nigeria,FALSE
 2012-06-03,Peru,Colombia,0,1,FIFA World Cup qualification,Lima,Peru,FALSE
@@ -34481,13 +34481,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-06-08,Russia,Czech Republic,4,1,UEFA Euro,Wrocław,Poland,TRUE
 2012-06-08,Singapore,Malaysia,2,2,Friendly,Singapore,Singapore,FALSE
 2012-06-08,Solomon Islands,Tahiti,0,1,Oceania Nations Cup,Honiara,Solomon Islands,FALSE
-2012-06-08,USA,Antigua and Barbuda,3,1,FIFA World Cup qualification,Tampa,USA,FALSE
+2012-06-08,United States,Antigua and Barbuda,3,1,FIFA World Cup qualification,Tampa,United States,FALSE
 2012-06-08,Western Sahara,Raetia,3,0,Viva World Cup,Erbil,Iraq,TRUE
 2012-06-08,Iraqi Kurdistan,Provence,2,1,Viva World Cup,Duhok,Iraq,FALSE
 2012-06-08,Zanzibar,Northern Cyprus,0,2,Viva World Cup,Duhok,Iraq,TRUE
 2012-06-09,Bolivia,Paraguay,3,1,FIFA World Cup qualification,La Paz,Bolivia,FALSE
 2012-06-09,Botswana,South Africa,1,1,FIFA World Cup qualification,Gaborone,Botswana,FALSE
-2012-06-09,Brazil,Argentina,3,4,Friendly,East Rutherford,USA,TRUE
+2012-06-09,Brazil,Argentina,3,4,Friendly,East Rutherford,United States,TRUE
 2012-06-09,Cape Verde,Tunisia,1,2,FIFA World Cup qualification,Praia,Cape Verde,FALSE
 2012-06-09,Congo,Niger,1,0,FIFA World Cup qualification,Pointe-Noire,Congo,FALSE
 2012-06-09,Equatorial Guinea,Sierra Leone,2,2,FIFA World Cup qualification,Malabo,Equatorial Guinea,FALSE
@@ -34530,7 +34530,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-06-12,Canada,Honduras,0,0,FIFA World Cup qualification,Toronto,Canada,FALSE
 2012-06-12,El Salvador,Mexico,1,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2012-06-12,Greece,Czech Republic,1,2,UEFA Euro,Wrocław,Poland,TRUE
-2012-06-12,Guatemala,USA,1,1,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
+2012-06-12,Guatemala,United States,1,1,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
 2012-06-12,Guyana,Costa Rica,0,4,FIFA World Cup qualification,Providence,Guyana,FALSE
 2012-06-12,Iran,Qatar,0,0,FIFA World Cup qualification,Tehran,Iran,FALSE
 2012-06-12,Iraq,Oman,1,1,FIFA World Cup qualification,Doha,Qatar,TRUE
@@ -34603,7 +34603,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-07-20,Northern Mariana Islands,Macau,1,5,EAFF Championship,Yona,Guam,TRUE
 2012-07-22,Guam,Macau,3,0,EAFF Championship,Yona,Guam,FALSE
 2012-08-08,Zambia,Zimbabwe,2,1,Friendly,Ndola,Zambia,FALSE
-2012-08-11,El Salvador,Guatemala,1,0,Friendly,Carson,USA,TRUE
+2012-08-11,El Salvador,Guatemala,1,0,Friendly,Carson,United States,TRUE
 2012-08-13,Jordan,Uzbekistan,0,1,Friendly,Amman,Jordan,FALSE
 2012-08-14,Burkina Faso,Togo,3,0,Friendly,Saint-Leu-la-Forêt,France,TRUE
 2012-08-14,Liechtenstein,Andorra,1,0,Friendly,Vaduz,Liechtenstein,FALSE
@@ -34617,19 +34617,19 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-08-15,Bolivia,Guyana,2,0,Friendly,Santa Cruz,Bolivia,FALSE
 2012-08-15,Botswana,Tanzania,3,3,Friendly,Molepolole,Botswana,FALSE
 2012-08-15,Bulgaria,Cyprus,1,0,Friendly,Sofia,Bulgaria,FALSE
-2012-08-15,Canada,Trinidad and Tobago,2,0,Friendly,Lauderhill,USA,TRUE
+2012-08-15,Canada,Trinidad and Tobago,2,0,Friendly,Lauderhill,United States,TRUE
 2012-08-15,China PR,Ghana,1,1,Friendly,Xi'an,China PR,FALSE
 2012-08-15,Costa Rica,Peru,0,1,Friendly,San José,Costa Rica,FALSE
 2012-08-15,Croatia,Switzerland,2,4,Friendly,Split,Croatia,FALSE
 2012-08-15,Denmark,Slovakia,1,3,Friendly,Odense,Denmark,FALSE
-2012-08-15,Ecuador,Chile,3,0,Friendly,New York,USA,TRUE
-2012-08-15,El Salvador,Jamaica,0,2,Friendly,Washington,USA,TRUE
+2012-08-15,Ecuador,Chile,3,0,Friendly,New York,United States,TRUE
+2012-08-15,El Salvador,Jamaica,0,2,Friendly,Washington,United States,TRUE
 2012-08-15,England,Italy,2,1,Friendly,Berne,Switzerland,TRUE
 2012-08-15,Equatorial Guinea,Liberia,1,0,Friendly,Malabo,Equatorial Guinea,FALSE
 2012-08-15,Estonia,Poland,1,0,Friendly,Tallinn,Estonia,FALSE
 2012-08-15,France,Uruguay,0,0,Friendly,Le Havre,France,FALSE
 2012-08-15,Germany,Argentina,1,3,Friendly,Frankfurt am Main,Germany,FALSE
-2012-08-15,Guatemala,Paraguay,3,3,Friendly,Washington,USA,TRUE
+2012-08-15,Guatemala,Paraguay,3,3,Friendly,Washington,United States,TRUE
 2012-08-15,Hungary,Israel,1,1,Friendly,Budapest,Hungary,FALSE
 2012-08-15,Iceland,Faroe Islands,2,0,Friendly,Reykjavík,Iceland,FALSE
 2012-08-15,Iran,Tunisia,2,2,Friendly,Kecskemét,Hungary,TRUE
@@ -34638,7 +34638,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-08-15,South Korea,Zambia,2,1,Friendly,Anyang,South Korea,FALSE
 2012-08-15,Luxembourg,Georgia,1,2,Friendly,Differdange,Luxembourg,FALSE
 2012-08-15,North Macedonia,Lithuania,1,0,Friendly,Skopje,North Macedonia,FALSE
-2012-08-15,Mexico,USA,0,1,Friendly,Mexico City,Mexico,FALSE
+2012-08-15,Mexico,United States,0,1,Friendly,Mexico City,Mexico,FALSE
 2012-08-15,Montenegro,Latvia,2,0,Friendly,Podgorica,Montenegro,FALSE
 2012-08-15,Morocco,Guinea,1,2,Friendly,Rabat,Morocco,FALSE
 2012-08-15,Niger,Nigeria,0,0,Friendly,Niamey,Niger,FALSE
@@ -34699,7 +34699,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-09-07,Guatemala,Antigua and Barbuda,3,1,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
 2012-09-07,Haiti,Saint Martin,7,0,CFU Caribbean Cup qualification,Port-au-Prince,Haiti,FALSE
 2012-09-07,Iceland,Norway,2,0,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
-2012-09-07,Jamaica,USA,2,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
+2012-09-07,Jamaica,United States,2,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2012-09-07,Kazakhstan,Republic of Ireland,1,2,FIFA World Cup qualification,Astana,Kazakhstan,FALSE
 2012-09-07,Latvia,Greece,1,2,FIFA World Cup qualification,Riga,Latvia,FALSE
 2012-09-07,Liechtenstein,Bosnia and Herzegovina,1,8,FIFA World Cup qualification,Vaduz,Liechtenstein,FALSE
@@ -34791,7 +34791,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-09-11,Turkey,Estonia,3,0,FIFA World Cup qualification,Istanbul,Turkey,FALSE
 2012-09-11,United Arab Emirates,Kuwait,3,0,Friendly,Dubai,United Arab Emirates,FALSE
 2012-09-11,Uruguay,Ecuador,1,1,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2012-09-11,USA,Jamaica,1,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2012-09-11,United States,Jamaica,1,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2012-09-11,Uzbekistan,South Korea,2,2,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2012-09-12,Thailand,Laos,2,1,Friendly,Bangkok,Thailand,FALSE
 2012-09-13,Senegal,Ivory Coast,0,2,African Cup of Nations qualification,Dakar,Senegal,FALSE
@@ -34840,7 +34840,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-10-11,Myanmar,Cambodia,3,0,AFF Championship,Yangon,Myanmar,FALSE
 2012-10-11,Kuwait,Syria,1,1,Friendly,Muscat,Oman,TRUE
 2012-10-12,Albania,Iceland,1,2,FIFA World Cup qualification,Tirana,Albania,FALSE
-2012-10-12,Antigua and Barbuda,USA,1,2,FIFA World Cup qualification,St. John's,Antigua and Barbuda,FALSE
+2012-10-12,Antigua and Barbuda,United States,1,2,FIFA World Cup qualification,St. John's,Antigua and Barbuda,FALSE
 2012-10-12,Argentina,Uruguay,3,0,FIFA World Cup qualification,Mendoza,Argentina,FALSE
 2012-10-12,Armenia,Italy,1,3,FIFA World Cup qualification,Yerevan,Armenia,FALSE
 2012-10-12,Bahrain,Philippines,0,0,Friendly,Arad,Bahrain,FALSE
@@ -34861,7 +34861,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-10-12,French Guiana,Anguilla,4,1,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,TRUE
 2012-10-12,Greece,Bosnia and Herzegovina,0,0,FIFA World Cup qualification,Piraeus,Greece,FALSE
 2012-10-12,Guatemala,Jamaica,2,1,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
-2012-10-12,Guyana,Mexico,0,5,FIFA World Cup qualification,Houston,USA,TRUE
+2012-10-12,Guyana,Mexico,0,5,FIFA World Cup qualification,Houston,United States,TRUE
 2012-10-12,Republic of Ireland,Germany,1,6,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
 2012-10-12,Kazakhstan,Austria,0,0,FIFA World Cup qualification,Astana,Kazakhstan,FALSE
 2012-10-12,Lesotho,Eswatini,2,1,Friendly,Maseru,Lesotho,FALSE
@@ -34936,7 +34936,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-10-16,Spain,France,1,1,FIFA World Cup qualification,Madrid,Spain,FALSE
 2012-10-16,Ukraine,Montenegro,0,1,FIFA World Cup qualification,Kyiv,Ukraine,FALSE
 2012-10-16,United Arab Emirates,Bahrain,6,2,Friendly,Dubai,United Arab Emirates,FALSE
-2012-10-16,USA,Guatemala,3,1,FIFA World Cup qualification,Kansas City,USA,FALSE
+2012-10-16,United States,Guatemala,3,1,FIFA World Cup qualification,Kansas City,United States,FALSE
 2012-10-16,Venezuela,Ecuador,0,0,FIFA World Cup qualification,Puerto la Cruz,Venezuela,FALSE
 2012-10-16,Vietnam,Indonesia,0,0,Friendly,Hanoi,Vietnam,FALSE
 2012-10-17,Poland,England,1,1,FIFA World Cup qualification,Warsaw,Poland,FALSE
@@ -34966,7 +34966,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-11-14,Armenia,Lithuania,4,2,Friendly,Yerevan,Armenia,FALSE
 2012-11-14,Austria,Ivory Coast,0,3,Friendly,Linz,Austria,FALSE
 2012-11-14,Bolivia,Costa Rica,1,1,Friendly,Santa Cruz,Bolivia,FALSE
-2012-11-14,Brazil,Colombia,1,1,Friendly,East Rutherford,USA,TRUE
+2012-11-14,Brazil,Colombia,1,1,Friendly,East Rutherford,United States,TRUE
 2012-11-14,Bulgaria,Ukraine,0,1,Friendly,Sofia,Bulgaria,FALSE
 2012-11-14,Cape Verde,Ghana,0,1,Friendly,Lisbon,Portugal,TRUE
 2012-11-14,China PR,New Zealand,1,1,Friendly,Shanghai,China PR,FALSE
@@ -34978,7 +34978,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-11-14,Georgia,Egypt,0,0,Friendly,Tbilisi,Georgia,FALSE
 2012-11-14,Grenada,French Guiana,1,1,CFU Caribbean Cup qualification,St. George's,Grenada,FALSE
 2012-11-14,Haiti,Guyana,1,0,CFU Caribbean Cup qualification,St. George's,Grenada,TRUE
-2012-11-14,Honduras,Peru,0,0,Friendly,Houston,USA,TRUE
+2012-11-14,Honduras,Peru,0,0,Friendly,Houston,United States,TRUE
 2012-11-14,Hungary,Norway,0,2,Friendly,Budapest,Hungary,FALSE
 2012-11-14,Indonesia,Timor-Leste,1,0,Friendly,Jakarta,Indonesia,FALSE
 2012-11-14,Iran,Uzbekistan,0,1,FIFA World Cup qualification,Tehran,Iran,FALSE
@@ -35003,7 +35003,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-11-14,Poland,Uruguay,1,3,Friendly,Gdańsk,Poland,FALSE
 2012-11-14,Qatar,Lebanon,1,0,FIFA World Cup qualification,Doha,Qatar,FALSE
 2012-11-14,Romania,Belgium,2,1,Friendly,Bucharest,Romania,FALSE
-2012-11-14,Russia,USA,2,2,Friendly,Krasnodar,Russia,FALSE
+2012-11-14,Russia,United States,2,2,Friendly,Krasnodar,Russia,FALSE
 2012-11-14,Rwanda,Namibia,2,2,Friendly,Kigali,Rwanda,FALSE
 2012-11-14,Saudi Arabia,Argentina,0,0,Friendly,Riyadh,Saudi Arabia,FALSE
 2012-11-14,Serbia,Chile,3,1,Friendly,St. Gallen,Switzerland,TRUE
@@ -35014,7 +35014,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2012-11-14,Tunisia,Switzerland,1,2,Friendly,Sousse,Tunisia,FALSE
 2012-11-14,Turkey,Denmark,1,1,Friendly,Istanbul,Turkey,FALSE
 2012-11-14,United Arab Emirates,Estonia,2,1,Friendly,Abu Dhabi,United Arab Emirates,FALSE
-2012-11-14,Venezuela,Nigeria,1,3,Friendly,Miami,USA,TRUE
+2012-11-14,Venezuela,Nigeria,1,3,Friendly,Miami,United States,TRUE
 2012-11-15,Philippines,Singapore,1,0,Friendly,Cebu City,Philippines,FALSE
 2012-11-16,French Guiana,Haiti,1,0,CFU Caribbean Cup qualification,St. George's,Grenada,TRUE
 2012-11-16,Trinidad and Tobago,Suriname,3,0,CFU Caribbean Cup qualification,Bacolet,Trinidad and Tobago,FALSE
@@ -35220,7 +35220,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-01-28,Niger,Ghana,0,3,African Cup of Nations,Port Elizabeth,South Africa,TRUE
 2013-01-29,Burkina Faso,Zambia,0,0,African Cup of Nations,Nelspruit,South Africa,TRUE
 2013-01-29,Ethiopia,Nigeria,0,2,African Cup of Nations,Rustenburg,South Africa,TRUE
-2013-01-29,USA,Canada,0,0,Friendly,Houston,USA,FALSE
+2013-01-29,United States,Canada,0,0,Friendly,Houston,United States,FALSE
 2013-01-30,Algeria,Ivory Coast,2,2,African Cup of Nations,Rustenburg,South Africa,TRUE
 2013-01-30,Oman,China PR,1,0,Friendly,Muscat,Oman,FALSE
 2013-01-30,Togo,Tunisia,1,1,African Cup of Nations,Nelspruit,South Africa,TRUE
@@ -35244,7 +35244,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-02-06,England,Brazil,2,1,Friendly,London,England,FALSE
 2013-02-06,France,Germany,1,2,Friendly,Saint-Denis,France,FALSE
 2013-02-06,Greece,Switzerland,0,0,Friendly,Piraeus,Greece,FALSE
-2013-02-06,Honduras,USA,2,1,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
+2013-02-06,Honduras,United States,2,1,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2013-02-06,Hungary,Belarus,1,1,Friendly,Belek,Turkey,TRUE
 2013-02-06,Iceland,Russia,0,2,Friendly,Marbella,Spain,TRUE
 2013-02-06,India,Palestine,2,4,Friendly,Kochi,India,FALSE
@@ -35364,7 +35364,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-03-22,Turkmenistan,Cambodia,7,0,AFC Challenge Cup qualification,Manila,Philippines,TRUE
 2013-03-22,United Arab Emirates,Uzbekistan,2,1,AFC Asian Cup qualification,Abu Dhabi,United Arab Emirates,FALSE
 2013-03-22,Uruguay,Paraguay,1,1,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2013-03-22,USA,Costa Rica,1,0,FIFA World Cup qualification,Commerce City,USA,FALSE
+2013-03-22,United States,Costa Rica,1,0,FIFA World Cup qualification,Commerce City,United States,FALSE
 2013-03-23,Belize,Trinidad and Tobago,0,0,Friendly,Belmopan,Belize,FALSE
 2013-03-23,Burkina Faso,Niger,4,0,FIFA World Cup qualification,Ouagadougou,Burkina Faso,FALSE
 2013-03-23,Cameroon,Togo,2,1,FIFA World Cup qualification,Yaoundé,Cameroon,FALSE
@@ -35413,7 +35413,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-03-26,Luxembourg,Finland,0,3,Friendly,Luxembourg,Luxembourg,FALSE
 2013-03-26,Malaysia,Palestine,0,2,Friendly,Kuantan,Malaysia,FALSE
 2013-03-26,Malta,Italy,0,2,FIFA World Cup qualification,Attard,Malta,FALSE
-2013-03-26,Mexico,USA,0,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+2013-03-26,Mexico,United States,0,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2013-03-26,Montenegro,England,1,1,FIFA World Cup qualification,Podgorica,Montenegro,FALSE
 2013-03-26,Netherlands,Romania,4,0,FIFA World Cup qualification,Amsterdam,Netherlands,FALSE
 2013-03-26,New Caledonia,Tahiti,1,0,FIFA World Cup qualification,Nouméa,New Caledonia,FALSE
@@ -35431,7 +35431,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-03-26,Venezuela,Colombia,1,0,FIFA World Cup qualification,Puerto Ordaz,Venezuela,FALSE
 2013-03-26,Wales,Croatia,1,2,FIFA World Cup qualification,Swansea,Wales,FALSE
 2013-04-06,Bolivia,Brazil,0,4,Friendly,Santa Cruz,Bolivia,FALSE
-2013-04-17,Mexico,Peru,0,0,Friendly,San Francisco,USA,TRUE
+2013-04-17,Mexico,Peru,0,0,Friendly,San Francisco,United States,TRUE
 2013-04-17,Qatar,Palestine,2,0,Friendly,Doha,Qatar,FALSE
 2013-04-21,Saint Vincent and the Grenadines,Saint Lucia,0,2,Windward Islands Tournament,Kingstown,Saint Vincent and the Grenadines,FALSE
 2013-04-24,Brazil,Chile,2,2,Friendly,Belo Horizonte,Brazil,FALSE
@@ -35449,25 +35449,25 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-05-28,Canada,Costa Rica,0,1,Friendly,Edmonton,Canada,FALSE
 2013-05-28,Turkey,Latvia,3,3,Friendly,Duisburg,Germany,TRUE
 2013-05-28,Brittany,Mali,1,0,Friendly,Nantes,France,FALSE
-2013-05-29,Ecuador,Germany,2,4,Friendly,Boca Raton,USA,TRUE
+2013-05-29,Ecuador,Germany,2,4,Friendly,Boca Raton,United States,TRUE
 2013-05-29,England,Republic of Ireland,1,1,Friendly,London,England,FALSE
 2013-05-29,Oman,Lebanon,1,1,Friendly,Doha,Qatar,TRUE
 2013-05-29,Qatar,Azerbaijan,1,1,Friendly,Doha,Qatar,FALSE
-2013-05-29,USA,Belgium,2,4,Friendly,Cleveland,USA,FALSE
+2013-05-29,United States,Belgium,2,4,Friendly,Cleveland,United States,FALSE
 2013-05-30,Japan,Bulgaria,0,2,Kirin Challenge Cup,Toyota,Japan,FALSE
 2013-05-31,Italy,San Marino,4,0,Friendly,Bologna,Italy,FALSE
-2013-05-31,Mexico,Nigeria,2,2,Friendly,Houston,USA,TRUE
+2013-05-31,Mexico,Nigeria,2,2,Friendly,Houston,United States,TRUE
 2013-05-31,Turkey,Slovenia,0,2,Friendly,Bielefeld,Germany,TRUE
 2013-06-01,Libya,Uganda,3,0,Friendly,Tripoli,Libya,FALSE
 2013-06-01,Panama,Peru,1,2,Friendly,Panama City,Panama,FALSE
 2013-06-02,Algeria,Burkina Faso,2,0,Friendly,Blida,Algeria,FALSE
 2013-06-02,Brazil,England,2,2,Friendly,Rio de Janeiro,Brazil,FALSE
-2013-06-02,Honduras,Israel,0,2,Friendly,New York,USA,TRUE
+2013-06-02,Honduras,Israel,0,2,Friendly,New York,United States,TRUE
 2013-06-02,Republic of Ireland,Georgia,4,0,Friendly,Dublin,Republic of Ireland,FALSE
 2013-06-02,Lesotho,South Africa,0,2,Friendly,Maseru,Lesotho,FALSE
 2013-06-02,Sudan,Tanzania,0,0,Friendly,Addis Ababa,Ethiopia,TRUE
 2013-06-02,Ukraine,Cameroon,0,0,Friendly,Kyiv,Ukraine,FALSE
-2013-06-02,USA,Germany,4,3,Friendly,Washington,USA,FALSE
+2013-06-02,United States,Germany,4,3,Friendly,Washington,United States,FALSE
 2013-06-03,Estonia,Belarus,0,2,Friendly,Tallinn,Estonia,FALSE
 2013-06-03,Sweden,North Macedonia,1,0,Friendly,Malmö,Sweden,FALSE
 2013-06-04,Myanmar,Singapore,0,2,Friendly,Yangon,Myanmar,FALSE
@@ -35503,7 +35503,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-06-07,Iceland,Slovenia,2,4,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
 2013-06-07,Indonesia,Netherlands,0,3,Friendly,Jakarta,Indonesia,FALSE
 2013-06-07,Republic of Ireland,Faroe Islands,3,0,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
-2013-06-07,Jamaica,USA,1,2,FIFA World Cup qualification,Kingston,Jamaica,FALSE
+2013-06-07,Jamaica,United States,1,2,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2013-06-07,Laos,Singapore,2,5,Friendly,Vientiane,Laos,FALSE
 2013-06-07,Latvia,Bosnia and Herzegovina,0,5,FIFA World Cup qualification,Riga,Latvia,FALSE
 2013-06-07,Libya,DR Congo,0,0,FIFA World Cup qualification,Tripoli,Libya,FALSE
@@ -35523,7 +35523,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-06-08,Central African Republic,South Africa,0,3,FIFA World Cup qualification,Yaoundé,Cameroon,TRUE
 2013-06-08,Gabon,Congo,0,0,FIFA World Cup qualification,Franceville,Gabon,FALSE
 2013-06-08,Gambia,Ivory Coast,0,3,FIFA World Cup qualification,Bakau,Gambia,FALSE
-2013-06-08,Haiti,Spain,1,2,Friendly,Miami Gardens,USA,TRUE
+2013-06-08,Haiti,Spain,1,2,Friendly,Miami Gardens,United States,TRUE
 2013-06-08,Morocco,Tanzania,2,1,FIFA World Cup qualification,Marrakech,Morocco,FALSE
 2013-06-08,Sierra Leone,Tunisia,2,2,FIFA World Cup qualification,Freetown,Sierra Leone,FALSE
 2013-06-08,Switzerland,Cyprus,1,0,FIFA World Cup qualification,Geneva,Switzerland,FALSE
@@ -35554,9 +35554,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-06-11,Mexico,Costa Rica,0,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2013-06-11,Norway,North Macedonia,2,0,Friendly,Oslo,Norway,FALSE
 2013-06-11,Qatar,North Korea,0,0,Friendly,Doha,Qatar,FALSE
-2013-06-11,Spain,Republic of Ireland,2,0,Friendly,New York,USA,TRUE
+2013-06-11,Spain,Republic of Ireland,2,0,Friendly,New York,United States,TRUE
 2013-06-11,Sweden,Faroe Islands,2,0,FIFA World Cup qualification,Solna,Sweden,FALSE
-2013-06-11,USA,Panama,2,0,FIFA World Cup qualification,Seattle,USA,FALSE
+2013-06-11,United States,Panama,2,0,FIFA World Cup qualification,Seattle,United States,FALSE
 2013-06-11,Venezuela,Uruguay,0,1,FIFA World Cup qualification,Puerto Ordaz,Venezuela,FALSE
 2013-06-12,Ghana,Ivory Coast,2,1,Friendly,Kumasi,Ghana,FALSE
 2013-06-12,Malawi,Kenya,2,2,FIFA World Cup qualification,Blantyre,Malawi,FALSE
@@ -35591,7 +35591,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-06-18,Costa Rica,Panama,2,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2013-06-18,Jordan,Oman,1,0,FIFA World Cup qualification,Amman,Jordan,FALSE
 2013-06-18,South Korea,Iran,0,1,FIFA World Cup qualification,Ulsan,South Korea,FALSE
-2013-06-18,USA,Honduras,1,0,FIFA World Cup qualification,Sandy,USA,FALSE
+2013-06-18,United States,Honduras,1,0,FIFA World Cup qualification,Sandy,United States,FALSE
 2013-06-18,Uzbekistan,Qatar,5,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2013-06-19,Brazil,Mexico,2,0,Confederations Cup,Fortaleza,Brazil,FALSE
 2013-06-19,Italy,Japan,4,3,Confederations Cup,Recife,Brazil,TRUE
@@ -35613,43 +35613,43 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-07-05,Nigeria,Ivory Coast,4,1,African Nations Championship,Kaduna,Nigeria,FALSE
 2013-07-06,Namibia,Mauritius,2,1,COSAFA Cup,Lusaka,Zambia,TRUE
 2013-07-07,Botswana,Eswatini,0,0,COSAFA Cup,Kitwe,Zambia,TRUE
-2013-07-07,Canada,Martinique,0,1,Gold Cup,Pasadena,USA,TRUE
+2013-07-07,Canada,Martinique,0,1,Gold Cup,Pasadena,United States,TRUE
 2013-07-07,DR Congo,Congo,2,1,African Nations Championship,Kinshasa,DR Congo,FALSE
-2013-07-07,Mexico,Panama,1,2,Gold Cup,Pasadena,USA,TRUE
-2013-07-08,El Salvador,Trinidad and Tobago,2,2,Gold Cup,Harrison,USA,TRUE
-2013-07-08,Haiti,Honduras,0,2,Gold Cup,Harrison,USA,TRUE
+2013-07-07,Mexico,Panama,1,2,Gold Cup,Pasadena,United States,TRUE
+2013-07-08,El Salvador,Trinidad and Tobago,2,2,Gold Cup,Harrison,United States,TRUE
+2013-07-08,Haiti,Honduras,0,2,Gold Cup,Harrison,United States,TRUE
 2013-07-08,Kenya,Lesotho,2,2,COSAFA Cup,Kitwe,Zambia,TRUE
 2013-07-08,Namibia,Seychelles,4,2,COSAFA Cup,Lusaka,Zambia,TRUE
-2013-07-09,Costa Rica,Cuba,3,0,Gold Cup,Portland,USA,TRUE
+2013-07-09,Costa Rica,Cuba,3,0,Gold Cup,Portland,United States,TRUE
 2013-07-09,Kenya,Eswatini,2,0,COSAFA Cup,Kitwe,Zambia,TRUE
 2013-07-09,Lesotho,Botswana,3,3,COSAFA Cup,Kitwe,Zambia,TRUE
-2013-07-09,USA,Belize,6,1,Gold Cup,Portland,USA,FALSE
+2013-07-09,United States,Belize,6,1,Gold Cup,Portland,United States,FALSE
 2013-07-10,Mauritius,Seychelles,4,0,COSAFA Cup,Kitwe,Zambia,TRUE
 2013-07-11,Kenya,Botswana,1,2,COSAFA Cup,Kitwe,Zambia,TRUE
 2013-07-11,Lesotho,Eswatini,2,0,COSAFA Cup,Lusaka,Zambia,TRUE
-2013-07-11,Mexico,Canada,2,0,Gold Cup,Seattle,USA,TRUE
-2013-07-11,Panama,Martinique,1,0,Gold Cup,Seattle,USA,TRUE
-2013-07-12,Honduras,El Salvador,1,0,Gold Cup,Miami Gardens,USA,TRUE
-2013-07-12,Trinidad and Tobago,Haiti,0,2,Gold Cup,Miami Gardens,USA,TRUE
-2013-07-13,Costa Rica,Belize,1,0,Gold Cup,Sandy,USA,TRUE
+2013-07-11,Mexico,Canada,2,0,Gold Cup,Seattle,United States,TRUE
+2013-07-11,Panama,Martinique,1,0,Gold Cup,Seattle,United States,TRUE
+2013-07-12,Honduras,El Salvador,1,0,Gold Cup,Miami Gardens,United States,TRUE
+2013-07-12,Trinidad and Tobago,Haiti,0,2,Gold Cup,Miami Gardens,United States,TRUE
+2013-07-13,Costa Rica,Belize,1,0,Gold Cup,Sandy,United States,TRUE
 2013-07-13,Morocco,Tunisia,0,0,African Nations Championship,Tangier,Morocco,FALSE
 2013-07-13,South Africa,Namibia,2,1,COSAFA Cup,Lusaka,Zambia,TRUE
-2013-07-13,USA,Cuba,4,1,Gold Cup,Sandy,USA,FALSE
+2013-07-13,United States,Cuba,4,1,Gold Cup,Sandy,United States,FALSE
 2013-07-13,Zimbabwe,Malawi,1,1,COSAFA Cup,Lusaka,Zambia,TRUE
-2013-07-14,Martinique,Mexico,1,3,Gold Cup,Denver,USA,TRUE
-2013-07-14,Panama,Canada,0,0,Gold Cup,Denver,USA,TRUE
+2013-07-14,Martinique,Mexico,1,3,Gold Cup,Denver,United States,TRUE
+2013-07-14,Panama,Canada,0,0,Gold Cup,Denver,United States,TRUE
 2013-07-14,Zambia,Mozambique,3,1,COSAFA Cup,Kitwe,Zambia,FALSE
 2013-07-14,Angola,Lesotho,1,1,COSAFA Cup,Kitwe,Zambia,TRUE
 2013-07-14,Bermuda,Greenland,3,0,Island Games,Hamilton,Bermuda,FALSE
 2013-07-14,Frøya,Falkland Islands,1,2,Island Games,Hamilton,Bermuda,TRUE
-2013-07-15,El Salvador,Haiti,1,0,Gold Cup,Houston,USA,TRUE
-2013-07-15,Honduras,Trinidad and Tobago,0,2,Gold Cup,Houston,USA,TRUE
+2013-07-15,El Salvador,Haiti,1,0,Gold Cup,Houston,United States,TRUE
+2013-07-15,Honduras,Trinidad and Tobago,0,2,Gold Cup,Houston,United States,TRUE
 2013-07-15,Bermuda,Falkland Islands,8,0,Island Games,Hamilton,Bermuda,FALSE
 2013-07-15,Greenland,Frøya,12,0,Island Games,Hamilton,Bermuda,TRUE
-2013-07-16,Cuba,Belize,4,0,Gold Cup,East Hartford,USA,TRUE
+2013-07-16,Cuba,Belize,4,0,Gold Cup,East Hartford,United States,TRUE
 2013-07-16,Namibia,Mozambique,0,1,COSAFA Cup,Kitwe,Zambia,TRUE
 2013-07-16,Malawi,Angola,2,3,COSAFA Cup,Kitwe,Zambia,TRUE
-2013-07-16,USA,Costa Rica,1,0,Gold Cup,East Hartford,USA,FALSE
+2013-07-16,United States,Costa Rica,1,0,Gold Cup,East Hartford,United States,FALSE
 2013-07-17,Zambia,South Africa,0,0,COSAFA Cup,Ndola,Zambia,FALSE
 2013-07-17,Zimbabwe,Lesotho,2,1,COSAFA Cup,Ndola,Zambia,TRUE
 2013-07-17,Falkland Islands,Greenland,0,9,Island Games,Hamilton,Bermuda,TRUE
@@ -35660,15 +35660,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-07-20,South Korea,Australia,0,0,EAFF Championship,Seoul,South Korea,FALSE
 2013-07-20,Lesotho,South Africa,1,2,COSAFA Cup,Ndola,Zambia,TRUE
 2013-07-20,Mauritania,Senegal,2,0,African Nations Championship,Nouakchott,Mauritania,FALSE
-2013-07-20,Mexico,Trinidad and Tobago,1,0,Gold Cup,Atlanta,USA,TRUE
-2013-07-20,Panama,Cuba,6,1,Gold Cup,Atlanta,USA,TRUE
+2013-07-20,Mexico,Trinidad and Tobago,1,0,Gold Cup,Atlanta,United States,TRUE
+2013-07-20,Panama,Cuba,6,1,Gold Cup,Atlanta,United States,TRUE
 2013-07-20,Zambia,Zimbabwe,2,0,COSAFA Cup,Ndola,Zambia,FALSE
-2013-07-21,Honduras,Costa Rica,1,0,Gold Cup,Baltimore,USA,TRUE
+2013-07-21,Honduras,Costa Rica,1,0,Gold Cup,Baltimore,United States,TRUE
 2013-07-21,Japan,China PR,3,3,EAFF Championship,Seoul,South Korea,TRUE
-2013-07-21,USA,El Salvador,5,1,Gold Cup,Baltimore,USA,FALSE
+2013-07-21,United States,El Salvador,5,1,Gold Cup,Baltimore,United States,FALSE
 2013-07-24,South Korea,China PR,0,0,EAFF Championship,Hwaseong,South Korea,FALSE
-2013-07-24,Panama,Mexico,2,1,Gold Cup,Arlington,USA,TRUE
-2013-07-24,USA,Honduras,3,1,Gold Cup,Arlington,USA,FALSE
+2013-07-24,Panama,Mexico,2,1,Gold Cup,Arlington,United States,TRUE
+2013-07-24,United States,Honduras,3,1,Gold Cup,Arlington,United States,FALSE
 2013-07-25,Japan,Australia,3,2,EAFF Championship,Hwaseong,South Korea,TRUE
 2013-07-27,Ivory Coast,Nigeria,2,0,African Nations Championship,Marcory,Ivory Coast,FALSE
 2013-07-27,Niger,Burkina Faso,1,0,African Nations Championship,Niamey,Niger,FALSE
@@ -35682,7 +35682,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-07-28,Mauritius,Zimbabwe,0,3,African Nations Championship,Curepipe,Mauritius,FALSE
 2013-07-28,Mozambique,Namibia,3,0,African Nations Championship,Maputo,Mozambique,FALSE
 2013-07-28,Sudan,Burundi,1,1,African Nations Championship,Omdurman,Sudan,FALSE
-2013-07-28,USA,Panama,1,0,Gold Cup,Chicago,USA,FALSE
+2013-07-28,United States,Panama,1,0,Gold Cup,Chicago,United States,FALSE
 2013-08-02,Namibia,Mozambique,3,0,African Nations Championship,Windhoek,Namibia,FALSE
 2013-08-02,Zimbabwe,Mauritius,1,0,African Nations Championship,Harare,Zimbabwe,FALSE
 2013-08-09,Gabon,Cameroon,1,0,African Nations Championship,Libreville,Gabon,FALSE
@@ -35693,7 +35693,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-08-14,Azerbaijan,Malta,3,0,Friendly,Baku,Azerbaijan,FALSE
 2013-08-14,Belarus,Montenegro,1,1,Friendly,Zhodzina,Belarus,FALSE
 2013-08-14,Belgium,France,0,0,Friendly,Brussels,Belgium,FALSE
-2013-08-14,Bosnia and Herzegovina,USA,3,4,Friendly,Sarajevo,Bosnia and Herzegovina,FALSE
+2013-08-14,Bosnia and Herzegovina,United States,3,4,Friendly,Sarajevo,Bosnia and Herzegovina,FALSE
 2013-08-14,Chile,Iraq,6,0,Friendly,Brøndby,Denmark,TRUE
 2013-08-14,Colombia,Serbia,1,0,Friendly,Barcelona,Spain,TRUE
 2013-08-14,Dominican Republic,Costa Rica,0,4,Friendly,Santo Domingo,Dominican Republic,FALSE
@@ -35715,7 +35715,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-08-14,Liechtenstein,Croatia,2,3,Friendly,Vaduz,Liechtenstein,FALSE
 2013-08-14,Luxembourg,Lithuania,2,1,Friendly,Luxembourg,Luxembourg,FALSE
 2013-08-14,North Macedonia,Bulgaria,2,0,Friendly,Skopje,North Macedonia,FALSE
-2013-08-14,Mexico,Ivory Coast,4,1,Friendly,East Rutherford,USA,TRUE
+2013-08-14,Mexico,Ivory Coast,4,1,Friendly,East Rutherford,United States,TRUE
 2013-08-14,Moldova,Andorra,1,1,Friendly,Chișinău,Moldova,FALSE
 2013-08-14,Morocco,Burkina Faso,1,2,Friendly,Tangier,Morocco,FALSE
 2013-08-14,Northern Ireland,Russia,1,0,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
@@ -35768,7 +35768,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-09-06,Chile,Venezuela,3,0,FIFA World Cup qualification,Santiago,Chile,FALSE
 2013-09-06,China PR,Singapore,6,1,Friendly,Tianjin,China PR,FALSE
 2013-09-06,Colombia,Ecuador,1,0,FIFA World Cup qualification,Barranquilla,Colombia,FALSE
-2013-09-06,Costa Rica,USA,3,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
+2013-09-06,Costa Rica,United States,3,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2013-09-06,Czech Republic,Armenia,1,2,FIFA World Cup qualification,Prague,Czech Republic,FALSE
 2013-09-06,England,Moldova,4,0,FIFA World Cup qualification,London,England,FALSE
 2013-09-06,Estonia,Netherlands,2,2,FIFA World Cup qualification,Tallinn,Estonia,FALSE
@@ -35836,7 +35836,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-09-10,Austria,Republic of Ireland,1,0,FIFA World Cup qualification,Vienna,Austria,FALSE
 2013-09-10,Belarus,France,2,4,FIFA World Cup qualification,Homel,Belarus,FALSE
 2013-09-10,Bolivia,Ecuador,1,1,FIFA World Cup qualification,La Paz,Bolivia,FALSE
-2013-09-10,Brazil,Portugal,3,1,Friendly,Foxborough,USA,TRUE
+2013-09-10,Brazil,Portugal,3,1,Friendly,Foxborough,United States,TRUE
 2013-09-10,Canada,Mauritania,0,1,Friendly,Oliva,Spain,TRUE
 2013-09-10,China PR,Malaysia,2,0,Friendly,Tianjin,China PR,FALSE
 2013-09-10,Cyprus,Slovenia,0,2,FIFA World Cup qualification,Nicosia,Cyprus,FALSE
@@ -35868,7 +35868,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-09-10,Spain,Chile,2,2,Friendly,Geneva,Switzerland,TRUE
 2013-09-10,Ukraine,England,0,0,FIFA World Cup qualification,Kyiv,Ukraine,FALSE
 2013-09-10,Uruguay,Colombia,2,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2013-09-10,USA,Mexico,2,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2013-09-10,United States,Mexico,2,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2013-09-10,Uzbekistan,Jordan,1,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2013-09-10,Venezuela,Peru,3,2,FIFA World Cup qualification,Puerto la Cruz,Venezuela,FALSE
 2013-09-10,Wales,Serbia,0,3,FIFA World Cup qualification,Cardiff,Wales,FALSE
@@ -35913,7 +35913,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-10-11,Spain,Belarus,2,1,FIFA World Cup qualification,Palma de Mallorca,Spain,FALSE
 2013-10-11,Sweden,Austria,2,1,FIFA World Cup qualification,Solna,Sweden,FALSE
 2013-10-11,Ukraine,Poland,1,0,FIFA World Cup qualification,Kharkiv,Ukraine,FALSE
-2013-10-11,USA,Jamaica,2,0,FIFA World Cup qualification,Kansas City,USA,FALSE
+2013-10-11,United States,Jamaica,2,0,FIFA World Cup qualification,Kansas City,United States,FALSE
 2013-10-11,Venezuela,Paraguay,1,1,FIFA World Cup qualification,San Cristóbal,Venezuela,FALSE
 2013-10-11,Wales,North Macedonia,1,0,FIFA World Cup qualification,Cardiff,Wales,FALSE
 2013-10-12,Burkina Faso,Algeria,3,2,FIFA World Cup qualification,Ouagadougou,Burkina Faso,FALSE
@@ -35955,7 +35955,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-10-15,Malaysia,Bahrain,1,1,AFC Asian Cup qualification,Shah Alam,Malaysia,FALSE
 2013-10-15,Montenegro,Moldova,2,5,FIFA World Cup qualification,Podgorica,Montenegro,FALSE
 2013-10-15,Norway,Iceland,1,1,FIFA World Cup qualification,Oslo,Norway,FALSE
-2013-10-15,Panama,USA,2,3,FIFA World Cup qualification,Panama City,Panama,FALSE
+2013-10-15,Panama,United States,2,3,FIFA World Cup qualification,Panama City,Panama,FALSE
 2013-10-15,Paraguay,Colombia,1,2,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 2013-10-15,Peru,Bolivia,1,1,FIFA World Cup qualification,Lima,Peru,FALSE
 2013-10-15,Philippines,Pakistan,3,1,Friendly,Bacolod,Philippines,FALSE
@@ -35983,7 +35983,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-11-14,Bonaire,Suriname,0,2,ABCS Tournament,Willemstad,Curaçao,TRUE
 2013-11-14,Curaçao,Aruba,2,0,ABCS Tournament,Willemstad,Curaçao,FALSE
 2013-11-14,Egypt,Zambia,2,0,Friendly,Cairo,Egypt,FALSE
-2013-11-15,Argentina,Ecuador,0,0,Friendly,East Rutherford,USA,TRUE
+2013-11-15,Argentina,Ecuador,0,0,Friendly,East Rutherford,United States,TRUE
 2013-11-15,Bahrain,Malaysia,1,0,AFC Asian Cup qualification,Riffa,Bahrain,FALSE
 2013-11-15,Belarus,Albania,0,0,Friendly,Antalya,Turkey,TRUE
 2013-11-15,China PR,Indonesia,1,0,AFC Asian Cup qualification,Xi'an,China PR,FALSE
@@ -36004,7 +36004,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-11-15,Portugal,Sweden,1,0,FIFA World Cup qualification,Lisbon,Portugal,FALSE
 2013-11-15,Russia,Serbia,1,1,Friendly,Dubai,United Arab Emirates,TRUE
 2013-11-15,Saudi Arabia,Iraq,2,1,AFC Asian Cup qualification,Dammam,Saudi Arabia,FALSE
-2013-11-15,Scotland,USA,0,0,Friendly,Glasgow,Scotland,FALSE
+2013-11-15,Scotland,United States,0,0,Friendly,Glasgow,Scotland,FALSE
 2013-11-15,Eswatini,South Africa,0,3,Friendly,Lobamba,Eswatini,FALSE
 2013-11-15,Syria,Singapore,4,0,AFC Asian Cup qualification,Tehran,Iran,TRUE
 2013-11-15,Thailand,Iran,0,3,AFC Asian Cup qualification,Bangkok,Thailand,FALSE
@@ -36016,7 +36016,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-11-16,Aruba,Bonaire,1,2,ABCS Tournament,Willemstad,Curaçao,TRUE
 2013-11-16,Curaçao,Suriname,1,3,ABCS Tournament,Willemstad,Curaçao,FALSE
 2013-11-16,Equatorial Guinea,Spain,1,2,Friendly,Malabo,Equatorial Guinea,FALSE
-2013-11-16,Honduras,Brazil,0,5,Friendly,Miami Gardens,USA,TRUE
+2013-11-16,Honduras,Brazil,0,5,Friendly,Miami Gardens,United States,TRUE
 2013-11-16,Netherlands,Japan,2,2,Friendly,Genk,Belgium,TRUE
 2013-11-16,Nigeria,Ethiopia,2,0,FIFA World Cup qualification,Calabar,Nigeria,FALSE
 2013-11-16,Senegal,Ivory Coast,1,1,FIFA World Cup qualification,Casablanca,Morocco,TRUE
@@ -36024,12 +36024,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-11-16,Wales,Finland,1,1,Friendly,Cardiff,Wales,FALSE
 2013-11-17,Cameroon,Tunisia,4,1,FIFA World Cup qualification,Yaoundé,Cameroon,FALSE
 2013-11-17,Luxembourg,Montenegro,1,4,Friendly,Luxembourg,Luxembourg,FALSE
-2013-11-18,Argentina,Bosnia and Herzegovina,2,0,Friendly,St. Louis,USA,TRUE
+2013-11-18,Argentina,Bosnia and Herzegovina,2,0,Friendly,St. Louis,United States,TRUE
 2013-11-18,Italy,Nigeria,2,2,Friendly,London,England,TRUE
 2013-11-18,Moldova,Lithuania,1,1,Friendly,Chișinău,Moldova,FALSE
 2013-11-19,Algeria,Burkina Faso,1,0,FIFA World Cup qualification,Blida,Algeria,FALSE
 2013-11-19,Australia,Costa Rica,1,0,Friendly,Sydney,Australia,FALSE
-2013-11-19,Austria,USA,1,0,Friendly,Vienna,Austria,FALSE
+2013-11-19,Austria,United States,1,0,Friendly,Vienna,Austria,FALSE
 2013-11-19,Bahrain,Yemen,2,0,AFC Asian Cup qualification,Riffa,Bahrain,FALSE
 2013-11-19,Belgium,Japan,2,3,Friendly,Brussels,Belgium,FALSE
 2013-11-19,Brazil,Chile,2,1,Friendly,Toronto,Canada,TRUE
@@ -36040,7 +36040,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2013-11-19,England,Germany,0,1,Friendly,London,England,FALSE
 2013-11-19,France,Ukraine,3,0,FIFA World Cup qualification,Saint-Denis,France,FALSE
 2013-11-19,Gibraltar,Slovakia,0,0,Friendly,Faro,Portugal,TRUE
-2013-11-19,Honduras,Ecuador,2,2,Friendly,Houston,USA,TRUE
+2013-11-19,Honduras,Ecuador,2,2,Friendly,Houston,United States,TRUE
 2013-11-19,Hong Kong,Uzbekistan,0,2,AFC Asian Cup qualification,So Kon Po,Hong Kong,FALSE
 2013-11-19,India,Nepal,2,0,Friendly,Siliguri,India,FALSE
 2013-11-19,Indonesia,Iraq,0,2,AFC Asian Cup qualification,Jakarta,Indonesia,FALSE
@@ -36148,17 +36148,17 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-01-22,Chile,Costa Rica,4,0,Friendly,Coquimbo,Chile,FALSE
 2014-01-22,Mauritania,Gabon,2,4,African Nations Championship,Bloemfontein,South Africa,TRUE
 2014-01-24,Oman,Finland,0,0,Friendly,Nizwa,Oman,FALSE
-2014-01-25,Costa Rica,South Korea,0,1,Friendly,Los Angeles,USA,TRUE
+2014-01-25,Costa Rica,South Korea,0,1,Friendly,Los Angeles,United States,TRUE
 2014-01-25,Mali,Zimbabwe,1,2,African Nations Championship,Cape Town,South Africa,TRUE
 2014-01-25,Morocco,Nigeria,3,4,African Nations Championship,Cape Town,South Africa,TRUE
 2014-01-26,Gabon,Libya,1,1,African Nations Championship,Polokwane,South Africa,TRUE
 2014-01-26,Ghana,DR Congo,1,0,African Nations Championship,Bloemfontein,South Africa,TRUE
-2014-01-29,Mexico,South Korea,4,0,Friendly,San Antonio,USA,TRUE
+2014-01-29,Mexico,South Korea,4,0,Friendly,San Antonio,United States,TRUE
 2014-01-29,Nigeria,Ghana,0,0,African Nations Championship,Bloemfontein,South Africa,TRUE
 2014-01-29,Zimbabwe,Libya,0,0,African Nations Championship,Bloemfontein,South Africa,TRUE
 2014-01-31,Oman,Jordan,0,0,AFC Asian Cup qualification,Muscat,Oman,FALSE
 2014-02-01,Libya,Ghana,0,0,African Nations Championship,Cape Town,South Africa,TRUE
-2014-02-01,USA,South Korea,2,0,Friendly,Carson,USA,FALSE
+2014-02-01,United States,South Korea,2,0,Friendly,Carson,United States,FALSE
 2014-02-01,Zimbabwe,Nigeria,0,1,African Nations Championship,Cape Town,South Africa,TRUE
 2014-02-04,Singapore,Jordan,1,3,AFC Asian Cup qualification,Singapore,Singapore,FALSE
 2014-02-19,Lebanon,Pakistan,3,1,Friendly,Beirut,Lebanon,FALSE
@@ -36219,7 +36219,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-03-05,Switzerland,Croatia,2,2,Friendly,St. Gallen,Switzerland,FALSE
 2014-03-05,Thailand,Lebanon,2,5,AFC Asian Cup qualification,Bangkok,Thailand,FALSE
 2014-03-05,Turkey,Sweden,2,1,Friendly,Ankara,Turkey,FALSE
-2014-03-05,Ukraine,USA,2,0,Friendly,Larnaca,Cyprus,TRUE
+2014-03-05,Ukraine,United States,2,0,Friendly,Larnaca,Cyprus,TRUE
 2014-03-05,Uzbekistan,United Arab Emirates,1,1,AFC Asian Cup qualification,Tashkent,Uzbekistan,FALSE
 2014-03-05,Vietnam,Hong Kong,3,1,AFC Asian Cup qualification,Hanoi,Vietnam,FALSE
 2014-03-05,Wales,Iceland,3,1,Friendly,Cardiff,Wales,FALSE
@@ -36287,7 +36287,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-05-26,Australia,South Africa,1,1,Friendly,Sydney,Australia,FALSE
 2014-05-26,Belgium,Luxembourg,5,1,Friendly,Genk,Belgium,FALSE
 2014-05-26,Estonia,Gibraltar,1,1,Friendly,Tallinn,Estonia,FALSE
-2014-05-26,Jamaica,Serbia,1,2,Friendly,Harrison,USA,TRUE
+2014-05-26,Jamaica,Serbia,1,2,Friendly,Harrison,United States,TRUE
 2014-05-26,North Macedonia,Cameroon,0,2,Friendly,Kufstein,Austria,TRUE
 2014-05-26,Montenegro,Iran,0,0,Friendly,Hartberg,Austria,TRUE
 2014-05-26,Russia,Slovakia,1,0,Friendly,Saint Petersburg,Russia,FALSE
@@ -36313,12 +36313,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-05-30,Angola,Iran,1,1,Friendly,Hartberg,Austria,TRUE
 2014-05-30,Aruba,Turks and Caicos Islands,1,0,CFU Caribbean Cup qualification,Oranjestad,Aruba,FALSE
 2014-05-30,Austria,Iceland,1,1,Friendly,Innsbruck,Austria,FALSE
-2014-05-30,Bosnia and Herzegovina,Ivory Coast,2,1,Friendly,St. Louis,USA,TRUE
+2014-05-30,Bosnia and Herzegovina,Ivory Coast,2,1,Friendly,St. Louis,United States,TRUE
 2014-05-30,Comoros,Kenya,1,1,African Cup of Nations qualification,Mitsamiouli,Comoros,FALSE
 2014-05-30,England,Peru,3,0,Friendly,London,England,FALSE
 2014-05-30,French Guiana,British Virgin Islands,6,0,CFU Caribbean Cup qualification,Oranjestad,Aruba,TRUE
 2014-05-30,North Macedonia,Qatar,0,0,Friendly,Rieti,Italy,TRUE
-2014-05-30,Montserrat,USA Virgin Islands,1,0,CFU Caribbean Cup qualification,Lookout,Montserrat,FALSE
+2014-05-30,Montserrat,United States Virgin Islands,1,0,CFU Caribbean Cup qualification,Lookout,Montserrat,FALSE
 2014-05-30,New Zealand,South Africa,0,0,Friendly,Auckland,New Zealand,FALSE
 2014-05-30,Palestine,Philippines,1,0,AFC Challenge Cup,Malé,Maldives,TRUE
 2014-05-30,South Sudan,Mozambique,0,0,African Cup of Nations qualification,Khartoum,Sudan,TRUE
@@ -36334,7 +36334,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-05-31,Guinea-Bissau,Central African Republic,3,1,African Cup of Nations qualification,Bissau,Guinea-Bissau,FALSE
 2014-05-31,Italy,Republic of Ireland,0,0,Friendly,London,England,TRUE
 2014-05-31,Latvia,Lithuania,1,0,Baltic Cup,Liepāja,Latvia,FALSE
-2014-05-31,Mexico,Ecuador,3,1,Friendly,Arlington,USA,TRUE
+2014-05-31,Mexico,Ecuador,3,1,Friendly,Arlington,United States,TRUE
 2014-05-31,Netherlands,Ghana,1,0,Friendly,Rotterdam,Netherlands,FALSE
 2014-05-31,Norway,Russia,1,1,Friendly,Oslo,Norway,FALSE
 2014-05-31,Portugal,Greece,0,0,Friendly,Oeiras,Portugal,FALSE
@@ -36348,18 +36348,18 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-01,Equatorial Guinea,Mauritania,3,0,African Cup of Nations qualification,Malabo,Equatorial Guinea,FALSE
 2014-06-01,France,Paraguay,1,1,Friendly,Nice,France,FALSE
 2014-06-01,Germany,Cameroon,2,2,Friendly,Mönchengladbach,Germany,FALSE
-2014-06-01,Honduras,Israel,2,4,Friendly,Houston,USA,TRUE
+2014-06-01,Honduras,Israel,2,4,Friendly,Houston,United States,TRUE
 2014-06-01,Lesotho,Liberia,2,0,African Cup of Nations qualification,Maseru,Lesotho,FALSE
 2014-06-01,Sweden,Belgium,0,2,Friendly,Solna,Sweden,FALSE
 2014-06-01,Turks and Caicos Islands,French Guiana,0,6,CFU Caribbean Cup qualification,Oranjestad,Aruba,TRUE
-2014-06-01,USA,Turkey,2,1,Friendly,Harrison,USA,FALSE
-2014-06-01,USA Virgin Islands,Bonaire,1,2,CFU Caribbean Cup qualification,Lookout,Montserrat,TRUE
+2014-06-01,United States,Turkey,2,1,Friendly,Harrison,United States,FALSE
+2014-06-01,United States Virgin Islands,Bonaire,1,2,CFU Caribbean Cup qualification,Lookout,Montserrat,TRUE
 2014-06-01,Zimbabwe,Tanzania,2,2,African Cup of Nations qualification,Harare,Zimbabwe,FALSE
 2014-06-01,Iraqi Kurdistan,Arameans Suryoye,1,2,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-01,Abkhazia,Occitania,1,1,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-01,Darfur,Padania,0,20,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-01,Ellan Vannin,Artsakh,3,2,CONIFA World Football Cup,Östersund,Sweden,TRUE
-2014-06-02,Costa Rica,Japan,1,3,Friendly,Tampa,USA,TRUE
+2014-06-02,Costa Rica,Japan,1,3,Friendly,Tampa,United States,TRUE
 2014-06-02,Tamil Eelam,Arameans Suryoye,0,2,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-02,Sápmi,Abkhazia,1,2,CONIFA World Football Cup,Östersund,Sweden,FALSE
 2014-06-02,Darfur,South Ossetia,0,19,CONIFA World Football Cup,Östersund,Sweden,TRUE
@@ -36369,16 +36369,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-03,British Virgin Islands,Turks and Caicos Islands,0,2,CFU Caribbean Cup qualification,Oranjestad,Aruba,TRUE
 2014-06-03,Czech Republic,Austria,1,2,Friendly,Olomouc,Czech Republic,FALSE
 2014-06-03,Georgia,United Arab Emirates,0,1,Friendly,Meyrin,Switzerland,TRUE
-2014-06-03,Greece,Nigeria,0,0,Friendly,Chester,USA,TRUE
-2014-06-03,Mexico,Bosnia and Herzegovina,0,1,Friendly,Chicago,USA,TRUE
+2014-06-03,Greece,Nigeria,0,0,Friendly,Chester,United States,TRUE
+2014-06-03,Mexico,Bosnia and Herzegovina,0,1,Friendly,Chicago,United States,TRUE
 2014-06-03,Switzerland,Peru,2,0,Friendly,Lucerne,Switzerland,FALSE
 2014-06-03,Tamil Eelam,Iraqi Kurdistan,0,9,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-03,Sápmi,Occitania,0,1,CONIFA World Football Cup,Östersund,Sweden,FALSE
 2014-06-03,South Ossetia,Padania,1,3,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-03,Artsakh,County of Nice,0,1,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-04,Argentina,Trinidad and Tobago,3,0,Friendly,Buenos Aires,Argentina,FALSE
-2014-06-04,Ecuador,England,2,2,Friendly,Miami Gardens,USA,TRUE
-2014-06-04,El Salvador,Ivory Coast,1,2,Friendly,Frisco,USA,TRUE
+2014-06-04,Ecuador,England,2,2,Friendly,Miami Gardens,United States,TRUE
+2014-06-04,El Salvador,Ivory Coast,1,2,Friendly,Frisco,United States,TRUE
 2014-06-04,Gibraltar,Malta,1,0,Friendly,Faro,Portugal,TRUE
 2014-06-04,Hungary,Albania,1,0,Friendly,Budapest,Hungary,FALSE
 2014-06-04,Iceland,Estonia,1,0,Friendly,Reykjavík,Iceland,FALSE
@@ -36394,14 +36394,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-05,Darfur,Artsakh,0,12,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-05,Padania,Abkhazia,3,3,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-05,Occitania,Iraqi Kurdistan,2,2,CONIFA World Football Cup,Östersund,Sweden,TRUE
-2014-06-06,Bolivia,Greece,1,2,Friendly,Harrison,USA,TRUE
+2014-06-06,Bolivia,Greece,1,2,Friendly,Harrison,United States,TRUE
 2014-06-06,Brazil,Serbia,1,0,Friendly,São Paulo,Brazil,FALSE
 2014-06-06,Colombia,Jordan,3,0,Friendly,Buenos Aires,Argentina,TRUE
-2014-06-06,Costa Rica,Republic of Ireland,1,1,Friendly,Chester,USA,TRUE
+2014-06-06,Costa Rica,Republic of Ireland,1,1,Friendly,Chester,United States,TRUE
 2014-06-06,Croatia,Australia,1,0,Friendly,Salvador,Brazil,TRUE
 2014-06-06,Germany,Armenia,6,1,Friendly,Mainz,Germany,FALSE
-2014-06-06,Japan,Zambia,4,3,Friendly,Tampa,USA,TRUE
-2014-06-06,Mexico,Portugal,0,1,Friendly,Foxborough,USA,TRUE
+2014-06-06,Japan,Zambia,4,3,Friendly,Tampa,United States,TRUE
+2014-06-06,Mexico,Portugal,0,1,Friendly,Foxborough,United States,TRUE
 2014-06-06,Poland,Lithuania,2,1,Friendly,Gdańsk,Poland,FALSE
 2014-06-06,Russia,Morocco,2,0,Friendly,Moscow,Russia,FALSE
 2014-06-06,County of Nice,South Ossetia,3,0,CONIFA World Football Cup,Östersund,Sweden,TRUE
@@ -36409,11 +36409,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-07,Argentina,Slovenia,2,0,Friendly,La Plata,Argentina,FALSE
 2014-06-07,Belgium,Tunisia,1,0,Friendly,Brussels,Belgium,FALSE
 2014-06-07,Cameroon,Moldova,1,0,Friendly,Yaoundé,Cameroon,FALSE
-2014-06-07,El Salvador,Spain,0,2,Friendly,Landover,USA,TRUE
+2014-06-07,El Salvador,Spain,0,2,Friendly,Landover,United States,TRUE
 2014-06-07,Estonia,Tajikistan,2,1,Friendly,Tallinn,Estonia,FALSE
-2014-06-07,Honduras,England,0,0,Friendly,Miami Gardens,USA,TRUE
+2014-06-07,Honduras,England,0,0,Friendly,Miami Gardens,United States,TRUE
 2014-06-07,Hungary,Kazakhstan,3,0,Friendly,Budapest,Hungary,FALSE
-2014-06-07,USA,Nigeria,2,1,Friendly,Jacksonville,USA,FALSE
+2014-06-07,United States,Nigeria,2,1,Friendly,Jacksonville,United States,FALSE
 2014-06-07,Sápmi,Artsakh,1,5,CONIFA World Football Cup,Östersund,Sweden,FALSE
 2014-06-07,Tamil Eelam,Darfur,10,0,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-07,Abkhazia,Occitania,0,1,CONIFA World Football Cup,Östersund,Sweden,TRUE
@@ -36423,8 +36423,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-08,San Marino,Albania,0,3,Friendly,Serravalle,San Marino,FALSE
 2014-06-08,South Ossetia,Arameans Suryoye,1,4,CONIFA World Football Cup,Östersund,Sweden,TRUE
 2014-06-08,County of Nice,Ellan Vannin,0,0,CONIFA World Football Cup,Östersund,Sweden,TRUE
-2014-06-09,Ghana,South Korea,4,0,Friendly,Miami Gardens,USA,TRUE
-2014-06-10,Republic of Ireland,Portugal,1,5,Friendly,East Rutherford,USA,TRUE
+2014-06-09,Ghana,South Korea,4,0,Friendly,Miami Gardens,United States,TRUE
+2014-06-10,Republic of Ireland,Portugal,1,5,Friendly,East Rutherford,United States,TRUE
 2014-06-12,Brazil,Croatia,3,1,FIFA World Cup,São Paulo,Brazil,FALSE
 2014-06-13,Chile,Australia,3,1,FIFA World Cup,Cuiabá,Brazil,TRUE
 2014-06-13,Mexico,Cameroon,1,0,FIFA World Cup,Natal,Brazil,TRUE
@@ -36437,7 +36437,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-15,France,Honduras,3,0,FIFA World Cup,Porto Alegre,Brazil,TRUE
 2014-06-15,Switzerland,Ecuador,2,1,FIFA World Cup,Brasília,Brazil,TRUE
 2014-06-16,Germany,Portugal,4,0,FIFA World Cup,Salvador,Brazil,TRUE
-2014-06-16,Ghana,USA,1,2,FIFA World Cup,Natal,Brazil,TRUE
+2014-06-16,Ghana,United States,1,2,FIFA World Cup,Natal,Brazil,TRUE
 2014-06-16,Iran,Nigeria,0,0,FIFA World Cup,Curitiba,Brazil,TRUE
 2014-06-17,Belgium,Algeria,2,1,FIFA World Cup,Belo Horizonte,Brazil,TRUE
 2014-06-17,Brazil,Mexico,0,0,FIFA World Cup,Fortaleza,Brazil,FALSE
@@ -36459,7 +36459,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-22,Belgium,Russia,1,0,FIFA World Cup,Rio de Janeiro,Brazil,TRUE
 2014-06-22,China PR,North Macedonia,0,0,Friendly,Jinan,China PR,FALSE
 2014-06-22,South Korea,Algeria,2,4,FIFA World Cup,Porto Alegre,Brazil,TRUE
-2014-06-22,USA,Portugal,2,2,FIFA World Cup,Manaus,Brazil,TRUE
+2014-06-22,United States,Portugal,2,2,FIFA World Cup,Manaus,Brazil,TRUE
 2014-06-23,Australia,Spain,0,3,FIFA World Cup,Curitiba,Brazil,TRUE
 2014-06-23,Brazil,Cameroon,4,1,FIFA World Cup,Brasília,Brazil,FALSE
 2014-06-23,Croatia,Mexico,1,3,FIFA World Cup,Recife,Brazil,TRUE
@@ -36476,7 +36476,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-26,Algeria,Russia,1,1,FIFA World Cup,Curitiba,Brazil,TRUE
 2014-06-26,South Korea,Belgium,0,1,FIFA World Cup,São Paulo,Brazil,TRUE
 2014-06-26,Portugal,Ghana,2,1,FIFA World Cup,Brasília,Brazil,TRUE
-2014-06-26,USA,Germany,0,1,FIFA World Cup,Recife,Brazil,TRUE
+2014-06-26,United States,Germany,0,1,FIFA World Cup,Recife,Brazil,TRUE
 2014-06-28,Brazil,Chile,1,1,FIFA World Cup,Belo Horizonte,Brazil,FALSE
 2014-06-28,Colombia,Uruguay,2,0,FIFA World Cup,Rio de Janeiro,Brazil,TRUE
 2014-06-29,China PR,Mali,1,3,Friendly,Shenzhen,China PR,FALSE
@@ -36485,7 +36485,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-06-30,France,Nigeria,2,0,FIFA World Cup,Brasília,Brazil,TRUE
 2014-06-30,Germany,Algeria,2,1,FIFA World Cup,Porto Alegre,Brazil,TRUE
 2014-07-01,Argentina,Switzerland,1,0,FIFA World Cup,São Paulo,Brazil,TRUE
-2014-07-01,Belgium,USA,2,1,FIFA World Cup,Salvador,Brazil,TRUE
+2014-07-01,Belgium,United States,2,1,FIFA World Cup,Salvador,Brazil,TRUE
 2014-07-02,Vietnam,Myanmar,6,0,Friendly,Thủ Dầu Một,Vietnam,FALSE
 2014-07-04,Brazil,Colombia,2,1,FIFA World Cup,Fortaleza,Brazil,FALSE
 2014-07-04,France,Germany,0,1,FIFA World Cup,Rio de Janeiro,Brazil,TRUE
@@ -36541,8 +36541,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-08-31,Zambia,Sudan,3,1,Friendly,Lusaka,Zambia,FALSE
 2014-09-02,Niger,Uganda,2,0,Friendly,Niamey,Niger,FALSE
 2014-09-03,Myanmar,Palestine,4,1,Friendly,Manila,Philippines,TRUE
-2014-09-03,Costa Rica,Nicaragua,3,0,UNCAF Cup,Washington,USA,TRUE
-2014-09-03,Czech Republic,USA,0,1,Friendly,Prague,Czech Republic,FALSE
+2014-09-03,Costa Rica,Nicaragua,3,0,UNCAF Cup,Washington,United States,TRUE
+2014-09-03,Czech Republic,United States,0,1,Friendly,Prague,Czech Republic,FALSE
 2014-09-03,Denmark,Turkey,1,2,Friendly,Odense,Denmark,FALSE
 2014-09-03,England,Norway,1,0,Friendly,London,England,FALSE
 2014-09-03,Germany,Argentina,2,4,Friendly,Düsseldorf,Germany,FALSE
@@ -36585,7 +36585,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-09-06,Gabon,Angola,1,0,African Cup of Nations qualification,Libreville,Gabon,FALSE
 2014-09-06,Ghana,Uganda,1,1,African Cup of Nations qualification,Kumasi,Ghana,FALSE
 2014-09-06,Ivory Coast,Sierra Leone,2,1,African Cup of Nations qualification,Abidjan,Ivory Coast,FALSE
-2014-09-06,Mexico,Chile,0,0,Friendly,Santa Clara,USA,TRUE
+2014-09-06,Mexico,Chile,0,0,Friendly,Santa Clara,United States,TRUE
 2014-09-06,Niger,Cape Verde,1,3,African Cup of Nations qualification,Niamey,Niger,FALSE
 2014-09-06,Nigeria,Congo,2,3,African Cup of Nations qualification,Calabar,Nigeria,FALSE
 2014-09-06,Palestine,Taiwan,7,3,Friendly,Manila,Philippines,TRUE
@@ -36596,7 +36596,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-09-06,Zambia,Mozambique,0,0,African Cup of Nations qualification,Ndola,Zambia,FALSE
 2014-09-07,Bonaire,Barbados,1,4,CFU Caribbean Cup qualification,Fort-de-France,Martinique,TRUE
 2014-09-07,Burundi,Tanzania,2,0,Friendly,Bujumbura,Burundi,FALSE
-2014-09-07,Costa Rica,Panama,2,2,UNCAF Cup,Dallas,USA,TRUE
+2014-09-07,Costa Rica,Panama,2,2,UNCAF Cup,Dallas,United States,TRUE
 2014-09-07,Denmark,Armenia,2,1,UEFA Euro qualification,Copenhagen,Denmark,FALSE
 2014-09-07,Dominica,Saint Lucia,1,2,CFU Caribbean Cup qualification,Basseterre,Saint Kitts and Nevis,TRUE
 2014-09-07,Faroe Islands,Finland,1,3,UEFA Euro qualification,Tórshavn,Faroe Islands,FALSE
@@ -36631,13 +36631,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-09-09,China PR,Jordan,1,1,Friendly,Harbin,China PR,FALSE
 2014-09-09,Croatia,Malta,2,0,UEFA Euro qualification,Zagreb,Croatia,FALSE
 2014-09-09,Czech Republic,Netherlands,2,1,UEFA Euro qualification,Prague,Czech Republic,FALSE
-2014-09-09,Haiti,Chile,0,1,Friendly,Fort Lauderdale,USA,TRUE
+2014-09-09,Haiti,Chile,0,1,Friendly,Fort Lauderdale,United States,TRUE
 2014-09-09,Iceland,Turkey,3,0,UEFA Euro qualification,Reykjavík,Iceland,FALSE
 2014-09-09,Indonesia,Yemen,0,0,Friendly,Yogyakarta,Indonesia,FALSE
 2014-09-09,Japan,Venezuela,2,2,Friendly,Yokohama,Japan,FALSE
 2014-09-09,Kazakhstan,Latvia,0,0,UEFA Euro qualification,Astana,Kazakhstan,FALSE
 2014-09-09,Kuwait,Bahrain,0,1,Friendly,Al Farwaniyah,Kuwait,FALSE
-2014-09-09,Mexico,Bolivia,1,0,Friendly,Commerce City,USA,TRUE
+2014-09-09,Mexico,Bolivia,1,0,Friendly,Commerce City,United States,TRUE
 2014-09-09,Norway,Italy,0,2,UEFA Euro qualification,Oslo,Norway,FALSE
 2014-09-09,Qatar,Peru,0,2,Friendly,Doha,Qatar,FALSE
 2014-09-09,Singapore,Hong Kong,0,0,Friendly,Hougang,Singapore,FALSE
@@ -36775,7 +36775,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-10-14,Saudi Arabia,Lebanon,1,1,Friendly,Jeddah,Saudi Arabia,FALSE
 2014-10-14,Serbia,Albania,0,3,UEFA Euro qualification,Belgrade,Serbia,FALSE
 2014-10-14,United Arab Emirates,Uzbekistan,0,4,Friendly,Dubai,United Arab Emirates,FALSE
-2014-10-14,USA,Honduras,1,1,Friendly,Boca Raton,USA,FALSE
+2014-10-14,United States,Honduras,1,1,Friendly,Boca Raton,United States,FALSE
 2014-10-15,Algeria,Malawi,3,0,African Cup of Nations qualification,Blida,Algeria,FALSE
 2014-10-15,Angola,Lesotho,4,0,African Cup of Nations qualification,Luanda,Angola,FALSE
 2014-10-15,Burkina Faso,Gabon,1,1,African Cup of Nations qualification,Ouagadougou,Burkina Faso,FALSE
@@ -36847,7 +36847,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-11-14,Scotland,Republic of Ireland,1,0,UEFA Euro qualification,Glasgow,Scotland,FALSE
 2014-11-14,Serbia,Denmark,1,3,UEFA Euro qualification,Belgrade,Serbia,FALSE
 2014-11-14,United Arab Emirates,Oman,0,0,Gulf Cup,Riyadh,Saudi Arabia,TRUE
-2014-11-14,USA,Colombia,1,2,Friendly,London,England,TRUE
+2014-11-14,United States,Colombia,1,2,Friendly,London,England,TRUE
 2014-11-15,Algeria,Ethiopia,3,1,African Cup of Nations qualification,Blida,Algeria,FALSE
 2014-11-15,Angola,Gabon,0,0,African Cup of Nations qualification,Luanda,Angola,FALSE
 2014-11-15,Austria,Russia,1,0,UEFA Euro qualification,Vienna,Austria,FALSE
@@ -36901,7 +36901,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2014-11-18,Greece,Serbia,0,2,Friendly,Perivólia,Greece,FALSE
 2014-11-18,Hungary,Russia,1,2,Friendly,Budapest,Hungary,FALSE
 2014-11-18,Iran,South Korea,1,0,Friendly,Tehran,Iran,FALSE
-2014-11-18,Republic of Ireland,USA,4,1,Friendly,Dublin,Republic of Ireland,FALSE
+2014-11-18,Republic of Ireland,United States,4,1,Friendly,Dublin,Republic of Ireland,FALSE
 2014-11-18,Italy,Albania,1,0,Friendly,Genoa,Italy,FALSE
 2014-11-18,Jamaica,Trinidad and Tobago,0,0,CFU Caribbean Cup,Montego Bay,Jamaica,FALSE
 2014-11-18,Japan,Australia,2,1,Friendly,Osaka,Japan,FALSE
@@ -36999,7 +36999,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-01-15,Bahrain,United Arab Emirates,1,2,AFC Asian Cup,Canberra,Australia,TRUE
 2015-01-15,Qatar,Iran,0,1,AFC Asian Cup,Sydney,Australia,TRUE
 2015-01-15,Sweden,Ivory Coast,2,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
-2015-01-16,Canada,Iceland,1,2,Friendly,Orlando,USA,TRUE
+2015-01-16,Canada,Iceland,1,2,Friendly,Orlando,United States,TRUE
 2015-01-16,Iraq,Japan,0,1,AFC Asian Cup,Brisbane,Australia,TRUE
 2015-01-16,Palestine,Jordan,1,5,AFC Asian Cup,Melbourne,Australia,TRUE
 2015-01-17,Australia,South Korea,0,1,AFC Asian Cup,Brisbane,Australia,FALSE
@@ -37012,7 +37012,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-01-18,Uzbekistan,Saudi Arabia,3,1,AFC Asian Cup,Melbourne,Australia,TRUE
 2015-01-18,Zambia,DR Congo,1,1,African Cup of Nations,Ebebiyín,Equatorial Guinea,TRUE
 2015-01-19,Algeria,South Africa,3,1,African Cup of Nations,Mongomo,Equatorial Guinea,TRUE
-2015-01-19,Canada,Iceland,1,1,Friendly,Orlando,USA,TRUE
+2015-01-19,Canada,Iceland,1,1,Friendly,Orlando,United States,TRUE
 2015-01-19,Finland,Sweden,1,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
 2015-01-19,Ghana,Senegal,1,2,African Cup of Nations,Mongomo,Equatorial Guinea,TRUE
 2015-01-19,Iran,United Arab Emirates,1,0,AFC Asian Cup,Brisbane,Australia,TRUE
@@ -37043,7 +37043,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-01-27,Senegal,Algeria,0,2,African Cup of Nations,Malabo,Equatorial Guinea,TRUE
 2015-01-27,South Africa,Ghana,1,2,African Cup of Nations,Mongomo,Equatorial Guinea,TRUE
 2015-01-28,Cameroon,Ivory Coast,0,1,African Cup of Nations,Malabo,Equatorial Guinea,TRUE
-2015-01-28,Chile,USA,3,2,Friendly,Rancagua,Chile,FALSE
+2015-01-28,Chile,United States,3,2,Friendly,Rancagua,Chile,FALSE
 2015-01-28,Guinea,Mali,1,1,African Cup of Nations,Mongomo,Equatorial Guinea,TRUE
 2015-01-30,Curaçao,Aruba,0,0,ABCS Tournament,Paramaribo,Suriname,TRUE
 2015-01-30,Iraq,United Arab Emirates,2,3,AFC Asian Cup,Newcastle,Australia,TRUE
@@ -37062,9 +37062,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-02-06,Pakistan,Afghanistan,2,1,Friendly,Lahore,Pakistan,FALSE
 2015-02-07,Equatorial Guinea,DR Congo,0,0,African Cup of Nations,Malabo,Equatorial Guinea,FALSE
 2015-02-08,Ivory Coast,Ghana,0,0,African Cup of Nations,Bata,Equatorial Guinea,TRUE
-2015-02-08,USA,Panama,2,0,Friendly,Carson,USA,FALSE
+2015-02-08,United States,Panama,2,0,Friendly,Carson,United States,FALSE
 2015-02-18,Kazakhstan,Moldova,1,1,Friendly,Antalya,Turkey,TRUE
-2015-03-08,Antigua and Barbuda,USA Virgin Islands,2,0,Friendly,St. John's,Antigua and Barbuda,FALSE
+2015-03-08,Antigua and Barbuda,United States Virgin Islands,2,0,Friendly,St. John's,Antigua and Barbuda,FALSE
 2015-03-08,Bermuda,Grenada,2,0,Friendly,Hamilton,Bermuda,FALSE
 2015-03-12,Cambodia,Macau,3,0,FIFA World Cup qualification,Phnom Penh,Cambodia,FALSE
 2015-03-12,Timor-Leste,Mongolia,0,3,FIFA World Cup qualification,Dili,East Timor,FALSE
@@ -37078,10 +37078,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-03-17,Mongolia,Timor-Leste,3,0,FIFA World Cup qualification,Ulan Bator,Mongolia,FALSE
 2015-03-17,Nepal,India,0,0,FIFA World Cup qualification,Kathmandu,Nepal,FALSE
 2015-03-22,Antigua and Barbuda,British Virgin Islands,1,0,Friendly,St. John's,Antigua and Barbuda,FALSE
-2015-03-22,Barbados,USA Virgin Islands,0,1,FIFA World Cup qualification,Bridgetown,Barbados,FALSE
+2015-03-22,Barbados,United States Virgin Islands,0,1,FIFA World Cup qualification,Bridgetown,Barbados,FALSE
 2015-03-23,Pakistan,Yemen,0,0,FIFA World Cup qualification,Isa Town,Bahrain,TRUE
 2015-03-25,Botswana,Lesotho,2,0,Friendly,Gaborone,Botswana,FALSE
-2015-03-25,Denmark,USA,3,2,Friendly,Aarhus,Denmark,FALSE
+2015-03-25,Denmark,United States,3,2,Friendly,Aarhus,Denmark,FALSE
 2015-03-25,Dominican Republic,Cuba,0,3,Friendly,Santiago de los Caballeros,Dominican Republic,FALSE
 2015-03-25,French Guiana,Honduras,3,1,Gold Cup qualification,Cayenne,French Guiana,FALSE
 2015-03-25,Gabon,Mali,4,3,Friendly,Beauvais,France,TRUE
@@ -37102,8 +37102,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-03-26,Oman,Malaysia,6,0,Friendly,Seeb,Oman,FALSE
 2015-03-26,Qatar,Algeria,1,0,Friendly,Doha,Qatar,FALSE
 2015-03-26,Thailand,Singapore,2,0,Friendly,Nakhon Ratchasima,Thailand,FALSE
-2015-03-26,USA Virgin Islands,Barbados,0,4,FIFA World Cup qualification,Charlotte Amalie,USA Virgin Islands,FALSE
-2015-03-27,Canada,Guatemala,1,0,Friendly,Fort Lauderdale,USA,TRUE
+2015-03-26,United States Virgin Islands,Barbados,0,4,FIFA World Cup qualification,Charlotte Amalie,United States Virgin Islands,FALSE
+2015-03-27,Canada,Guatemala,1,0,Friendly,Fort Lauderdale,United States,TRUE
 2015-03-27,China PR,Haiti,2,2,Friendly,Changsha,China PR,FALSE
 2015-03-27,Curaçao,Montserrat,2,1,FIFA World Cup qualification,Willemstad,Curaçao,FALSE
 2015-03-27,England,Lithuania,4,0,UEFA Euro qualification,London,England,FALSE
@@ -37177,16 +37177,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-03-31,Montserrat,Curaçao,2,2,FIFA World Cup qualification,Lookout,Montserrat,FALSE
 2015-03-31,Netherlands,Spain,2,0,Friendly,Amsterdam,Netherlands,FALSE
 2015-03-31,Panama,Costa Rica,2,1,Friendly,Panama City,Panama,FALSE
-2015-03-31,Peru,Venezuela,0,1,Friendly,Fort Lauderdale,USA,TRUE
+2015-03-31,Peru,Venezuela,0,1,Friendly,Fort Lauderdale,United States,TRUE
 2015-03-31,Portugal,Cape Verde,0,2,Friendly,Estoril,Portugal,FALSE
 2015-03-31,Russia,Kazakhstan,0,0,Friendly,Khimki,Russia,FALSE
 2015-03-31,Singapore,Guam,2,2,Friendly,Kallang,Singapore,FALSE
 2015-03-31,Slovakia,Czech Republic,1,0,Friendly,Žilina,Slovakia,FALSE
 2015-03-31,Sweden,Iran,3,1,Friendly,Solna,Sweden,FALSE
-2015-03-31,Switzerland,USA,1,1,Friendly,Zürich,Switzerland,FALSE
+2015-03-31,Switzerland,United States,1,1,Friendly,Zürich,Switzerland,FALSE
 2015-03-31,Tajikistan,Syria,2,3,Friendly,Dushanbe,Tajikistan,FALSE
 2015-03-31,Ukraine,Latvia,1,1,Friendly,Lviv,Ukraine,FALSE
-2015-04-15,USA,Mexico,2,0,Friendly,San Antonio,USA,FALSE
+2015-04-15,United States,Mexico,2,0,Friendly,San Antonio,United States,FALSE
 2015-05-10,Barbados,Saint Kitts and Nevis,1,3,Friendly,Bridgetown,Barbados,FALSE
 2015-05-10,Zambia,Malawi,2,0,Friendly,Lusaka,Zambia,FALSE
 2015-05-12,Kazakhstan,Burkina Faso,0,0,Friendly,Almaty,Kazakhstan,FALSE
@@ -37229,7 +37229,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-05-30,Madagascar,Botswana,2,1,COSAFA Cup,Moruleng-Saulspoort,South Africa,TRUE
 2015-05-30,Mexico,Guatemala,3,0,Friendly,Tuxtla Gutiérrez,Mexico,FALSE
 2015-05-30,Namibia,Mozambique,2,0,COSAFA Cup,Moruleng-Saulspoort,South Africa,TRUE
-2015-05-31,El Salvador,Honduras,0,2,Friendly,Washington,USA,TRUE
+2015-05-31,El Salvador,Honduras,0,2,Friendly,Washington,United States,TRUE
 2015-05-31,Northern Ireland,Qatar,1,1,Friendly,Crewe,England,TRUE
 2015-06-02,Bangladesh,Afghanistan,1,1,Friendly,Dhaka,Bangladesh,FALSE
 2015-06-02,Cambodia,Laos,1,1,Friendly,Phnom Penh,Cambodia,FALSE
@@ -37238,7 +37238,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-06-05,Curaçao,Trinidad and Tobago,1,0,Friendly,Willemstad,Curaçao,FALSE
 2015-06-05,Hungary,Lithuania,4,0,Friendly,Debrecen,Hungary,FALSE
 2015-06-05,Jordan,Kuwait,2,2,Friendly,Istanbul,Turkey,TRUE
-2015-06-05,Netherlands,USA,3,4,Friendly,Amsterdam,Netherlands,FALSE
+2015-06-05,Netherlands,United States,3,4,Friendly,Amsterdam,Netherlands,FALSE
 2015-06-05,Oman,Syria,1,2,Friendly,Muscat,Oman,FALSE
 2015-06-05,Scotland,Qatar,1,0,Friendly,Edinburgh,Scotland,FALSE
 2015-06-05,Thailand,Bahrain,1,1,Friendly,Bangkok,Thailand,FALSE
@@ -37275,7 +37275,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-06-09,Uganda,Gambia,1,1,Friendly,Kampala,Uganda,FALSE
 2015-06-10,Brazil,Honduras,1,0,Friendly,Porto Alegre,Brazil,FALSE
 2015-06-10,Curaçao,Cuba,0,0,FIFA World Cup qualification,Willemstad,Curaçao,FALSE
-2015-06-10,Germany,USA,1,2,Friendly,Cologne,Germany,FALSE
+2015-06-10,Germany,United States,1,2,Friendly,Cologne,Germany,FALSE
 2015-06-10,Switzerland,Liechtenstein,3,0,Friendly,Thun,Switzerland,FALSE
 2015-06-11,Afghanistan,Syria,0,6,FIFA World Cup qualification,Mashhad,Iran,TRUE
 2015-06-11,Bangladesh,Kyrgyzstan,1,3,FIFA World Cup qualification,Dhaka,Bangladesh,FALSE
@@ -37418,7 +37418,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-06-25,Bolivia,Peru,1,3,Copa América,Temuco,Chile,TRUE
 2015-06-26,Argentina,Colombia,0,0,Copa América,Viña del Mar,Chile,TRUE
 2015-06-27,Brazil,Paraguay,1,1,Copa América,Concepción,Chile,TRUE
-2015-06-27,Mexico,Costa Rica,2,2,Friendly,Orlando,USA,TRUE
+2015-06-27,Mexico,Costa Rica,2,2,Friendly,Orlando,United States,TRUE
 2015-06-28,Greenland,Menorca,2,2,Island Games,Grouville,Jersey,TRUE
 2015-06-28,Saare County,Åland Islands,1,2,Island Games,Grouville,Jersey,TRUE
 2015-06-28,Gibraltar,Gotland,2,1,Island Games,St. Peter,Jersey,TRUE
@@ -37445,7 +37445,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-06-30,Falkland Islands,Shetland,0,5,Island Games,St. Peter,Jersey,TRUE
 2015-06-30,Jersey,Isle of Man,1,2,Island Games,St. John,Jersey,FALSE
 2015-06-30,Alderney,Western Isles,2,3,Island Games,St. Peter,Jersey,TRUE
-2015-07-01,Honduras,Mexico,0,0,Friendly,Houston,USA,TRUE
+2015-07-01,Honduras,Mexico,0,0,Friendly,Houston,United States,TRUE
 2015-07-02,Hitra,Alderney,5,1,Island Games,St. Ouen,Jersey,TRUE
 2015-07-02,Gotland,Saare County,2,3,Island Games,St. Ouen,Jersey,TRUE
 2015-07-02,Falkland Islands,Western Isles,1,2,Island Games,St. Brelade,Jersey,TRUE
@@ -37461,32 +37461,32 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-07-04,Chile,Argentina,0,0,Copa América,Santiago,Chile,FALSE
 2015-07-04,Zambia,Namibia,2,1,African Nations Championship,Lusaka,Zambia,FALSE
 2015-07-06,Malawi,Uganda,1,0,Friendly,Blantyre,Malawi,FALSE
-2015-07-07,Panama,Haiti,1,1,Gold Cup,Frisco,USA,TRUE
-2015-07-07,USA,Honduras,2,1,Gold Cup,Frisco,USA,FALSE
-2015-07-08,Costa Rica,Jamaica,2,2,Gold Cup,Carson,USA,TRUE
-2015-07-08,El Salvador,Canada,0,0,Gold Cup,Carson,USA,TRUE
-2015-07-09,Mexico,Cuba,6,0,Gold Cup,Chicago,USA,TRUE
-2015-07-09,Trinidad and Tobago,Guatemala,3,1,Gold Cup,Chicago,USA,TRUE
-2015-07-10,Honduras,Panama,1,1,Gold Cup,Foxborough,USA,TRUE
-2015-07-10,USA,Haiti,1,0,Gold Cup,Foxborough,USA,FALSE
-2015-07-11,Costa Rica,El Salvador,1,1,Gold Cup,Houston,USA,TRUE
-2015-07-11,Jamaica,Canada,1,0,Gold Cup,Houston,USA,TRUE
-2015-07-12,Guatemala,Mexico,0,0,Gold Cup,Glendale,USA,TRUE
-2015-07-12,Trinidad and Tobago,Cuba,2,0,Gold Cup,Glendale,USA,TRUE
-2015-07-13,Honduras,Haiti,0,1,Gold Cup,Kansas City,USA,TRUE
-2015-07-13,USA,Panama,1,1,Gold Cup,Kansas City,USA,FALSE
+2015-07-07,Panama,Haiti,1,1,Gold Cup,Frisco,United States,TRUE
+2015-07-07,United States,Honduras,2,1,Gold Cup,Frisco,United States,FALSE
+2015-07-08,Costa Rica,Jamaica,2,2,Gold Cup,Carson,United States,TRUE
+2015-07-08,El Salvador,Canada,0,0,Gold Cup,Carson,United States,TRUE
+2015-07-09,Mexico,Cuba,6,0,Gold Cup,Chicago,United States,TRUE
+2015-07-09,Trinidad and Tobago,Guatemala,3,1,Gold Cup,Chicago,United States,TRUE
+2015-07-10,Honduras,Panama,1,1,Gold Cup,Foxborough,United States,TRUE
+2015-07-10,United States,Haiti,1,0,Gold Cup,Foxborough,United States,FALSE
+2015-07-11,Costa Rica,El Salvador,1,1,Gold Cup,Houston,United States,TRUE
+2015-07-11,Jamaica,Canada,1,0,Gold Cup,Houston,United States,TRUE
+2015-07-12,Guatemala,Mexico,0,0,Gold Cup,Glendale,United States,TRUE
+2015-07-12,Trinidad and Tobago,Cuba,2,0,Gold Cup,Glendale,United States,TRUE
+2015-07-13,Honduras,Haiti,0,1,Gold Cup,Kansas City,United States,TRUE
+2015-07-13,United States,Panama,1,1,Gold Cup,Kansas City,United States,FALSE
 2015-07-14,Canada,Costa Rica,0,0,Gold Cup,Toronto,Canada,FALSE
 2015-07-14,Jamaica,El Salvador,1,0,Gold Cup,Toronto,Canada,TRUE
-2015-07-15,Guatemala,Cuba,0,1,Gold Cup,Charlotte,USA,TRUE
-2015-07-15,Trinidad and Tobago,Mexico,4,4,Gold Cup,Charlotte,USA,TRUE
-2015-07-18,Haiti,Jamaica,0,1,Gold Cup,Baltimore,USA,TRUE
-2015-07-18,USA,Cuba,6,0,Gold Cup,Baltimore,USA,FALSE
-2015-07-19,Mexico,Costa Rica,1,0,Gold Cup,East Rutherford,USA,TRUE
-2015-07-19,Trinidad and Tobago,Panama,1,1,Gold Cup,East Rutherford,USA,TRUE
-2015-07-22,Panama,Mexico,1,2,Gold Cup,Atlanta,USA,TRUE
-2015-07-22,USA,Jamaica,1,2,Gold Cup,Atlanta,USA,FALSE
-2015-07-25,USA,Panama,1,1,Gold Cup,Chester,USA,FALSE
-2015-07-26,Jamaica,Mexico,1,3,Gold Cup,Philadelphia,USA,TRUE
+2015-07-15,Guatemala,Cuba,0,1,Gold Cup,Charlotte,United States,TRUE
+2015-07-15,Trinidad and Tobago,Mexico,4,4,Gold Cup,Charlotte,United States,TRUE
+2015-07-18,Haiti,Jamaica,0,1,Gold Cup,Baltimore,United States,TRUE
+2015-07-18,United States,Cuba,6,0,Gold Cup,Baltimore,United States,FALSE
+2015-07-19,Mexico,Costa Rica,1,0,Gold Cup,East Rutherford,United States,TRUE
+2015-07-19,Trinidad and Tobago,Panama,1,1,Gold Cup,East Rutherford,United States,TRUE
+2015-07-22,Panama,Mexico,1,2,Gold Cup,Atlanta,United States,TRUE
+2015-07-22,United States,Jamaica,1,2,Gold Cup,Atlanta,United States,FALSE
+2015-07-25,United States,Panama,1,1,Gold Cup,Chester,United States,FALSE
+2015-07-26,Jamaica,Mexico,1,3,Gold Cup,Philadelphia,United States,TRUE
 2015-08-02,China PR,South Korea,0,2,EAFF Championship,Wuhan,China PR,FALSE
 2015-08-02,North Korea,Japan,2,1,EAFF Championship,Wuhan,China PR,TRUE
 2015-08-05,China PR,North Korea,2,0,EAFF Championship,Wuhan,China PR,FALSE
@@ -37557,7 +37557,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-09-05,Botswana,Burkina Faso,1,0,African Cup of Nations qualification,Francistown,Botswana,FALSE
 2015-09-05,Chile,Paraguay,3,2,Friendly,Santiago,Chile,FALSE
 2015-09-05,Comoros,Uganda,0,1,African Cup of Nations qualification,Mitsamiouli,Comoros,FALSE
-2015-09-05,Costa Rica,Brazil,0,1,Friendly,Harrison,USA,TRUE
+2015-09-05,Costa Rica,Brazil,0,1,Friendly,Harrison,United States,TRUE
 2015-09-05,Estonia,Lithuania,1,0,UEFA Euro qualification,Tallinn,Estonia,FALSE
 2015-09-05,Gabon,Sudan,4,0,Friendly,Libreville,Gabon,FALSE
 2015-09-05,Guinea-Bissau,Congo,2,4,African Cup of Nations qualification,Bissau,Guinea-Bissau,FALSE
@@ -37620,7 +37620,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-09-08,Lithuania,San Marino,2,1,UEFA Euro qualification,Vilnius,Lithuania,FALSE
 2015-09-08,North Macedonia,Spain,0,1,UEFA Euro qualification,Skopje,North Macedonia,FALSE
 2015-09-08,Malaysia,Saudi Arabia,0,3,FIFA World Cup qualification,Shah Alam,Malaysia,FALSE
-2015-09-08,Mexico,Argentina,2,2,Friendly,Arlington,USA,TRUE
+2015-09-08,Mexico,Argentina,2,2,Friendly,Arlington,United States,TRUE
 2015-09-08,Moldova,Montenegro,0,2,UEFA Euro qualification,Chișinău,Moldova,FALSE
 2015-09-08,Nigeria,Niger,2,0,Friendly,Port Harcourt,Nigeria,FALSE
 2015-09-08,Palestine,United Arab Emirates,0,0,FIFA World Cup qualification,Al-Ram,Palestine,FALSE
@@ -37706,7 +37706,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-10-10,Kosovo,Equatorial Guinea,2,0,Friendly,Pristina,Kosovo,FALSE
 2015-10-10,Madagascar,Central African Republic,3,0,FIFA World Cup qualification,Antananarivo,Madagascar,FALSE
 2015-10-10,Norway,Malta,2,0,UEFA Euro qualification,Oslo,Norway,FALSE
-2015-10-10,USA,Mexico,2,3,Friendly,Pasadena,USA,FALSE
+2015-10-10,United States,Mexico,2,3,Friendly,Pasadena,United States,FALSE
 2015-10-11,Armenia,Albania,0,3,UEFA Euro qualification,Yerevan,Armenia,FALSE
 2015-10-11,Denmark,France,1,2,Friendly,Copenhagen,Denmark,FALSE
 2015-10-11,Egypt,Zambia,3,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
@@ -37745,7 +37745,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2015-10-13,Cyprus,Bosnia and Herzegovina,2,3,UEFA Euro qualification,Nicosia,Cyprus,FALSE
 2015-10-13,Timor-Leste,Malaysia,0,3,FIFA World Cup qualification,Dili,East Timor,FALSE
 2015-10-13,Ecuador,Bolivia,2,0,FIFA World Cup qualification,Quito,Ecuador,FALSE
-2015-10-13,El Salvador,Guatemala,1,1,Friendly,Carson,USA,TRUE
+2015-10-13,El Salvador,Guatemala,1,1,Friendly,Carson,United States,TRUE
 2015-10-13,Guinea-Bissau,Liberia,1,3,FIFA World Cup qualification,Bissau,Guinea-Bissau,FALSE
 2015-10-13,Iran,Japan,1,1,Friendly,Tehran,Iran,FALSE
 2015-10-13,Italy,Norway,2,1,UEFA Euro qualification,Rome,Italy,FALSE
@@ -38015,7 +38015,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-01-30,Cameroon,Ivory Coast,0,3,African Nations Championship,Butare,Rwanda,TRUE
 2016-01-30,Rwanda,DR Congo,1,2,African Nations Championship,Kigali,Rwanda,FALSE
 2016-01-31,Tunisia,Mali,1,2,African Nations Championship,Kigali,Rwanda,TRUE
-2016-01-31,USA,Iceland,3,2,Friendly,Carson,USA,FALSE
+2016-01-31,United States,Iceland,3,2,Friendly,Carson,United States,FALSE
 2016-01-31,Zambia,Guinea,0,0,African Nations Championship,Gisenyi,Rwanda,TRUE
 2016-02-03,DR Congo,Guinea,1,1,African Nations Championship,Kigali,Rwanda,TRUE
 2016-02-04,Mali,Ivory Coast,1,0,African Nations Championship,Kigali,Rwanda,TRUE
@@ -38085,7 +38085,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-03-25,Canada,Mexico,0,3,FIFA World Cup qualification,Vancouver,Canada,FALSE
 2016-03-25,El Salvador,Honduras,2,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2016-03-25,Gabon,Sierra Leone,2,1,Friendly,Franceville,Gabon,FALSE
-2016-03-25,Guatemala,USA,2,0,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
+2016-03-25,Guatemala,United States,2,0,FIFA World Cup qualification,Guatemala,Guatemala,FALSE
 2016-03-25,Guinea,Malawi,0,0,African Cup of Nations qualification,Conakry,Guinea,FALSE
 2016-03-25,Haiti,Panama,0,0,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
 2016-03-25,Republic of Ireland,Switzerland,1,0,Friendly,Dublin,Republic of Ireland,FALSE
@@ -38119,7 +38119,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-03-26,Russia,Lithuania,3,0,Friendly,Moscow,Russia,FALSE
 2016-03-26,Senegal,Niger,2,0,African Cup of Nations qualification,Dakar,Senegal,FALSE
 2016-03-26,Seychelles,Lesotho,2,0,African Cup of Nations qualification,Victoria,Seychelles,FALSE
-2016-03-26,Sint Maarten,USA Virgin Islands,1,2,CFU Caribbean Cup qualification,Philipsburg,Sint Maarten,FALSE
+2016-03-26,Sint Maarten,United States Virgin Islands,1,2,CFU Caribbean Cup qualification,Philipsburg,Sint Maarten,FALSE
 2016-03-27,Benin,South Sudan,4,1,African Cup of Nations qualification,Cotonou,Benin,FALSE
 2016-03-27,Botswana,Comoros,2,1,African Cup of Nations qualification,Francistown,Botswana,FALSE
 2016-03-27,Congo,Zambia,1,1,African Cup of Nations qualification,Brazzaville,Congo,FALSE
@@ -38194,16 +38194,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-03-29,Uganda,Burkina Faso,0,0,African Cup of Nations qualification,Kampala,Uganda,FALSE
 2016-03-29,United Arab Emirates,Saudi Arabia,1,1,FIFA World Cup qualification,Abu Dhabi,United Arab Emirates,FALSE
 2016-03-29,Uruguay,Peru,1,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2016-03-29,USA,Guatemala,4,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2016-03-29,United States,Guatemala,4,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2016-03-29,Uzbekistan,Bahrain,1,0,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2016-03-29,Venezuela,Chile,1,4,FIFA World Cup qualification,Barinas,Venezuela,FALSE
-2016-03-29,USA Virgin Islands,Grenada,1,2,CFU Caribbean Cup qualification,Charlotte Amalie,USA Virgin Islands,FALSE
+2016-03-29,United States Virgin Islands,Grenada,1,2,CFU Caribbean Cup qualification,Charlotte Amalie,United States Virgin Islands,FALSE
 2016-04-27,Martinique,Panama,0,2,Friendly,Fort-de-France,Martinique,FALSE
 2016-05-20,Hungary,Ivory Coast,0,0,Friendly,Budapest,Hungary,FALSE
 2016-05-20,Galicia,Venezuela,1,1,Friendly,La Coruña,Spain,FALSE
 2016-05-21,Botswana,Lesotho,2,1,Friendly,Serowe,Botswana,FALSE
 2016-05-22,England,Turkey,2,1,Friendly,Manchester,England,FALSE
-2016-05-22,Puerto Rico,USA,1,3,Friendly,Bayamón,Puerto Rico,FALSE
+2016-05-22,Puerto Rico,United States,1,3,Friendly,Bayamón,Puerto Rico,FALSE
 2016-05-25,Romania,DR Congo,1,1,Friendly,Como,Italy,TRUE
 2016-05-25,Serbia,Cyprus,2,1,Friendly,Užice,Serbia,FALSE
 2016-05-26,Azerbaijan,Andorra,0,0,Friendly,Bad Erlach,Austria,TRUE
@@ -38219,10 +38219,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-05-27,Corsica,Basque Country,1,1,Friendly,Ajaccio,France,FALSE
 2016-05-28,Myanmar,Malaysia,0,0,Friendly,Yangon,Myanmar,FALSE
 2016-05-28,Costa Rica,Venezuela,2,1,Friendly,San José,Costa Rica,FALSE
-2016-05-28,El Salvador,Peru,1,3,Friendly,Seattle,USA,TRUE
+2016-05-28,El Salvador,Peru,1,3,Friendly,Seattle,United States,TRUE
 2016-05-28,Gabon,Mauritania,0,2,Friendly,Cornellà de Llobregat,Spain,TRUE
-2016-05-28,Guatemala,Armenia,1,7,Friendly,Carson,USA,TRUE
-2016-05-28,Mexico,Paraguay,1,0,Friendly,Atlanta,USA,TRUE
+2016-05-28,Guatemala,Armenia,1,7,Friendly,Carson,United States,TRUE
+2016-05-28,Mexico,Paraguay,1,0,Friendly,Atlanta,United States,TRUE
 2016-05-28,New Zealand,Fiji,3,1,Oceania Nations Cup,Port Moresby,Papua New Guinea,TRUE
 2016-05-28,Rwanda,Senegal,0,2,Friendly,Kigali,Rwanda,FALSE
 2016-05-28,Switzerland,Belgium,1,2,Friendly,Geneva,Switzerland,FALSE
@@ -38268,7 +38268,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-01,Belgium,Finland,1,1,Friendly,Brussels,Belgium,FALSE
 2016-06-01,Curaçao,Guyana,5,2,CFU Caribbean Cup qualification,Willemstad,Curaçao,FALSE
 2016-06-01,Czech Republic,Russia,2,1,Friendly,Innsbruck,Austria,TRUE
-2016-06-01,El Salvador,Armenia,0,4,Friendly,Carson,USA,TRUE
+2016-06-01,El Salvador,Armenia,0,4,Friendly,Carson,United States,TRUE
 2016-06-01,Estonia,Andorra,2,0,Friendly,Tallinn,Estonia,FALSE
 2016-06-01,Grenada,Puerto Rico,3,3,CFU Caribbean Cup qualification,St. George's,Grenada,FALSE
 2016-06-01,Latvia,Lithuania,2,1,Baltic Cup,Liepāja,Latvia,FALSE
@@ -38307,7 +38307,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-03,Switzerland,Moldova,2,1,Friendly,Lugano,Switzerland,FALSE
 2016-06-03,Thailand,Syria,2,2,King's Cup,Bangkok,Thailand,FALSE
 2016-06-03,United Arab Emirates,Jordan,1,3,King's Cup,Bangkok,Thailand,TRUE
-2016-06-03,USA,Colombia,0,2,Copa América,Santa Clara,USA,FALSE
+2016-06-03,United States,Colombia,0,2,Copa América,Santa Clara,United States,FALSE
 2016-06-03,Vietnam,Hong Kong,2,2,Friendly,Yangon,Myanmar,TRUE
 2016-06-03,United Koreans in Japan,Sápmi,1,2,CONIFA World Football Cup,Sukhumi,Georgia,TRUE
 2016-06-03,Iraqi Kurdistan,Western Armenia,0,0,CONIFA World Football Cup,Sukhumi,Georgia,TRUE
@@ -38316,8 +38316,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-04,Australia,Greece,1,0,Friendly,Sydney,Australia,FALSE
 2016-06-04,Austria,Netherlands,0,2,Friendly,Vienna,Austria,FALSE
 2016-06-04,Botswana,Uganda,1,2,African Cup of Nations qualification,Francistown,Botswana,FALSE
-2016-06-04,Brazil,Ecuador,0,0,Copa América,Pasadena,USA,TRUE
-2016-06-04,Costa Rica,Paraguay,0,0,Copa América,Orlando,USA,TRUE
+2016-06-04,Brazil,Ecuador,0,0,Copa América,Pasadena,United States,TRUE
+2016-06-04,Costa Rica,Paraguay,0,0,Copa América,Orlando,United States,TRUE
 2016-06-04,Croatia,San Marino,10,0,Friendly,Rijeka,Croatia,FALSE
 2016-06-04,Estonia,Latvia,0,0,Baltic Cup,Tallinn,Estonia,FALSE
 2016-06-04,Fiji,Vanuatu,2,3,Oceania Nations Cup,Port Moresby,Papua New Guinea,TRUE
@@ -38325,14 +38325,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-04,Gambia,South Africa,0,4,African Cup of Nations qualification,Bakau,Gambia,FALSE
 2016-06-04,Germany,Hungary,2,0,Friendly,Gelsenkirchen,Germany,FALSE
 2016-06-04,Guadeloupe,Dominica,2,1,CFU Caribbean Cup qualification,Les Abymes,Guadeloupe,FALSE
-2016-06-04,Haiti,Peru,0,1,Copa América,Seattle,USA,TRUE
+2016-06-04,Haiti,Peru,0,1,Copa América,Seattle,United States,TRUE
 2016-06-04,Ivory Coast,Gabon,2,1,Friendly,Bouaké,Ivory Coast,FALSE
 2016-06-04,New Zealand,Solomon Islands,1,0,Oceania Nations Cup,Port Moresby,Papua New Guinea,TRUE
 2016-06-04,Rwanda,Mozambique,2,3,African Cup of Nations qualification,Kigali,Rwanda,FALSE
 2016-06-04,Slovakia,Northern Ireland,0,0,Friendly,Trnava,Slovakia,FALSE
 2016-06-04,South Sudan,Mali,0,3,African Cup of Nations qualification,Juba,South Sudan,FALSE
 2016-06-04,Tanzania,Egypt,0,2,African Cup of Nations qualification,Dar es Salaam,Tanzania,FALSE
-2016-06-04,USA Virgin Islands,Guyana,0,7,CFU Caribbean Cup qualification,Charlotte Amalie,USA Virgin Islands,FALSE
+2016-06-04,United States Virgin Islands,Guyana,0,7,CFU Caribbean Cup qualification,Charlotte Amalie,United States Virgin Islands,FALSE
 2016-06-04,Abkhazia,Northern Cyprus,2,0,CONIFA World Football Cup,Sukhumi,Georgia,FALSE
 2016-06-04,Padania,Panjab,1,0,CONIFA World Football Cup,Sukhumi,Georgia,TRUE
 2016-06-04,United Koreans in Japan,Iraqi Kurdistan,1,1,CONIFA World Football Cup,Sukhumi,Georgia,TRUE
@@ -38341,13 +38341,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-05,Central African Republic,Angola,3,0,African Cup of Nations qualification,Bangui,Central African Republic,FALSE
 2016-06-05,Comoros,Burkina Faso,0,1,African Cup of Nations qualification,Moroni,Comoros,FALSE
 2016-06-05,Czech Republic,South Korea,1,2,Friendly,Prague,Czech Republic,FALSE
-2016-06-05,Jamaica,Venezuela,0,1,Copa América,Chicago,USA,TRUE
+2016-06-05,Jamaica,Venezuela,0,1,Copa América,Chicago,United States,TRUE
 2016-06-05,Kenya,Congo,2,1,African Cup of Nations qualification,Nairobi,Kenya,FALSE
 2016-06-05,Lesotho,Ethiopia,1,2,African Cup of Nations qualification,Maseru,Lesotho,FALSE
 2016-06-05,Liberia,Togo,2,2,African Cup of Nations qualification,Monrovia,Liberia,FALSE
 2016-06-05,Madagascar,DR Congo,1,6,African Cup of Nations qualification,Mahajanga,Madagascar,FALSE
 2016-06-05,Mauritius,Ghana,0,2,African Cup of Nations qualification,Mapou,Mauritius,FALSE
-2016-06-05,Mexico,Uruguay,3,1,Copa América,Glendale,USA,TRUE
+2016-06-05,Mexico,Uruguay,3,1,Copa América,Glendale,United States,TRUE
 2016-06-05,Papua New Guinea,Samoa,8,0,Oceania Nations Cup,Port Moresby,Papua New Guinea,FALSE
 2016-06-05,Russia,Serbia,1,1,Friendly,Monaco,Monaco,TRUE
 2016-06-05,Slovenia,Turkey,0,1,Friendly,Ljubljana,Slovenia,FALSE
@@ -38359,12 +38359,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-05,Zimbabwe,Malawi,3,0,African Cup of Nations qualification,Harare,Zimbabwe,FALSE
 2016-06-05,Padania,Northern Cyprus,0,2,CONIFA World Football Cup,Sukhumi,Georgia,TRUE
 2016-06-05,Abkhazia,Panjab,1,1,CONIFA World Football Cup,Sukhumi,Georgia,FALSE
-2016-06-06,Argentina,Chile,2,1,Copa América,Santa Clara,USA,TRUE
+2016-06-06,Argentina,Chile,2,1,Copa América,Santa Clara,United States,TRUE
 2016-06-06,Myanmar,Hong Kong,3,0,Friendly,Yangon,Myanmar,FALSE
 2016-06-06,Iceland,Liechtenstein,4,0,Friendly,Reykjavík,Iceland,FALSE
 2016-06-06,Italy,Finland,2,0,Friendly,Verona,Italy,FALSE
 2016-06-06,Malaysia,Timor-Leste,3,0,AFC Asian Cup qualification,Johor Bahru,Malaysia,FALSE
-2016-06-06,Panama,Bolivia,2,1,Copa América,Orlando,USA,TRUE
+2016-06-06,Panama,Bolivia,2,1,Copa América,Orlando,United States,TRUE
 2016-06-06,Poland,Lithuania,0,0,Friendly,Kraków,Poland,FALSE
 2016-06-06,Singapore,Vietnam,0,3,Friendly,Yangon,Myanmar,TRUE
 2016-06-07,Australia,Greece,1,2,Friendly,Melbourne,Australia,FALSE
@@ -38373,37 +38373,37 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-07,Cambodia,Taiwan,2,0,AFC Asian Cup qualification,Phnom Penh,Cambodia,FALSE
 2016-06-07,Canada,Uzbekistan,2,1,Friendly,Bad Waltersdorf,Austria,TRUE
 2016-06-07,China PR,Kazakhstan,0,1,Friendly,Dalian,China PR,FALSE
-2016-06-07,Colombia,Paraguay,2,1,Copa América,Pasadena,USA,TRUE
-2016-06-07,Curaçao,USA Virgin Islands,7,0,CFU Caribbean Cup qualification,Willemstad,Curaçao,FALSE
+2016-06-07,Colombia,Paraguay,2,1,Copa América,Pasadena,United States,TRUE
+2016-06-07,Curaçao,United States Virgin Islands,7,0,CFU Caribbean Cup qualification,Willemstad,Curaçao,FALSE
 2016-06-07,Dominican Republic,French Guiana,2,1,CFU Caribbean Cup qualification,Santo Domingo,Dominican Republic,FALSE
 2016-06-07,India,Laos,6,1,AFC Asian Cup qualification,Guwahati,India,FALSE
 2016-06-07,Iran,Kyrgyzstan,6,0,Friendly,Tehran,Iran,FALSE
 2016-06-07,Japan,Bosnia and Herzegovina,1,2,Kirin Cup,Suita,Japan,FALSE
 2016-06-07,Spain,Georgia,0,1,Friendly,Getafe,Spain,FALSE
 2016-06-07,Saint Vincent and the Grenadines,Saint Kitts and Nevis,0,1,CFU Caribbean Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
-2016-06-07,USA,Costa Rica,4,0,Copa América,Chicago,USA,FALSE
+2016-06-07,United States,Costa Rica,4,0,Copa América,Chicago,United States,FALSE
 2016-06-07,Yemen,Maldives,2,0,AFC Asian Cup qualification,Doha,Qatar,TRUE
-2016-06-08,Brazil,Haiti,7,1,Copa América,Orlando,USA,TRUE
-2016-06-08,Ecuador,Peru,2,2,Copa América,Glendale,USA,TRUE
+2016-06-08,Brazil,Haiti,7,1,Copa América,Orlando,United States,TRUE
+2016-06-08,Ecuador,Peru,2,2,Copa América,Glendale,United States,TRUE
 2016-06-08,New Zealand,New Caledonia,1,0,Oceania Nations Cup,Port Moresby,Papua New Guinea,TRUE
 2016-06-08,Papua New Guinea,Solomon Islands,2,1,Oceania Nations Cup,Port Moresby,Papua New Guinea,FALSE
 2016-06-08,Portugal,Estonia,7,0,Friendly,Lisbon,Portugal,FALSE
-2016-06-09,Mexico,Jamaica,2,0,Copa América,Pasadena,USA,TRUE
-2016-06-09,Uruguay,Venezuela,0,1,Copa América,Philadelphia,USA,TRUE
-2016-06-10,Argentina,Panama,5,0,Copa América,Chicago,USA,TRUE
-2016-06-10,Chile,Bolivia,2,1,Copa América,Foxborough,USA,TRUE
+2016-06-09,Mexico,Jamaica,2,0,Copa América,Pasadena,United States,TRUE
+2016-06-09,Uruguay,Venezuela,0,1,Copa América,Philadelphia,United States,TRUE
+2016-06-10,Argentina,Panama,5,0,Copa América,Chicago,United States,TRUE
+2016-06-10,Chile,Bolivia,2,1,Copa América,Foxborough,United States,TRUE
 2016-06-10,France,Romania,2,1,UEFA Euro,Saint-Denis,France,FALSE
 2016-06-11,Albania,Switzerland,0,1,UEFA Euro,Lens,France,TRUE
-2016-06-11,Colombia,Costa Rica,2,3,Copa América,Houston,USA,TRUE
+2016-06-11,Colombia,Costa Rica,2,3,Copa América,Houston,United States,TRUE
 2016-06-11,England,Russia,1,1,UEFA Euro,Marseille,France,TRUE
 2016-06-11,Papua New Guinea,New Zealand,0,0,Oceania Nations Cup,Port Moresby,Papua New Guinea,FALSE
 2016-06-11,Seychelles,Madagascar,0,1,COSAFA Cup,Windhoek,Namibia,TRUE
-2016-06-11,USA,Paraguay,1,0,Copa América,Philadelphia,USA,FALSE
+2016-06-11,United States,Paraguay,1,0,Copa América,Philadelphia,United States,FALSE
 2016-06-11,Wales,Slovakia,2,1,UEFA Euro,Bordeaux,France,TRUE
 2016-06-11,Zimbabwe,Eswatini,2,2,COSAFA Cup,Windhoek,Namibia,TRUE
 2016-06-12,Benin,Equatorial Guinea,2,1,African Cup of Nations qualification,Cotonou,Benin,FALSE
-2016-06-12,Brazil,Peru,0,1,Copa América,Foxborough,USA,TRUE
-2016-06-12,Ecuador,Haiti,4,0,Copa América,East Rutherford,USA,TRUE
+2016-06-12,Brazil,Peru,0,1,Copa América,Foxborough,United States,TRUE
+2016-06-12,Ecuador,Haiti,4,0,Copa América,East Rutherford,United States,TRUE
 2016-06-12,Germany,Ukraine,2,0,UEFA Euro,Villeneuve-d'Ascq,France,TRUE
 2016-06-12,Lesotho,Mauritius,3,0,COSAFA Cup,Windhoek,Namibia,TRUE
 2016-06-12,Malawi,Angola,3,0,COSAFA Cup,Windhoek,Namibia,TRUE
@@ -38412,14 +38412,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-13,Belgium,Italy,0,2,UEFA Euro,Lyon,France,TRUE
 2016-06-13,Republic of Ireland,Sweden,1,1,UEFA Euro,Saint-Denis,France,TRUE
 2016-06-13,Madagascar,Zimbabwe,0,0,COSAFA Cup,Windhoek,Namibia,TRUE
-2016-06-13,Mexico,Venezuela,1,1,Copa América,Houston,USA,TRUE
+2016-06-13,Mexico,Venezuela,1,1,Copa América,Houston,United States,TRUE
 2016-06-13,Spain,Czech Republic,1,0,UEFA Euro,Toulouse,France,TRUE
 2016-06-13,Eswatini,Seychelles,4,0,COSAFA Cup,Windhoek,Namibia,TRUE
-2016-06-13,Uruguay,Jamaica,3,0,Copa América,Santa Clara,USA,TRUE
+2016-06-13,Uruguay,Jamaica,3,0,Copa América,Santa Clara,United States,TRUE
 2016-06-14,Angola,Lesotho,0,2,COSAFA Cup,Windhoek,Namibia,TRUE
-2016-06-14,Argentina,Bolivia,3,0,Copa América,Seattle,USA,TRUE
+2016-06-14,Argentina,Bolivia,3,0,Copa América,Seattle,United States,TRUE
 2016-06-14,Austria,Hungary,0,2,UEFA Euro,Bordeaux,France,TRUE
-2016-06-14,Chile,Panama,4,2,Copa América,Philadelphia,USA,TRUE
+2016-06-14,Chile,Panama,4,2,Copa América,Philadelphia,United States,TRUE
 2016-06-14,Mauritius,Malawi,0,1,COSAFA Cup,Windhoek,Namibia,TRUE
 2016-06-14,Portugal,Iceland,1,1,UEFA Euro,Saint-Étienne,France,TRUE
 2016-06-15,France,Albania,2,0,UEFA Euro,Marseille,France,FALSE
@@ -38432,15 +38432,15 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-16,Germany,Poland,0,0,UEFA Euro,Saint-Denis,France,TRUE
 2016-06-16,Malawi,Lesotho,0,1,COSAFA Cup,Windhoek,Namibia,TRUE
 2016-06-16,Ukraine,Northern Ireland,0,2,UEFA Euro,Lyon,France,TRUE
-2016-06-16,USA,Ecuador,2,1,Copa América,Seattle,USA,FALSE
+2016-06-16,United States,Ecuador,2,1,Copa América,Seattle,United States,FALSE
 2016-06-17,Czech Republic,Croatia,2,2,UEFA Euro,Saint-Étienne,France,TRUE
 2016-06-17,Italy,Sweden,1,0,UEFA Euro,Toulouse,France,TRUE
-2016-06-17,Peru,Colombia,0,0,Copa América,East Rutherford,USA,TRUE
+2016-06-17,Peru,Colombia,0,0,Copa América,East Rutherford,United States,TRUE
 2016-06-17,Spain,Turkey,3,0,UEFA Euro,Nice,France,TRUE
-2016-06-18,Argentina,Venezuela,4,1,Copa América,Foxborough,USA,TRUE
+2016-06-18,Argentina,Venezuela,4,1,Copa América,Foxborough,United States,TRUE
 2016-06-18,Belgium,Republic of Ireland,3,0,UEFA Euro,Bordeaux,France,TRUE
 2016-06-18,Iceland,Hungary,1,1,UEFA Euro,Marseille,France,TRUE
-2016-06-18,Mexico,Chile,0,7,Copa América,Santa Clara,USA,TRUE
+2016-06-18,Mexico,Chile,0,7,Copa América,Santa Clara,United States,TRUE
 2016-06-18,Namibia,Botswana,1,1,COSAFA Cup,Windhoek,Namibia,FALSE
 2016-06-18,Portugal,Austria,0,0,UEFA Euro,Lyon,France,TRUE
 2016-06-18,South Africa,Lesotho,1,1,COSAFA Cup,Windhoek,Namibia,TRUE
@@ -38457,9 +38457,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-21,Namibia,Mozambique,3,0,COSAFA Cup,Windhoek,Namibia,FALSE
 2016-06-21,Northern Ireland,Germany,0,1,UEFA Euro,Paris,France,TRUE
 2016-06-21,Ukraine,Poland,0,1,UEFA Euro,Marseille,France,TRUE
-2016-06-21,USA,Argentina,0,4,Copa América,Houston,USA,FALSE
+2016-06-21,United States,Argentina,0,4,Copa América,Houston,United States,FALSE
 2016-06-22,Botswana,DR Congo,0,0,COSAFA Cup,Windhoek,Namibia,TRUE
-2016-06-22,Colombia,Chile,0,2,Copa América,Chicago,USA,TRUE
+2016-06-22,Colombia,Chile,0,2,Copa América,Chicago,United States,TRUE
 2016-06-22,Hungary,Portugal,3,3,UEFA Euro,Lyon,France,TRUE
 2016-06-22,Iceland,Austria,2,1,UEFA Euro,Saint-Denis,France,TRUE
 2016-06-22,Italy,Republic of Ireland,0,1,UEFA Euro,Villeneuve-d'Ascq,France,TRUE
@@ -38471,9 +38471,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-06-25,South Africa,Botswana,3,2,COSAFA Cup,Windhoek,Namibia,TRUE
 2016-06-25,Eswatini,DR Congo,1,0,COSAFA Cup,Windhoek,Namibia,TRUE
 2016-06-25,Switzerland,Poland,1,1,UEFA Euro,Saint-Étienne,France,TRUE
-2016-06-25,USA,Colombia,0,1,Copa América,Glendale,USA,FALSE
+2016-06-25,United States,Colombia,0,1,Copa América,Glendale,United States,FALSE
 2016-06-25,Wales,Northern Ireland,1,0,UEFA Euro,Paris,France,TRUE
-2016-06-26,Argentina,Chile,0,0,Copa América,East Rutherford,USA,TRUE
+2016-06-26,Argentina,Chile,0,0,Copa América,East Rutherford,United States,TRUE
 2016-06-26,Fiji,Malaysia,1,1,Friendly,Nadi,Fiji,FALSE
 2016-06-26,France,Republic of Ireland,2,1,UEFA Euro,Lyon,France,FALSE
 2016-06-26,Germany,Slovakia,3,0,UEFA Euro,Villeneuve-d'Ascq,France,TRUE
@@ -38544,7 +38544,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-09-02,Latvia,Luxembourg,3,1,Friendly,Riga,Latvia,FALSE
 2016-09-02,Panama,Jamaica,2,0,FIFA World Cup qualification,Panama City,Panama,FALSE
 2016-09-02,South Africa,Mauritania,1,1,African Cup of Nations qualification,Nelspruit,South Africa,FALSE
-2016-09-02,Saint Vincent and the Grenadines,USA,0,6,FIFA World Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
+2016-09-02,Saint Vincent and the Grenadines,United States,0,6,FIFA World Cup qualification,Kingstown,Saint Vincent and the Grenadines,FALSE
 2016-09-02,Sudan,Gabon,1,2,Friendly,Khartoum,Sudan,FALSE
 2016-09-02,Trinidad and Tobago,Guatemala,2,2,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2016-09-03,Angola,Madagascar,1,1,African Cup of Nations qualification,Luanda,Angola,FALSE
@@ -38617,7 +38617,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-09-06,Thailand,Japan,0,2,FIFA World Cup qualification,Bangkok,Thailand,FALSE
 2016-09-06,United Arab Emirates,Australia,0,1,FIFA World Cup qualification,Abu Dhabi,United Arab Emirates,FALSE
 2016-09-06,Uruguay,Paraguay,4,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
-2016-09-06,USA,Trinidad and Tobago,4,0,FIFA World Cup qualification,Jacksonville,USA,FALSE
+2016-09-06,United States,Trinidad and Tobago,4,0,FIFA World Cup qualification,Jacksonville,United States,FALSE
 2016-09-06,Venezuela,Argentina,2,2,FIFA World Cup qualification,Mérida,Venezuela,FALSE
 2016-09-29,Qatar,Serbia,3,0,Friendly,Doha,Qatar,FALSE
 2016-09-30,Botswana,Angola,1,1,Friendly,Gaborone,Botswana,FALSE
@@ -38652,7 +38652,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-10-06,Uzbekistan,Iran,0,1,FIFA World Cup qualification,Tashkent,Uzbekistan,FALSE
 2016-10-06,Vietnam,North Korea,5,2,Friendly,Ho Chi Minh City,Vietnam,FALSE
 2016-10-07,Belgium,Bosnia and Herzegovina,4,0,FIFA World Cup qualification,Brussels,Belgium,FALSE
-2016-10-07,Cuba,USA,0,2,Friendly,Havana,Cuba,FALSE
+2016-10-07,Cuba,United States,0,2,Friendly,Havana,Cuba,FALSE
 2016-10-07,Estonia,Gibraltar,4,0,FIFA World Cup qualification,Tallinn,Estonia,FALSE
 2016-10-07,France,Bulgaria,4,1,FIFA World Cup qualification,Saint-Denis,France,FALSE
 2016-10-07,Ghana,Uganda,0,0,FIFA World Cup qualification,Tamale,Ghana,FALSE
@@ -38676,7 +38676,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-10-08,Gabon,Morocco,0,0,FIFA World Cup qualification,Franceville,Gabon,FALSE
 2016-10-08,Germany,Czech Republic,3,0,FIFA World Cup qualification,Hamburg,Germany,FALSE
 2016-10-08,Ivory Coast,Mali,3,1,FIFA World Cup qualification,Bouaké,Ivory Coast,FALSE
-2016-10-08,Mexico,New Zealand,2,1,Friendly,Nashville,USA,TRUE
+2016-10-08,Mexico,New Zealand,2,1,Friendly,Nashville,United States,TRUE
 2016-10-08,Montenegro,Kazakhstan,5,0,FIFA World Cup qualification,Podgorica,Montenegro,FALSE
 2016-10-08,Northern Ireland,San Marino,4,0,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
 2016-10-08,Poland,Denmark,3,2,FIFA World Cup qualification,Warsaw,Poland,FALSE
@@ -38731,7 +38731,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-10-11,Lebanon,Equatorial Guinea,1,1,Friendly,Beirut,Lebanon,FALSE
 2016-10-11,Lithuania,Malta,2,0,FIFA World Cup qualification,Vilnius,Lithuania,FALSE
 2016-10-11,Malaysia,Afghanistan,1,1,Friendly,Shah Alam,Malaysia,FALSE
-2016-10-11,Mexico,Panama,1,0,Friendly,Bridgeview,USA,TRUE
+2016-10-11,Mexico,Panama,1,0,Friendly,Bridgeview,United States,TRUE
 2016-10-11,Morocco,Canada,4,0,Friendly,Marrakech,Morocco,FALSE
 2016-10-11,Norway,San Marino,4,1,FIFA World Cup qualification,Oslo,Norway,FALSE
 2016-10-11,Oman,Bahrain,2,2,Friendly,Muscat,Oman,FALSE
@@ -38801,7 +38801,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-11-11,Slovakia,Lithuania,4,0,FIFA World Cup qualification,Trnava,Slovakia,FALSE
 2016-11-11,Togo,Comoros,2,2,Friendly,Tunis,Tunisia,TRUE
 2016-11-11,Trinidad and Tobago,Costa Rica,0,2,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
-2016-11-11,USA,Mexico,1,2,FIFA World Cup qualification,Columbus,USA,FALSE
+2016-11-11,United States,Mexico,1,2,FIFA World Cup qualification,Columbus,United States,FALSE
 2016-11-12,Albania,Israel,0,3,FIFA World Cup qualification,Elbasan,Albania,FALSE
 2016-11-12,Austria,Republic of Ireland,0,1,FIFA World Cup qualification,Vienna,Austria,FALSE
 2016-11-12,Cameroon,Zambia,1,1,FIFA World Cup qualification,Limbé,Cameroon,FALSE
@@ -38848,7 +38848,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2016-11-15,Bolivia,Paraguay,1,0,FIFA World Cup qualification,La Paz,Bolivia,FALSE
 2016-11-15,Chile,Uruguay,3,1,FIFA World Cup qualification,Santiago,Chile,FALSE
 2016-11-15,China PR,Qatar,0,0,FIFA World Cup qualification,Kunming,China PR,FALSE
-2016-11-15,Costa Rica,USA,4,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
+2016-11-15,Costa Rica,United States,4,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2016-11-15,Czech Republic,Denmark,1,1,Friendly,Mladá Boleslav,Czech Republic,FALSE
 2016-11-15,Ecuador,Venezuela,3,0,FIFA World Cup qualification,Quito,Ecuador,FALSE
 2016-11-15,England,Spain,2,2,Friendly,London,England,FALSE
@@ -38960,12 +38960,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-01-28,Senegal,Cameroon,0,0,African Cup of Nations,Franceville,Gabon,TRUE
 2017-01-29,DR Congo,Ghana,1,2,African Cup of Nations,Oyem,Gabon,TRUE
 2017-01-29,Egypt,Morocco,1,0,African Cup of Nations,Port-Gentil,Gabon,TRUE
-2017-01-29,USA,Serbia,0,0,Friendly,San Diego,USA,FALSE
+2017-01-29,United States,Serbia,0,0,Friendly,San Diego,United States,FALSE
 2017-02-01,Burkina Faso,Egypt,1,1,African Cup of Nations,Libreville,Gabon,TRUE
 2017-02-02,Cameroon,Ghana,2,0,African Cup of Nations,Franceville,Gabon,TRUE
 2017-02-04,Burkina Faso,Ghana,1,0,African Cup of Nations,Port-Gentil,Gabon,TRUE
 2017-02-05,Egypt,Cameroon,1,2,African Cup of Nations,Libreville,Gabon,TRUE
-2017-02-08,Mexico,Iceland,1,0,Friendly,Las Vegas,USA,TRUE
+2017-02-08,Mexico,Iceland,1,0,Friendly,Las Vegas,United States,TRUE
 2017-02-22,Ecuador,Honduras,3,1,Friendly,Guayaquil,Ecuador,FALSE
 2017-03-09,Qatar,Azerbaijan,1,2,Friendly,Doha,Qatar,FALSE
 2017-03-10,Trinidad and Tobago,Barbados,2,0,Friendly,Couva,Trinidad and Tobago,FALSE
@@ -39021,7 +39021,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-03-24,Trinidad and Tobago,Panama,1,0,FIFA World Cup qualification,Port of Spain,Trinidad and Tobago,FALSE
 2017-03-24,Tunisia,Cameroon,0,1,Friendly,Monastir,Tunisia,FALSE
 2017-03-24,Turkey,Finland,2,0,FIFA World Cup qualification,Antalya,Turkey,FALSE
-2017-03-24,USA,Honduras,6,0,FIFA World Cup qualification,San Jose,USA,FALSE
+2017-03-24,United States,Honduras,6,0,FIFA World Cup qualification,San Jose,United States,FALSE
 2017-03-25,Andorra,Faroe Islands,0,0,FIFA World Cup qualification,Sant Julià de Lòria,Andorra,FALSE
 2017-03-25,Belgium,Greece,1,1,FIFA World Cup qualification,Brussels,Belgium,FALSE
 2017-03-25,Bosnia and Herzegovina,Gibraltar,5,0,FIFA World Cup qualification,Zenica,Bosnia and Herzegovina,FALSE
@@ -39085,7 +39085,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-03-28,Netherlands,Italy,1,2,Friendly,Amsterdam,Netherlands,FALSE
 2017-03-28,New Zealand,Fiji,2,0,FIFA World Cup qualification,Wellington,New Zealand,FALSE
 2017-03-28,Oman,Bhutan,14,0,AFC Asian Cup qualification,Muscat,Oman,FALSE
-2017-03-28,Panama,USA,1,1,FIFA World Cup qualification,Panama City,Panama,FALSE
+2017-03-28,Panama,United States,1,1,FIFA World Cup qualification,Panama City,Panama,FALSE
 2017-03-28,Peru,Uruguay,2,1,FIFA World Cup qualification,Lima,Peru,FALSE
 2017-03-28,Philippines,Nepal,4,1,AFC Asian Cup qualification,Manila,Philippines,FALSE
 2017-03-28,Portugal,Sweden,2,3,Friendly,Funchal,Portugal,FALSE
@@ -39114,14 +39114,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-05-25,Fiji,Solomon Islands,1,1,Friendly,Suva,Fiji,FALSE
 2017-05-25,Ghana,Benin,1,1,Friendly,Accra,Ghana,FALSE
 2017-05-26,Corsica,Nigeria,1,1,Friendly,Ajaccio,France,FALSE
-2017-05-28,El Salvador,Honduras,2,2,Friendly,Washington,USA,TRUE
+2017-05-28,El Salvador,Honduras,2,2,Friendly,Washington,United States,TRUE
 2017-05-28,Fiji,Solomon Islands,1,0,Friendly,Lautoka,Fiji,FALSE
-2017-05-28,Mexico,Croatia,1,2,Friendly,Los Angeles,USA,TRUE
+2017-05-28,Mexico,Croatia,1,2,Friendly,Los Angeles,United States,TRUE
 2017-05-31,Italy,San Marino,8,0,Friendly,Empoli,Italy,FALSE
 2017-05-31,Ivory Coast,Benin,1,1,Friendly,Abidjan,Ivory Coast,FALSE
 2017-05-31,Morocco,Netherlands,1,2,Friendly,Agadir,Morocco,FALSE
 2017-06-01,Iraq,Jordan,1,0,Friendly,Basra,Iraq,FALSE
-2017-06-01,Mexico,Republic of Ireland,3,1,Friendly,East Rutherford,USA,TRUE
+2017-06-01,Mexico,Republic of Ireland,3,1,Friendly,East Rutherford,United States,TRUE
 2017-06-01,Nigeria,Togo,3,0,Friendly,Saint-Leu-la-Forêt,France,TRUE
 2017-06-01,Switzerland,Belarus,1,0,Friendly,Neuchâtel,Switzerland,FALSE
 2017-06-02,Chile,Burkina Faso,3,0,Friendly,Santiago,Chile,FALSE
@@ -39131,7 +39131,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-06-02,Oman,Syria,1,1,Friendly,Muscat,Oman,FALSE
 2017-06-03,Ethiopia,Uganda,0,0,Friendly,Hawassa,Ethiopia,FALSE
 2017-06-03,Portugal,Cyprus,4,0,Friendly,Estoril,Portugal,FALSE
-2017-06-03,USA,Venezuela,1,1,Friendly,Sandy,USA,FALSE
+2017-06-03,United States,Venezuela,1,1,Friendly,Sandy,United States,FALSE
 2017-06-04,Armenia,Saint Kitts and Nevis,5,0,Friendly,Yerevan,Armenia,FALSE
 2017-06-04,Gabon,Zambia,0,0,Friendly,Libreville,Gabon,FALSE
 2017-06-04,Republic of Ireland,Uruguay,3,1,Friendly,Dublin,Republic of Ireland,FALSE
@@ -39181,10 +39181,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-06-08,Australia,Saudi Arabia,3,2,FIFA World Cup qualification,Adelaide,Australia,FALSE
 2017-06-08,Cambodia,Indonesia,0,2,Friendly,Phnom Penh,Cambodia,FALSE
 2017-06-08,Costa Rica,Panama,0,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
-2017-06-08,Ecuador,Venezuela,1,1,Friendly,Boca Raton,USA,TRUE
+2017-06-08,Ecuador,Venezuela,1,1,Friendly,Boca Raton,United States,TRUE
 2017-06-08,Mexico,Honduras,3,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2017-06-08,Peru,Paraguay,1,0,Friendly,Trujillo,Peru,FALSE
-2017-06-08,USA,Trinidad and Tobago,2,0,FIFA World Cup qualification,Commerce City,USA,FALSE
+2017-06-08,United States,Trinidad and Tobago,2,0,FIFA World Cup qualification,Commerce City,United States,FALSE
 2017-06-09,Andorra,Hungary,1,0,FIFA World Cup qualification,Sant Julià de Lòria,Andorra,FALSE
 2017-06-09,Argentina,Brazil,1,0,Superclásico de las Américas,Melbourne,Australia,TRUE
 2017-06-09,Belarus,Bulgaria,2,1,FIFA World Cup qualification,Barysaw,Belarus,FALSE
@@ -39242,7 +39242,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-06-11,Italy,Liechtenstein,5,0,FIFA World Cup qualification,Udine,Italy,FALSE
 2017-06-11,Kosovo,Turkey,1,4,FIFA World Cup qualification,Shkodër,Albania,TRUE
 2017-06-11,North Macedonia,Spain,1,2,FIFA World Cup qualification,Skopje,North Macedonia,FALSE
-2017-06-11,Mexico,USA,1,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+2017-06-11,Mexico,United States,1,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2017-06-11,Moldova,Georgia,2,2,FIFA World Cup qualification,Chișinău,Moldova,FALSE
 2017-06-11,New Caledonia,Fiji,2,1,FIFA World Cup qualification,Nouméa,New Caledonia,FALSE
 2017-06-11,Serbia,Wales,1,1,FIFA World Cup qualification,Belgrade,Serbia,FALSE
@@ -39256,7 +39256,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-06-13,Cameroon,Colombia,0,4,Friendly,Getafe,Spain,TRUE
 2017-06-13,Canada,Curaçao,2,1,Friendly,Montréal,Canada,FALSE
 2017-06-13,Costa Rica,Trinidad and Tobago,2,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
-2017-06-13,El Salvador,Ecuador,0,3,Friendly,Harrison,USA,TRUE
+2017-06-13,El Salvador,Ecuador,0,3,Friendly,Harrison,United States,TRUE
 2017-06-13,France,England,3,2,Friendly,Saint-Denis,France,FALSE
 2017-06-13,Hong Kong,North Korea,1,1,AFC Asian Cup qualification,So Kon Po,Hong Kong,FALSE
 2017-06-13,India,Kyrgyzstan,1,0,AFC Asian Cup qualification,Bangalore,India,FALSE
@@ -39348,9 +39348,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-06-30,Greenland,Isle of Man,0,6,Island Games,Visby,Sweden,TRUE
 2017-07-01,Botswana,Zambia,1,2,COSAFA Cup,Rustenburg,South Africa,TRUE
 2017-07-01,Gambia,Guinea-Bissau,0,0,Friendly,Bakau,Gambia,FALSE
-2017-07-01,Mexico,Paraguay,2,1,Friendly,Seattle,USA,TRUE
+2017-07-01,Mexico,Paraguay,2,1,Friendly,Seattle,United States,TRUE
 2017-07-01,Namibia,Lesotho,0,0,COSAFA Cup,Rustenburg,South Africa,TRUE
-2017-07-01,USA,Ghana,2,1,Friendly,East Hartford,USA,FALSE
+2017-07-01,United States,Ghana,2,1,Friendly,East Hartford,United States,FALSE
 2017-07-02,Chile,Germany,0,1,Confederations Cup,Saint Petersburg,Russia,TRUE
 2017-07-02,Portugal,Mexico,2,1,Confederations Cup,Moscow,Russia,TRUE
 2017-07-02,South Africa,Tanzania,0,1,COSAFA Cup,Rustenburg,South Africa,FALSE
@@ -39365,28 +39365,28 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-07-05,Zambia,Tanzania,4,2,COSAFA Cup,Moruleng,South Africa,TRUE
 2017-07-06,Dominica,Saint Vincent and the Grenadines,2,2,Windward Islands Tournament,St. George's,Grenada,TRUE
 2017-07-06,Grenada,Barbados,0,2,Windward Islands Tournament,St. George's,Grenada,FALSE
-2017-07-07,French Guiana,Canada,2,4,Gold Cup,Harrison,USA,TRUE
-2017-07-07,Honduras,Costa Rica,0,1,Gold Cup,Harrison,USA,TRUE
+2017-07-07,French Guiana,Canada,2,4,Gold Cup,Harrison,United States,TRUE
+2017-07-07,Honduras,Costa Rica,0,1,Gold Cup,Harrison,United States,TRUE
 2017-07-07,South Africa,Namibia,1,0,COSAFA Cup,Moruleng,South Africa,FALSE
 2017-07-07,Tanzania,Lesotho,0,0,COSAFA Cup,Moruleng,South Africa,TRUE
 2017-07-08,Guinea-Bissau,Gambia,0,1,Friendly,Bissau,Guinea-Bissau,FALSE
-2017-07-08,Martinique,Nicaragua,2,0,Gold Cup,Nashville,USA,TRUE
-2017-07-08,USA,Panama,1,1,Gold Cup,Nashville,USA,FALSE
-2017-07-09,Curaçao,Jamaica,0,2,Gold Cup,San Diego,USA,TRUE
-2017-07-09,Mexico,El Salvador,3,1,Gold Cup,San Diego,USA,TRUE
+2017-07-08,Martinique,Nicaragua,2,0,Gold Cup,Nashville,United States,TRUE
+2017-07-08,United States,Panama,1,1,Gold Cup,Nashville,United States,FALSE
+2017-07-09,Curaçao,Jamaica,0,2,Gold Cup,San Diego,United States,TRUE
+2017-07-09,Mexico,El Salvador,3,1,Gold Cup,San Diego,United States,TRUE
 2017-07-09,Zambia,Zimbabwe,1,3,COSAFA Cup,Rustenburg,South Africa,TRUE
-2017-07-11,Costa Rica,Canada,1,1,Gold Cup,Houston,USA,TRUE
-2017-07-11,Honduras,French Guiana,0,0,Gold Cup,Houston,USA,TRUE
-2017-07-12,Panama,Nicaragua,2,1,Gold Cup,Tampa,USA,TRUE
-2017-07-12,USA,Martinique,3,2,Gold Cup,Tampa,USA,FALSE
-2017-07-13,El Salvador,Curaçao,2,0,Gold Cup,Denver,USA,TRUE
-2017-07-13,Mexico,Jamaica,0,0,Gold Cup,Denver,USA,TRUE
-2017-07-14,Canada,Honduras,0,0,Gold Cup,Frisco,USA,TRUE
-2017-07-14,Costa Rica,French Guiana,3,0,Gold Cup,Frisco,USA,TRUE
+2017-07-11,Costa Rica,Canada,1,1,Gold Cup,Houston,United States,TRUE
+2017-07-11,Honduras,French Guiana,0,0,Gold Cup,Houston,United States,TRUE
+2017-07-12,Panama,Nicaragua,2,1,Gold Cup,Tampa,United States,TRUE
+2017-07-12,United States,Martinique,3,2,Gold Cup,Tampa,United States,FALSE
+2017-07-13,El Salvador,Curaçao,2,0,Gold Cup,Denver,United States,TRUE
+2017-07-13,Mexico,Jamaica,0,0,Gold Cup,Denver,United States,TRUE
+2017-07-14,Canada,Honduras,0,0,Gold Cup,Frisco,United States,TRUE
+2017-07-14,Costa Rica,French Guiana,3,0,Gold Cup,Frisco,United States,TRUE
 2017-07-14,Thailand,North Korea,3,0,King's Cup,Bangkok,Thailand,FALSE
 2017-07-14,South Sudan,Uganda,0,0,African Nations Championship,Juba,South Sudan,FALSE
-2017-07-15,Panama,Martinique,3,0,Gold Cup,Cleveland,USA,TRUE
-2017-07-15,USA,Nicaragua,3,0,Gold Cup,Cleveland,USA,FALSE
+2017-07-15,Panama,Martinique,3,0,Gold Cup,Cleveland,United States,TRUE
+2017-07-15,United States,Nicaragua,3,0,Gold Cup,Cleveland,United States,FALSE
 2017-07-15,Djibouti,Ethiopia,1,5,African Nations Championship,Djibouti,Djibouti,FALSE
 2017-07-15,Tanzania,Rwanda,1,1,African Nations Championship,Mwanza,Tanzania,FALSE
 2017-07-15,Botswana,South Africa,0,2,African Nations Championship,Francistown,Botswana,FALSE
@@ -39395,8 +39395,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-07-15,Guinea-Bissau,Guinea,1,3,African Nations Championship,Bissau,Guinea-Bissau,FALSE
 2017-07-15,Sierra Leone,Senegal,1,1,African Nations Championship,Freetown,Sierra Leone,FALSE
 2017-07-16,Burkina Faso,North Korea,3,3,King's Cup,Bangkok,Thailand,TRUE
-2017-07-16,Curaçao,Mexico,0,2,Gold Cup,San Antonio,USA,TRUE
-2017-07-16,Jamaica,El Salvador,1,1,Gold Cup,San Antonio,USA,TRUE
+2017-07-16,Curaçao,Mexico,0,2,Gold Cup,San Antonio,United States,TRUE
+2017-07-16,Jamaica,El Salvador,1,1,Gold Cup,San Antonio,United States,TRUE
 2017-07-16,Madagascar,Mozambique,2,2,African Nations Championship,Antananarivo,Madagascar,FALSE
 2017-07-16,Mauritius,Angola,0,1,African Nations Championship,Belle Vue Maurel,Mauritius,FALSE
 2017-07-16,Namibia,Zimbabwe,1,0,African Nations Championship,Windhoek,Namibia,FALSE
@@ -39404,11 +39404,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-07-16,Liberia,Mauritania,0,2,African Nations Championship,Monrovia,Liberia,FALSE
 2017-07-16,Togo,Benin,1,1,African Nations Championship,Lomé,Togo,FALSE
 2017-07-16,Thailand,Belarus,0,0,King's Cup,Bangkok,Thailand,FALSE
-2017-07-19,Costa Rica,Panama,1,0,Gold Cup,Philadelphia,USA,TRUE
-2017-07-19,USA,El Salvador,2,0,Gold Cup,Philadelphia,USA,FALSE
-2017-07-20,Jamaica,Canada,2,1,Gold Cup,Glendale,USA,TRUE
-2017-07-20,Mexico,Honduras,1,0,Gold Cup,Glendale,USA,TRUE
-2017-07-22,USA,Costa Rica,2,0,Gold Cup,Arlington,USA,FALSE
+2017-07-19,Costa Rica,Panama,1,0,Gold Cup,Philadelphia,United States,TRUE
+2017-07-19,United States,El Salvador,2,0,Gold Cup,Philadelphia,United States,FALSE
+2017-07-20,Jamaica,Canada,2,1,Gold Cup,Glendale,United States,TRUE
+2017-07-20,Mexico,Honduras,1,0,Gold Cup,Glendale,United States,TRUE
+2017-07-22,United States,Costa Rica,2,0,Gold Cup,Arlington,United States,FALSE
 2017-07-22,Rwanda,Tanzania,0,0,African Nations Championship,Kigali,Rwanda,FALSE
 2017-07-22,Uganda,South Sudan,5,1,African Nations Championship,Kampala,Uganda,FALSE
 2017-07-22,South Africa,Botswana,1,0,African Nations Championship,Saulspoort,South Africa,FALSE
@@ -39416,7 +39416,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-07-22,Guinea,Guinea-Bissau,7,0,African Nations Championship,Conakry,Guinea,FALSE
 2017-07-22,Mali,Gambia,4,0,African Nations Championship,Bamako,Mali,FALSE
 2017-07-22,Senegal,Sierra Leone,3,1,African Nations Championship,Dakar,Senegal,FALSE
-2017-07-23,Mexico,Jamaica,0,1,Gold Cup,Pasadena,USA,TRUE
+2017-07-23,Mexico,Jamaica,0,1,Gold Cup,Pasadena,United States,TRUE
 2017-07-23,Burundi,Sudan,0,0,African Nations Championship,Bujumbura,Burundi,FALSE
 2017-07-23,Ethiopia,Djibouti,3,0,African Nations Championship,Hawassa,Ethiopia,FALSE
 2017-07-23,Angola,Mauritius,3,2,African Nations Championship,Luanda,Angola,FALSE
@@ -39426,7 +39426,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-07-23,Mauritania,Liberia,0,1,African Nations Championship,Zouérat,Mauritania,FALSE
 2017-07-23,Benin,Togo,1,1,African Nations Championship,Cotonou,Benin,FALSE
 2017-07-26,Ecuador,Trinidad and Tobago,3,1,Friendly,Guayaquil,Ecuador,FALSE
-2017-07-26,USA,Jamaica,2,1,Gold Cup,Santa Clara,USA,FALSE
+2017-07-26,United States,Jamaica,2,1,Gold Cup,Santa Clara,United States,FALSE
 2017-07-29,Sudan,Burundi,1,0,African Nations Championship,Obeid,Sudan,FALSE
 2017-08-05,Zambia,Ethiopia,0,0,Friendly,Lusaka,Zambia,FALSE
 2017-08-07,Rwanda,Sudan,2,1,Friendly,Kigali,Rwanda,FALSE
@@ -39495,7 +39495,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-09-01,Slovakia,Slovenia,1,0,FIFA World Cup qualification,Trnava,Slovakia,FALSE
 2017-09-01,Trinidad and Tobago,Honduras,1,2,FIFA World Cup qualification,Couva,Trinidad and Tobago,FALSE
 2017-09-01,Tunisia,DR Congo,2,1,FIFA World Cup qualification,Radès,Tunisia,FALSE
-2017-09-01,USA,Costa Rica,0,2,FIFA World Cup qualification,Harrison,USA,FALSE
+2017-09-01,United States,Costa Rica,0,2,FIFA World Cup qualification,Harrison,United States,FALSE
 2017-09-02,Albania,Liechtenstein,2,0,FIFA World Cup qualification,Elbasan,Albania,FALSE
 2017-09-02,Canada,Jamaica,2,0,Friendly,Toronto,Canada,FALSE
 2017-09-02,Croatia,Kosovo,1,0,FIFA World Cup qualification,Zagreb,Croatia,FALSE
@@ -39548,7 +39548,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-09-05,Costa Rica,Mexico,1,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2017-09-05,Ecuador,Peru,0,2,FIFA World Cup qualification,Quito,Ecuador,FALSE
 2017-09-05,Egypt,Uganda,1,0,FIFA World Cup qualification,Alexandria,Egypt,FALSE
-2017-09-05,Honduras,USA,1,1,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
+2017-09-05,Honduras,United States,1,1,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2017-09-05,Iceland,Ukraine,2,0,FIFA World Cup qualification,Reykjavík,Iceland,FALSE
 2017-09-05,Iran,Syria,2,2,FIFA World Cup qualification,Tehran,Iran,FALSE
 2017-09-05,Iraq,United Arab Emirates,1,0,FIFA World Cup qualification,Amman,Jordan,TRUE
@@ -39612,7 +39612,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-10-06,Mexico,Trinidad and Tobago,3,1,FIFA World Cup qualification,San Luis Potosí,Mexico,FALSE
 2017-10-06,Spain,Albania,3,0,FIFA World Cup qualification,Alicante,Spain,FALSE
 2017-10-06,Turkey,Iceland,0,3,FIFA World Cup qualification,Eskişehir,Turkey,FALSE
-2017-10-06,USA,Panama,4,0,FIFA World Cup qualification,Orlando,USA,FALSE
+2017-10-06,United States,Panama,4,0,FIFA World Cup qualification,Orlando,United States,FALSE
 2017-10-07,Andorra,Portugal,0,2,FIFA World Cup qualification,Sant Julià de Lòria,Andorra,FALSE
 2017-10-07,Belarus,Netherlands,1,3,FIFA World Cup qualification,Barysaw,Belarus,FALSE
 2017-10-07,Bosnia and Herzegovina,Belgium,3,4,FIFA World Cup qualification,Sarajevo,Bosnia and Herzegovina,FALSE
@@ -39638,7 +39638,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-10-08,Czech Republic,San Marino,5,0,FIFA World Cup qualification,Plzeň,Czech Republic,FALSE
 2017-10-08,Denmark,Romania,1,1,FIFA World Cup qualification,Copenhagen,Denmark,FALSE
 2017-10-08,Egypt,Congo,2,1,FIFA World Cup qualification,Alexandria,Egypt,FALSE
-2017-10-08,El Salvador,Canada,1,0,Friendly,Houston,USA,TRUE
+2017-10-08,El Salvador,Canada,1,0,Friendly,Houston,United States,TRUE
 2017-10-08,Germany,Azerbaijan,5,1,FIFA World Cup qualification,Kaiserslautern,Germany,FALSE
 2017-10-08,Kazakhstan,Armenia,1,1,FIFA World Cup qualification,Astana,Kazakhstan,FALSE
 2017-10-08,Lithuania,England,0,1,FIFA World Cup qualification,Vilnius,Lithuania,FALSE
@@ -39687,7 +39687,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-10-10,Saudi Arabia,Ghana,0,3,Friendly,Jeddah,Saudi Arabia,FALSE
 2017-10-10,Taiwan,Bahrain,2,1,AFC Asian Cup qualification,Taipei,Taiwan,FALSE
 2017-10-10,Tajikistan,Nepal,3,0,AFC Asian Cup qualification,Hisor,Tajikistan,FALSE
-2017-10-10,Trinidad and Tobago,USA,2,1,FIFA World Cup qualification,Couva,Trinidad and Tobago,FALSE
+2017-10-10,Trinidad and Tobago,United States,2,1,FIFA World Cup qualification,Couva,Trinidad and Tobago,FALSE
 2017-10-10,Turkmenistan,Singapore,2,1,AFC Asian Cup qualification,Ashgabat,Turkmenistan,FALSE
 2017-10-10,Uruguay,Bolivia,4,2,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 2017-10-10,Vietnam,Cambodia,5,0,AFC Asian Cup qualification,Hanoi,Vietnam,FALSE
@@ -39776,7 +39776,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2017-11-14,Macau,Kyrgyzstan,3,4,AFC Asian Cup qualification,Macau,Macau,FALSE
 2017-11-14,Nepal,Philippines,0,0,AFC Asian Cup qualification,Lalitpur,Nepal,FALSE
 2017-11-14,Palestine,Maldives,8,1,AFC Asian Cup qualification,Jenin,Palestine,FALSE
-2017-11-14,Portugal,USA,1,1,Friendly,Leiria,Portugal,FALSE
+2017-11-14,Portugal,United States,1,1,Friendly,Leiria,Portugal,FALSE
 2017-11-14,Qatar,Iceland,1,1,Friendly,Doha,Qatar,FALSE
 2017-11-14,Romania,Netherlands,0,3,Friendly,Bucharest,Romania,FALSE
 2017-11-14,Russia,Spain,3,3,Friendly,Saint Petersburg,Russia,FALSE
@@ -39898,13 +39898,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-01-27,Moldova,South Korea,0,1,Friendly,Antalya,Turkey,TRUE
 2018-01-27,Morocco,Namibia,2,0,African Nations Championship,Casablanca,Morocco,FALSE
 2018-01-27,Zambia,Sudan,0,1,African Nations Championship,Marrakech,Morocco,TRUE
-2018-01-28,USA,Bosnia and Herzegovina,0,0,Friendly,Carson,USA,FALSE
+2018-01-28,United States,Bosnia and Herzegovina,0,0,Friendly,Carson,United States,FALSE
 2018-01-28,Congo,Libya,1,1,African Nations Championship,Agadir,Morocco,TRUE
 2018-01-28,Nigeria,Angola,2,1,African Nations Championship,Tangier,Morocco,TRUE
 2018-01-28,Yorkshire,Ellan Vannin,1,1,Friendly,Fitzwilliam,England,FALSE
 2018-01-30,Azerbaijan,Moldova,0,0,Friendly,Antalya,Turkey,TRUE
 2018-01-30,Jamaica,South Korea,2,2,Friendly,Antalya,Turkey,TRUE
-2018-01-31,Mexico,Bosnia and Herzegovina,1,0,Friendly,San Antonio,USA,TRUE
+2018-01-31,Mexico,Bosnia and Herzegovina,1,0,Friendly,San Antonio,United States,TRUE
 2018-01-31,Morocco,Libya,3,1,African Nations Championship,Casablanca,Morocco,FALSE
 2018-01-31,Sudan,Nigeria,0,1,African Nations Championship,Marrakech,Morocco,TRUE
 2018-02-03,Latvia,South Korea,0,1,Friendly,Antalya,Turkey,TRUE
@@ -39952,10 +39952,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-03-23,Hungary,Kazakhstan,2,3,Friendly,Budapest,Hungary,FALSE
 2018-03-23,Italy,Argentina,0,2,Friendly,Manchester,England,TRUE
 2018-03-23,Japan,Mali,1,1,Friendly,Liège,Belgium,TRUE
-2018-03-23,Mexico,Iceland,3,0,Friendly,Santa Clara,USA,TRUE
+2018-03-23,Mexico,Iceland,3,0,Friendly,Santa Clara,United States,TRUE
 2018-03-23,Netherlands,England,0,1,Friendly,Amsterdam,Netherlands,FALSE
 2018-03-23,Norway,Australia,4,1,Friendly,Oslo,Norway,FALSE
-2018-03-23,Peru,Croatia,2,0,Friendly,Miami Gardens,USA,TRUE
+2018-03-23,Peru,Croatia,2,0,Friendly,Miami Gardens,United States,TRUE
 2018-03-23,Poland,Nigeria,0,1,Friendly,Wrocław,Poland,FALSE
 2018-03-23,Portugal,Egypt,2,1,Friendly,Zürich,Switzerland,TRUE
 2018-03-23,Russia,Brazil,0,3,Friendly,Moscow,Russia,FALSE
@@ -40025,14 +40025,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-03-27,Lebanon,Malaysia,2,1,AFC Asian Cup qualification,Beirut,Lebanon,FALSE
 2018-03-27,Luxembourg,Austria,0,4,Friendly,Luxembourg,Luxembourg,FALSE
 2018-03-27,Maldives,Bhutan,7,0,AFC Asian Cup qualification,Malé,Maldives,FALSE
-2018-03-27,Mexico,Croatia,0,1,Friendly,Arlington,USA,TRUE
+2018-03-27,Mexico,Croatia,0,1,Friendly,Arlington,United States,TRUE
 2018-03-27,Moldova,Ivory Coast,1,2,Friendly,Beauvais,France,TRUE
 2018-03-27,Mongolia,Mauritius,0,2,Friendly,Ulan Bator,Mongolia,FALSE
 2018-03-27,Montenegro,Turkey,2,2,Friendly,Podgorica,Montenegro,FALSE
 2018-03-27,Morocco,Uzbekistan,2,0,Friendly,Casablanca,Morocco,FALSE
 2018-03-27,Namibia,Lesotho,2,1,Friendly,Windhoek,Namibia,FALSE
 2018-03-27,Oman,Palestine,1,0,AFC Asian Cup qualification,Muscat,Oman,FALSE
-2018-03-27,Peru,Iceland,3,1,Friendly,Harrison,USA,TRUE
+2018-03-27,Peru,Iceland,3,1,Friendly,Harrison,United States,TRUE
 2018-03-27,Philippines,Tajikistan,2,1,AFC Asian Cup qualification,Manila,Philippines,FALSE
 2018-03-27,Poland,South Korea,3,2,Friendly,Chorzów,Poland,FALSE
 2018-03-27,Romania,Sweden,1,0,Friendly,Craiova,Romania,FALSE
@@ -40047,7 +40047,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-03-27,Tunisia,Costa Rica,1,0,Friendly,Nice,France,TRUE
 2018-03-27,Uganda,Malawi,0,0,Friendly,Kampala,Uganda,FALSE
 2018-03-27,Ukraine,Japan,2,1,Friendly,Liège,Belgium,TRUE
-2018-03-27,USA,Paraguay,1,0,Friendly,Cary,USA,FALSE
+2018-03-27,United States,Paraguay,1,0,Friendly,Cary,United States,FALSE
 2018-03-27,Yemen,Nepal,2,1,AFC Asian Cup qualification,Doha,Qatar,TRUE
 2018-04-01,Malaysia,Bhutan,7,0,Friendly,Kuala Lumpur,Malaysia,FALSE
 2018-04-08,Barawa,Chagos Islands,4,1,Friendly,London,England,FALSE
@@ -40070,13 +40070,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-05-27,Niger,Central African Republic,3,3,Friendly,Niamey,Niger,FALSE
 2018-05-27,Madagascar,Mozambique,2,1,COSAFA Cup,Polokwane,South Africa,TRUE
 2018-05-27,Comoros,Seychelles,1,1,COSAFA Cup,Polokwane,South Africa,TRUE
-2018-05-28,USA,Bolivia,3,0,Friendly,Chester,USA,FALSE
+2018-05-28,United States,Bolivia,3,0,Friendly,Chester,United States,FALSE
 2018-05-28,Nigeria,DR Congo,1,1,Friendly,Port Harcourt,Nigeria,FALSE
 2018-05-28,Kenya,Equatorial Guinea,1,0,Friendly,Machakos,Kenya,FALSE
 2018-05-28,Portugal,Tunisia,2,2,Friendly,Braga,Portugal,FALSE
 2018-05-28,Italy,Saudi Arabia,2,1,Friendly,St. Gallen,Switzerland,TRUE
 2018-05-28,France,Republic of Ireland,2,0,Friendly,Saint-Denis,France,FALSE
-2018-05-28,Mexico,Wales,0,0,Friendly,Pasadena,USA,TRUE
+2018-05-28,Mexico,Wales,0,0,Friendly,Pasadena,United States,TRUE
 2018-05-28,Turkey,Iran,2,1,Friendly,Istanbul,Turkey,FALSE
 2018-05-28,South Korea,Honduras,2,0,Friendly,Daegu,South Korea,FALSE
 2018-05-28,Bosnia and Herzegovina,Montenegro,0,0,Friendly,Zenica,Bosnia and Herzegovina,FALSE
@@ -40120,13 +40120,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-06-01,Botswana,Mauritius,6,0,COSAFA Cup,Polokwane,South Africa,TRUE
 2018-06-01,Angola,Malawi,0,0,COSAFA Cup,Polokwane,South Africa,TRUE
 2018-06-01,India,Taiwan,5,0,Intercontinental Cup,Mumbai,India,FALSE
-2018-06-02,El Salvador,Honduras,1,0,Friendly,Houston,USA,TRUE
+2018-06-02,El Salvador,Honduras,1,0,Friendly,Houston,United States,TRUE
 2018-06-02,Thailand,China PR,0,2,Friendly,Bangkok,Thailand,FALSE
 2018-06-02,England,Nigeria,2,1,Friendly,London,England,FALSE
 2018-06-02,Montenegro,Slovenia,0,2,Friendly,Podgorica,Montenegro,FALSE
 2018-06-02,Mexico,Scotland,1,0,Friendly,Mexico City,Mexico,FALSE
 2018-06-02,Sweden,Denmark,0,0,Friendly,Solna,Sweden,FALSE
-2018-06-02,Republic of Ireland,USA,2,1,Friendly,Dublin,Republic of Ireland,FALSE
+2018-06-02,Republic of Ireland,United States,2,1,Friendly,Dublin,Republic of Ireland,FALSE
 2018-06-02,Belgium,Portugal,0,0,Friendly,Brussels,Belgium,FALSE
 2018-06-02,Austria,Germany,2,1,Friendly,Klagenfurt,Austria,FALSE
 2018-06-02,Niger,Uganda,2,1,Friendly,Niamey,Niger,FALSE
@@ -40218,7 +40218,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-06-09,Latvia,Azerbaijan,1,3,Friendly,Riga,Latvia,FALSE
 2018-06-09,Finland,Belarus,2,0,Friendly,Tampere,Finland,FALSE
 2018-06-09,Tunisia,Spain,0,1,Friendly,Krasnodar,Russia,TRUE
-2018-06-09,France,USA,1,1,Friendly,Lyon,France,FALSE
+2018-06-09,France,United States,1,1,Friendly,Lyon,France,FALSE
 2018-06-09,Matabeleland,Tamil Eelam,1,0,CONIFA World Football Cup,Aveley,England,TRUE
 2018-06-09,Tibet,United Koreans in Japan,1,1,CONIFA World Football Cup,Rotherhithe,England,TRUE
 2018-06-09,Kabylia,Abkhazia,0,2,CONIFA World Football Cup,Aveley,England,TRUE
@@ -40352,16 +40352,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-09-07,Romania,Montenegro,0,0,UEFA Nations League,Ploiești,Romania,FALSE
 2018-09-07,Faroe Islands,Malta,3,1,UEFA Nations League,Tórshavn,Faroe Islands,FALSE
 2018-09-07,Azerbaijan,Kosovo,0,0,UEFA Nations League,Baku,Azerbaijan,FALSE
-2018-09-07,Argentina,Guatemala,3,0,Friendly,Los Angeles,USA,TRUE
+2018-09-07,Argentina,Guatemala,3,0,Friendly,Los Angeles,United States,TRUE
 2018-09-07,Taiwan,Malaysia,2,0,Friendly,Taipei,Taiwan,FALSE
-2018-09-07,Ecuador,Jamaica,2,0,Friendly,Harrison,USA,TRUE
+2018-09-07,Ecuador,Jamaica,2,0,Friendly,Harrison,United States,TRUE
 2018-09-07,South Korea,Costa Rica,2,0,Friendly,Goyang,South Korea,FALSE
-2018-09-07,Mexico,Uruguay,1,4,Friendly,Houston,USA,TRUE
+2018-09-07,Mexico,Uruguay,1,4,Friendly,Houston,United States,TRUE
 2018-09-07,Qatar,China PR,1,0,Friendly,Doha,Qatar,FALSE
 2018-09-07,Scotland,Belgium,0,4,Friendly,Glasgow,Scotland,FALSE
 2018-09-07,Singapore,Mauritius,1,1,Friendly,Bishan,Singapore,FALSE
-2018-09-07,USA,Brazil,0,2,Friendly,East Rutherford,USA,FALSE
-2018-09-07,Venezuela,Colombia,1,2,Friendly,Miami Gardens,USA,TRUE
+2018-09-07,United States,Brazil,0,2,Friendly,East Rutherford,United States,FALSE
+2018-09-07,Venezuela,Colombia,1,2,Friendly,Miami Gardens,United States,TRUE
 2018-09-07,Maldives,Sri Lanka,0,0,SAFF Cup,Dhaka,Bangladesh,TRUE
 2018-09-07,Anguilla,French Guiana,0,5,CONCACAF Nations League qualification,The Valley,Anguilla,FALSE
 2018-09-07,Antigua and Barbuda,Saint Lucia,0,3,CONCACAF Nations League qualification,North Sound,Antigua and Barbuda,FALSE
@@ -40402,7 +40402,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-09-09,Rwanda,Ivory Coast,1,2,African Cup of Nations qualification,Kigali,Rwanda,FALSE
 2018-09-09,India,Maldives,2,0,SAFF Cup,Dhaka,Bangladesh,TRUE
 2018-09-09,Bonaire,Dominican Republic,0,5,CONCACAF Nations League qualification,Willemstad,Netherlands Antilles,TRUE
-2018-09-09,USA Virgin Islands,Canada,0,8,CONCACAF Nations League qualification,Bradenton,USA,TRUE
+2018-09-09,United States Virgin Islands,Canada,0,8,CONCACAF Nations League qualification,Bradenton,United States,TRUE
 2018-09-09,Aruba,Bermuda,3,1,CONCACAF Nations League qualification,Willemstad,Netherlands Antilles,TRUE
 2018-09-09,Jamaica,Cayman Islands,4,0,CONCACAF Nations League qualification,Kingston,Jamaica,FALSE
 2018-09-09,Saint Kitts and Nevis,Puerto Rico,1,0,CONCACAF Nations League qualification,Basseterre,Saint Kitts and Nevis,FALSE
@@ -40429,8 +40429,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-09-11,Finland,Estonia,1,0,UEFA Nations League,Turku,Finland,FALSE
 2018-09-11,San Marino,Luxembourg,0,3,UEFA Nations League,Serravalle,San Marino,FALSE
 2018-09-11,Moldova,Belarus,0,0,UEFA Nations League,Chișinău,Moldova,FALSE
-2018-09-11,Colombia,Argentina,0,0,Friendly,East Rutherford,USA,TRUE
-2018-09-11,Ecuador,Guatemala,2,0,Friendly,Bridgeview,USA,TRUE
+2018-09-11,Colombia,Argentina,0,0,Friendly,East Rutherford,United States,TRUE
+2018-09-11,Ecuador,Guatemala,2,0,Friendly,Bridgeview,United States,TRUE
 2018-09-11,England,Switzerland,1,0,Friendly,London,England,FALSE
 2018-09-11,Gabon,Zambia,0,1,Friendly,Libreville,Gabon,FALSE
 2018-09-11,Indonesia,Mauritius,1,0,Friendly,Cikarang,Indonesia,FALSE
@@ -40445,10 +40445,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-09-11,Poland,Republic of Ireland,1,1,Friendly,Wrocław,Poland,FALSE
 2018-09-11,Qatar,Palestine,3,0,Friendly,Doha,Qatar,FALSE
 2018-09-11,Singapore,Fiji,2,0,Friendly,Bishan,Singapore,FALSE
-2018-09-11,USA,Mexico,1,0,Friendly,Nashville,USA,FALSE
+2018-09-11,United States,Mexico,1,0,Friendly,Nashville,United States,FALSE
 2018-09-11,Uzbekistan,Iran,0,1,Friendly,Tashkent,Uzbekistan,FALSE
 2018-09-11,Saint Martin,Guadeloupe,0,3,CONCACAF Nations League qualification,The Valley,Anguilla,TRUE
-2018-09-12,Brazil,El Salvador,5,0,Friendly,Landover,USA,TRUE
+2018-09-12,Brazil,El Salvador,5,0,Friendly,Landover,United States,TRUE
 2018-09-12,India,Pakistan,3,1,SAFF Cup,Dhaka,Bangladesh,TRUE
 2018-09-12,Nepal,Maldives,0,3,SAFF Cup,Dhaka,Bangladesh,TRUE
 2018-09-15,Maldives,India,2,1,SAFF Cup,Dhaka,Bangladesh,TRUE
@@ -40474,7 +40474,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-10-11,Kuwait,Lebanon,1,0,Friendly,Kuwait City,Kuwait,FALSE
 2018-10-11,Mexico,Costa Rica,3,2,Friendly,San Nicolás de los Garza,Mexico,FALSE
 2018-10-11,Turkey,Bosnia and Herzegovina,0,0,Friendly,Rize,Turkey,FALSE
-2018-10-11,USA,Colombia,2,4,Friendly,Tampa,USA,FALSE
+2018-10-11,United States,Colombia,2,4,Friendly,Tampa,United States,FALSE
 2018-10-11,Wales,Spain,1,4,Friendly,Cardiff,Wales,FALSE
 2018-10-11,Congo,Liberia,3,1,African Cup of Nations qualification,Brazzaville,Congo,FALSE
 2018-10-11,French Guiana,Saint Vincent and the Grenadines,0,1,CONCACAF Nations League qualification,Cayenne,French Guiana,FALSE
@@ -40488,7 +40488,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-10-12,Cambodia,Timor-Leste,2,2,Friendly,Phnom Penh,Cambodia,FALSE
 2018-10-12,Japan,Panama,3,0,Kirin Challenge Cup,Niigata,Japan,FALSE
 2018-10-12,South Korea,Uruguay,2,1,Friendly,Seoul,South Korea,FALSE
-2018-10-12,Peru,Chile,3,0,Friendly,Miami Gardens,USA,TRUE
+2018-10-12,Peru,Chile,3,0,Friendly,Miami Gardens,United States,TRUE
 2018-10-12,Qatar,Ecuador,4,3,Friendly,Doha,Qatar,FALSE
 2018-10-12,Saudi Arabia,Brazil,0,2,Friendly,Riyadh,Saudi Arabia,FALSE
 2018-10-12,Singapore,Mongolia,2,0,Friendly,Bishan,Singapore,FALSE
@@ -40501,7 +40501,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-10-12,Egypt,Eswatini,4,1,African Cup of Nations qualification,Cairo,Egypt,FALSE
 2018-10-12,Cape Verde,Tanzania,3,0,African Cup of Nations qualification,Praia,Cape Verde,FALSE
 2018-10-12,Basque Country,Venezuela,4,2,Friendly,Vitoria-Gasteiz,Spain,FALSE
-2018-10-12,USA Virgin Islands,Curaçao,0,5,CONCACAF Nations League qualification,Bradenton,USA,TRUE
+2018-10-12,United States Virgin Islands,Curaçao,0,5,CONCACAF Nations League qualification,Bradenton,United States,TRUE
 2018-10-12,Bahamas,Antigua and Barbuda,0,6,CONCACAF Nations League qualification,Nassau,Bahamas,FALSE
 2018-10-12,Dominican Republic,Cayman Islands,3,0,CONCACAF Nations League qualification,Santiago de los Caballeros,Dominican Republic,FALSE
 2018-10-12,Bermuda,Sint Maarten,12,0,CONCACAF Nations League qualification,Hamilton,Bermuda,FALSE
@@ -40562,7 +40562,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-10-16,Belgium,Netherlands,1,1,Friendly,Brussels,Belgium,FALSE
 2018-10-16,Cambodia,Singapore,1,2,Friendly,Phnom Penh,Cambodia,FALSE
 2018-10-16,China PR,Syria,2,0,Friendly,Nanjing,China PR,FALSE
-2018-10-16,Colombia,Costa Rica,3,1,Friendly,Harrison,USA,TRUE
+2018-10-16,Colombia,Costa Rica,3,1,Friendly,Harrison,United States,TRUE
 2018-10-16,Denmark,Austria,2,0,Friendly,Herning,Denmark,FALSE
 2018-10-16,Indonesia,Hong Kong,1,1,Friendly,Cikarang,Indonesia,FALSE
 2018-10-16,Iran,Bolivia,2,1,Friendly,Tehran,Iran,FALSE
@@ -40574,7 +40574,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-10-16,Oman,Ecuador,0,0,Friendly,Doha,Qatar,TRUE
 2018-10-16,Sweden,Slovakia,1,1,Friendly,Stockholm,Sweden,FALSE
 2018-10-16,United Arab Emirates,Venezuela,0,2,Friendly,Barcelona,Spain,TRUE
-2018-10-16,USA,Peru,1,1,Friendly,East Hartford,USA,FALSE
+2018-10-16,United States,Peru,1,1,Friendly,East Hartford,United States,FALSE
 2018-10-16,Uzbekistan,Qatar,2,0,Friendly,Tashkent,Uzbekistan,FALSE
 2018-10-16,Madagascar,Equatorial Guinea,1,0,African Cup of Nations qualification,Antananarivo,Madagascar,FALSE
 2018-10-16,Malawi,Cameroon,0,0,African Cup of Nations qualification,Blantyre,Malawi,FALSE
@@ -40616,7 +40616,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-11-15,Kazakhstan,Latvia,1,1,UEFA Nations League,Astana,Kazakhstan,FALSE
 2018-11-15,Luxembourg,Belarus,0,2,UEFA Nations League,Luxembourg City,Luxembourg,FALSE
 2018-11-15,San Marino,Moldova,0,1,UEFA Nations League,Serravalle,San Marino,FALSE
-2018-11-15,England,USA,3,0,Friendly,London,England,FALSE
+2018-11-15,England,United States,3,0,Friendly,London,England,FALSE
 2018-11-15,Germany,Russia,3,0,Friendly,Leipzig,Germany,FALSE
 2018-11-15,Iran,Trinidad and Tobago,1,0,Friendly,Tehran,Iran,FALSE
 2018-11-15,Israel,Guatemala,7,0,Friendly,Netanya,Israel,FALSE
@@ -40687,7 +40687,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-11-18,Yorkshire,Panjab,5,4,Friendly,Ossett,England,FALSE
 2018-11-18,Turks and Caicos Islands,Saint Vincent and the Grenadines,3,2,CONCACAF Nations League qualification,Providenciales,Turks and Caicos Islands,FALSE
 2018-11-18,Bahamas,Anguilla,1,1,CONCACAF Nations League qualification,Nassau,Bahamas,FALSE
-2018-11-18,Barbados,USA Virgin Islands,3,0,CONCACAF Nations League qualification,Bridgetown,Barbados,FALSE
+2018-11-18,Barbados,United States Virgin Islands,3,0,CONCACAF Nations League qualification,Bridgetown,Barbados,FALSE
 2018-11-18,Saint Kitts and Nevis,Canada,0,1,CONCACAF Nations League qualification,Basseterre,Saint Kitts and Nevis,FALSE
 2018-11-19,Germany,Netherlands,2,2,UEFA Nations League,Gelsenkirchen,Germany,FALSE
 2018-11-19,Czech Republic,Slovakia,1,0,UEFA Nations League,Prague,Czech Republic,FALSE
@@ -40719,7 +40719,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2018-11-20,France,Uruguay,1,0,Friendly,Paris,France,FALSE
 2018-11-20,Iran,Venezuela,1,1,Friendly,Doha,Qatar,TRUE
 2018-11-20,Iraq,Bolivia,0,0,Friendly,Al-Ain,Iraq,FALSE
-2018-11-20,Italy,USA,1,0,Friendly,Genk,Belgium,TRUE
+2018-11-20,Italy,United States,1,0,Friendly,Genk,Belgium,TRUE
 2018-11-20,Japan,Kyrgyzstan,4,0,Kirin Challenge Cup,Toyota,Japan,FALSE
 2018-11-20,Jordan,Saudi Arabia,1,1,Friendly,Amman,Jordan,FALSE
 2018-11-20,South Korea,Uzbekistan,4,0,Friendly,Brisbane,Australia,TRUE
@@ -40824,16 +40824,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-01-24,Vietnam,Japan,0,1,AFC Asian Cup,Dubai,United Arab Emirates,TRUE
 2019-01-25,South Korea,Qatar,0,1,AFC Asian Cup,Abu Dhabi,United Arab Emirates,TRUE
 2019-01-25,United Arab Emirates,Australia,1,0,AFC Asian Cup,Al Ain,United Arab Emirates,FALSE
-2019-01-27,USA,Panama,3,0,Friendly,Glendale,USA,FALSE
+2019-01-27,United States,Panama,3,0,Friendly,Glendale,United States,FALSE
 2019-01-28,Iran,Japan,0,3,AFC Asian Cup,Al Ain,United Arab Emirates,TRUE
 2019-01-29,United Arab Emirates,Qatar,0,4,AFC Asian Cup,Abu Dhabi,United Arab Emirates,FALSE
 2019-02-01,Japan,Qatar,1,3,AFC Asian Cup,Abu Dhabi,United Arab Emirates,TRUE
-2019-02-02,USA,Costa Rica,2,0,Friendly,San Jose,USA,FALSE
+2019-02-02,United States,Costa Rica,2,0,Friendly,San Jose,United States,FALSE
 2019-02-21,Kazakhstan,Moldova,1,0,Friendly,Belek,Turkey,TRUE
 2019-02-27,Cuba,Bermuda,5,0,Friendly,Havana,Cuba,FALSE
 2019-03-03,Bolivia,Nicaragua,2,2,Friendly,Villa Tunari,Bolivia,FALSE
 2019-03-04,Barbados,Grenada,3,0,Friendly,Kingstown,Saint Vincent and the Grenadines,TRUE
-2019-03-06,El Salvador,Guatemala,3,1,Friendly,Los Angeles,USA,TRUE
+2019-03-06,El Salvador,Guatemala,3,1,Friendly,Los Angeles,United States,TRUE
 2019-03-09,Cambodia,Bangladesh,0,1,Friendly,Phnom Penh,Cambodia,FALSE
 2019-03-16,Bahamas,Turks and Caicos Islands,6,1,Friendly,Nassau,Bahamas,FALSE
 2019-03-18,Fiji,New Caledonia,3,0,Friendly,Suva,Fiji,FALSE
@@ -40845,7 +40845,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-03-21,Kuwait,Nepal,0,0,Friendly,Al Ahmadi,Kuwait,FALSE
 2019-03-21,Mauritius,New Caledonia,3,1,Friendly,Lautoka,Fiji,TRUE
 2019-03-21,United Arab Emirates,Saudi Arabia,2,1,Friendly,Abu Dhabi,United Arab Emirates,FALSE
-2019-03-21,USA,Ecuador,1,0,Friendly,Orlando,USA,FALSE
+2019-03-21,United States,Ecuador,1,0,Friendly,Orlando,United States,FALSE
 2019-03-21,Northern Ireland,Estonia,2,0,UEFA Euro qualification,Belfast,Northern Ireland,FALSE
 2019-03-21,Netherlands,Belarus,4,0,UEFA Euro qualification,Rotterdam,Netherlands,FALSE
 2019-03-21,Croatia,Azerbaijan,2,1,UEFA Euro qualification,Zagreb,Croatia,FALSE
@@ -40861,8 +40861,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-03-22,Guatemala,Costa Rica,1,0,Friendly,Guatemala City,Guatemala,FALSE
 2019-03-22,Japan,Colombia,0,1,Kirin Challenge Cup,Yokohama,Japan,FALSE
 2019-03-22,South Korea,Bolivia,1,0,Friendly,Ulsan,South Korea,FALSE
-2019-03-22,Mexico,Chile,3,1,Friendly,San Diego,USA,TRUE
-2019-03-22,Peru,Paraguay,1,0,Friendly,Harrison,USA,TRUE
+2019-03-22,Mexico,Chile,3,1,Friendly,San Diego,United States,TRUE
+2019-03-22,Peru,Paraguay,1,0,Friendly,Harrison,United States,TRUE
 2019-03-22,Bulgaria,Montenegro,1,1,UEFA Euro qualification,Sofia,Bulgaria,FALSE
 2019-03-22,England,Czech Republic,5,0,UEFA Euro qualification,London,England,FALSE
 2019-03-22,Portugal,Ukraine,0,0,UEFA Euro qualification,Lisbon,Portugal,FALSE
@@ -40871,7 +40871,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-03-22,Andorra,Iceland,0,2,UEFA Euro qualification,Andorra la Vella,Andorra,FALSE
 2019-03-22,Moldova,France,1,4,UEFA Euro qualification,Chișinău,Moldova,FALSE
 2019-03-22,Botswana,Angola,0,1,African Cup of Nations qualification,Francistown,Botswana,FALSE
-2019-03-22,Anguilla,USA Virgin Islands,0,3,CONCACAF Nations League qualification,The Valley,Anguilla,FALSE
+2019-03-22,Anguilla,United States Virgin Islands,0,3,CONCACAF Nations League qualification,The Valley,Anguilla,FALSE
 2019-03-22,Saint Vincent and the Grenadines,Bonaire,2,1,CONCACAF Nations League qualification,Arnos Vale,Saint Vincent and the Grenadines,FALSE
 2019-03-22,Cayman Islands,Montserrat,1,2,CONCACAF Nations League qualification,West Bay,Cayman Islands,FALSE
 2019-03-22,Saint Lucia,Aruba,3,2,CONCACAF Nations League qualification,North Sound,Antigua and Barbuda,TRUE
@@ -40939,18 +40939,18 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-03-26,Czech Republic,Brazil,1,3,Friendly,Prague,Czech Republic,FALSE
 2019-03-26,Ghana,Mauritania,3,1,Friendly,Accra,Ghana,FALSE
 2019-03-26,Gibraltar,Estonia,0,1,Friendly,Gibraltar,Gibraltar,FALSE
-2019-03-26,Honduras,Ecuador,0,0,Friendly,Harrison,USA,TRUE
+2019-03-26,Honduras,Ecuador,0,0,Friendly,Harrison,United States,TRUE
 2019-03-26,Ivory Coast,Liberia,1,0,Friendly,Abidjan,Ivory Coast,FALSE
 2019-03-26,Japan,Bolivia,0,1,Kirin Challenge Cup,Kobe,Japan,FALSE
 2019-03-26,South Korea,Colombia,2,1,Friendly,Seoul,South Korea,FALSE
 2019-03-26,Morocco,Argentina,0,1,Friendly,Tangier,Morocco,FALSE
 2019-03-26,Nicaragua,Guatemala,0,1,Friendly,Managua,Nicaragua,FALSE
 2019-03-26,Nigeria,Egypt,1,0,Friendly,Asaba,Nigeria,FALSE
-2019-03-26,Paraguay,Mexico,2,4,Friendly,Santa Clara,USA,TRUE
-2019-03-26,Peru,El Salvador,0,2,Friendly,Washington,USA,TRUE
+2019-03-26,Paraguay,Mexico,2,4,Friendly,Santa Clara,United States,TRUE
+2019-03-26,Peru,El Salvador,0,2,Friendly,Washington,United States,TRUE
 2019-03-26,Senegal,Mali,2,1,Friendly,Dakar,Senegal,FALSE
 2019-03-26,United Arab Emirates,Syria,0,0,Friendly,Abu Dhabi,United Arab Emirates,FALSE
-2019-03-26,USA,Chile,1,1,Friendly,Houston,USA,FALSE
+2019-03-26,United States,Chile,1,1,Friendly,Houston,United States,FALSE
 2019-03-26,Republic of Ireland,Georgia,1,0,UEFA Euro qualification,Dublin,Republic of Ireland,FALSE
 2019-03-26,Switzerland,Denmark,3,3,UEFA Euro qualification,Basel,Switzerland,FALSE
 2019-03-26,Malta,Spain,0,2,UEFA Euro qualification,Attard,Malta,FALSE
@@ -40966,7 +40966,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-05-11,Seychelles,Botswana,1,3,African Nations Championship qualification,Victoria,Seychelles,FALSE
 2019-05-25,Eswatini,Mauritius,2,2,COSAFA Cup,Durban,South Africa,TRUE
 2019-05-25,Kernow,Barawa,5,0,Friendly,Bodmin,England,FALSE
-2019-05-25,Cascadia,Chagos Islands,6,3,Friendly,Kent,USA,FALSE
+2019-05-25,Cascadia,Chagos Islands,6,3,Friendly,Kent,United States,FALSE
 2019-05-26,Mozambique,Namibia,1,2,COSAFA Cup,Durban,South Africa,TRUE
 2019-05-26,Malawi,Seychelles,3,0,COSAFA Cup,Durban,South Africa,TRUE
 2019-05-27,Eswatini,Comoros,2,2,COSAFA Cup,Durban,South Africa,TRUE
@@ -40981,11 +40981,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-05-31,Laos,Sri Lanka,2,2,Friendly,Vientiane,Laos,FALSE
 2019-06-01,Lesotho,Uganda,0,0,COSAFA Cup,Durban,South Africa,TRUE
 2019-06-01,Zimbabwe,Comoros,2,0,COSAFA Cup,Durban,South Africa,TRUE
-2019-06-01,Venezuela,Ecuador,1,1,Friendly,Miami Gardens,USA,TRUE
+2019-06-01,Venezuela,Ecuador,1,1,Friendly,Miami Gardens,United States,TRUE
 2019-06-01,Yorkshire,Parishes of Jersey,1,0,Atlantic Heritage Cup,Ossett,England,FALSE
 2019-06-02,South Africa,Botswana,2,2,COSAFA Cup,Durban,South Africa,FALSE
 2019-06-02,Zambia,Malawi,2,2,COSAFA Cup,Durban,South Africa,TRUE
-2019-06-02,El Salvador,Haiti,1,0,Friendly,Washington,USA,TRUE
+2019-06-02,El Salvador,Haiti,1,0,Friendly,Washington,United States,TRUE
 2019-06-02,France,Bolivia,2,0,Friendly,Nantes,France,FALSE
 2019-06-02,Luxembourg,Madagascar,3,3,Friendly,Luxembourg City,Luxembourg,FALSE
 2019-06-02,Malaysia,Nepal,2,0,Friendly,Kuala Lumpur,Malaysia,FALSE
@@ -41011,10 +41011,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-06-05,Zimbabwe,Zambia,0,0,COSAFA Cup,Durban,South Africa,TRUE
 2019-06-05,Brazil,Qatar,2,0,Friendly,Brasília,Brazil,FALSE
 2019-06-05,Japan,Trinidad and Tobago,0,0,Kirin Challenge Cup,Toyota City,Japan,FALSE
-2019-06-05,Mexico,Venezuela,3,1,Friendly,Atlanta,USA,TRUE
+2019-06-05,Mexico,Venezuela,3,1,Friendly,Atlanta,United States,TRUE
 2019-06-05,Paraguay,Honduras,1,1,Friendly,Ciudad del Este,Paraguay,FALSE
 2019-06-05,Peru,Costa Rica,1,0,Friendly,Lima,Peru,FALSE
-2019-06-05,USA,Jamaica,0,1,Friendly,Washington,USA,FALSE
+2019-06-05,United States,Jamaica,0,1,Friendly,Washington,United States,FALSE
 2019-06-05,Portugal,Switzerland,3,1,UEFA Nations League,Porto,Portugal,FALSE
 2019-06-06,Bermuda,Guyana,1,0,Friendly,Hamilton,Bermuda,FALSE
 2019-06-06,Chile,Haiti,2,1,Friendly,Coquimbo,Chile,FALSE
@@ -41080,11 +41080,11 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-06-09,Cameroon,Zambia,2,1,Friendly,Majadahonda,Cameroon,FALSE
 2019-06-09,DR Congo,Burkina Faso,0,0,Friendly,Marbella,Spain,TRUE
 2019-06-09,Japan,El Salvador,2,0,Kirin Challenge Cup,Rifu,Japan,FALSE
-2019-06-09,Mexico,Ecuador,3,2,Friendly,Arlington,USA,TRUE
+2019-06-09,Mexico,Ecuador,3,2,Friendly,Arlington,United States,TRUE
 2019-06-09,Paraguay,Guatemala,2,0,Friendly,Asunción,Paraguay,FALSE
 2019-06-09,Peru,Colombia,0,3,Friendly,Lima,Peru,FALSE
 2019-06-09,Turkmenistan,Uganda,0,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
-2019-06-09,USA,Venezuela,0,3,Friendly,Cincinnati,USA,FALSE
+2019-06-09,United States,Venezuela,0,3,Friendly,Cincinnati,United States,FALSE
 2019-06-09,Switzerland,England,0,0,UEFA Nations League,Guimarães,Portugal,TRUE
 2019-06-09,Portugal,Netherlands,1,0,UEFA Nations League,Porto,Portugal,FALSE
 2019-06-09,Western Armenia,South Ossetia,0,1,CONIFA European Football Cup,Stepanakert,Azerbaijan,TRUE
@@ -41138,8 +41138,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-06-14,Brazil,Bolivia,3,0,Copa América,São Paulo,Brazil,FALSE
 2019-06-15,Venezuela,Peru,0,0,Copa América,Porto Alegre,Brazil,TRUE
 2019-06-15,Argentina,Colombia,0,2,Copa América,Salvador,Brazil,TRUE
-2019-06-15,Canada,Martinique,4,0,Gold Cup,Los Angeles,USA,TRUE
-2019-06-15,Mexico,Cuba,7,0,Gold Cup,Los Angeles,USA,TRUE
+2019-06-15,Canada,Martinique,4,0,Gold Cup,Los Angeles,United States,TRUE
+2019-06-15,Mexico,Cuba,7,0,Gold Cup,Los Angeles,United States,TRUE
 2019-06-15,Ghana,South Africa,0,0,Friendly,Dubai,United Arab Emirates,TRUE
 2019-06-15,Indonesia,Vanuatu,6,0,Friendly,Jakarta,Indonesia,FALSE
 2019-06-15,Ivory Coast,Uganda,0,1,Friendly,Abu Dhabi,United Arab Emirates,TRUE
@@ -41171,13 +41171,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-06-18,Guernsey,Saint Helena,9,0,Inter Games Football Tournament,Anglesey,Wales,TRUE
 2019-06-18,Bolivia,Peru,1,3,Copa América,Rio de Janeiro,Brazil,TRUE
 2019-06-18,Brazil,Venezuela,0,0,Copa América,Salvador,Brazil,FALSE
-2019-06-18,Panama,Trinidad and Tobago,2,0,Gold Cup,Saint Paul,USA,TRUE
-2019-06-18,USA,Guyana,4,0,Gold Cup,Saint Paul,USA,FALSE
+2019-06-18,Panama,Trinidad and Tobago,2,0,Gold Cup,Saint Paul,United States,TRUE
+2019-06-18,United States,Guyana,4,0,Gold Cup,Saint Paul,United States,FALSE
 2019-06-18,Benin,Mauritania,3,1,Friendly,Marrakech,Morocco,TRUE
 2019-06-19,Colombia,Qatar,1,0,Copa América,São Paulo,Brazil,TRUE
 2019-06-19,Argentina,Paraguay,1,1,Copa América,Belo Horizonte,Brazil,TRUE
-2019-06-19,Cuba,Martinique,0,3,Gold Cup,Denver,USA,TRUE
-2019-06-19,Mexico,Canada,3,1,Gold Cup,Denver,USA,TRUE
+2019-06-19,Cuba,Martinique,0,3,Gold Cup,Denver,United States,TRUE
+2019-06-19,Mexico,Canada,3,1,Gold Cup,Denver,United States,TRUE
 2019-06-19,Ivory Coast,Zambia,4,1,Friendly,Abu Dhabi,United Arab Emirates,TRUE
 2019-06-20,Western Isles,Saint Helena,2,1,Inter Games Football Tournament,Anglesey,Wales,TRUE
 2019-06-20,Orkney,Alderney,1,2,Inter Games Football Tournament,Anglesey,Wales,TRUE
@@ -41185,44 +41185,44 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-06-20,Ynys Môn,Shetland,2,1,Inter Games Football Tournament,Anglesey,Wales,FALSE
 2019-06-20,Isle of Man,Guernsey,2,3,Inter Games Football Tournament,Anglesey,Wales,TRUE
 2019-06-20,Uruguay,Japan,2,2,Copa América,Porto Alegre,Brazil,TRUE
-2019-06-20,Nicaragua,Haiti,0,2,Gold Cup,Frisco,USA,TRUE
-2019-06-20,Costa Rica,Bermuda,2,1,Gold Cup,Frisco,USA,TRUE
+2019-06-20,Nicaragua,Haiti,0,2,Gold Cup,Frisco,United States,TRUE
+2019-06-20,Costa Rica,Bermuda,2,1,Gold Cup,Frisco,United States,TRUE
 2019-06-21,Shetland,Isle of Man,0,5,Inter Games Football Tournament,Anglesey,Wales,TRUE
 2019-06-21,Ynys Môn,Guernsey,2,1,Inter Games Football Tournament,Anglesey,Wales,FALSE
 2019-06-21,Egypt,Zimbabwe,1,0,African Cup of Nations,Cairo,Egypt,FALSE
 2019-06-21,Ecuador,Chile,1,2,Copa América,Salvador,Brazil,TRUE
-2019-06-21,El Salvador,Jamaica,0,0,Gold Cup,Houston,USA,TRUE
-2019-06-21,Honduras,Curaçao,0,1,Gold Cup,Houston,USA,TRUE
+2019-06-21,El Salvador,Jamaica,0,0,Gold Cup,Houston,United States,TRUE
+2019-06-21,Honduras,Curaçao,0,1,Gold Cup,Houston,United States,TRUE
 2019-06-22,DR Congo,Uganda,0,2,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-22,Nigeria,Burundi,1,0,African Cup of Nations,Alexandria,Egypt,TRUE
 2019-06-22,Guinea,Madagascar,2,2,African Cup of Nations,Alexandria,Egypt,TRUE
 2019-06-22,Bolivia,Venezuela,1,3,Copa América,Belo Horizonte,Brazil,TRUE
-2019-06-22,Guyana,Panama,2,4,Gold Cup,Cleveland,USA,TRUE
-2019-06-22,USA,Trinidad and Tobago,6,0,Gold Cup,Cleveland,USA,FALSE
+2019-06-22,Guyana,Panama,2,4,Gold Cup,Cleveland,United States,TRUE
+2019-06-22,United States,Trinidad and Tobago,6,0,Gold Cup,Cleveland,United States,FALSE
 2019-06-22,Brazil,Peru,5,0,Copa América,São Paulo,Brazil,FALSE
 2019-06-23,Senegal,Tanzania,2,0,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-23,Algeria,Kenya,2,0,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-23,Morocco,Namibia,1,0,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-23,Colombia,Paraguay,1,0,Copa América,Salvador,Brazil,TRUE
 2019-06-23,Qatar,Argentina,0,2,Copa América,Porto Alegre,Brazil,TRUE
-2019-06-23,Canada,Cuba,7,0,Gold Cup,Charlotte,USA,TRUE
-2019-06-23,Martinique,Mexico,2,3,Gold Cup,Charlotte,USA,TRUE
+2019-06-23,Canada,Cuba,7,0,Gold Cup,Charlotte,United States,TRUE
+2019-06-23,Martinique,Mexico,2,3,Gold Cup,Charlotte,United States,TRUE
 2019-06-24,Ivory Coast,South Africa,1,0,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-24,Tunisia,Angola,1,1,African Cup of Nations,Suez,Egypt,TRUE
 2019-06-24,Mali,Mauritania,4,1,African Cup of Nations,Suez,Egypt,TRUE
 2019-06-24,Chile,Uruguay,0,1,Copa América,Rio de Janeiro,Brazil,TRUE
 2019-06-24,Ecuador,Japan,1,1,Copa América,Belo Horizonte,Brazil,TRUE
-2019-06-24,Bermuda,Nicaragua,2,0,Gold Cup,New Jersey,USA,TRUE
-2019-06-24,Haiti,Costa Rica,2,1,Gold Cup,New Jersey,USA,TRUE
+2019-06-24,Bermuda,Nicaragua,2,0,Gold Cup,New Jersey,United States,TRUE
+2019-06-24,Haiti,Costa Rica,2,1,Gold Cup,New Jersey,United States,TRUE
 2019-06-25,Cameroon,Guinea-Bissau,2,0,African Cup of Nations,Ismaila,Egypt,TRUE
 2019-06-25,Ghana,Benin,2,2,African Cup of Nations,Ismaila,Egypt,TRUE
-2019-06-25,Jamaica,Curaçao,1,1,Gold Cup,Los Angeles,USA,TRUE
-2019-06-25,Honduras,El Salvador,4,0,Gold Cup,Los Angeles,USA,TRUE
+2019-06-25,Jamaica,Curaçao,1,1,Gold Cup,Los Angeles,United States,TRUE
+2019-06-25,Honduras,El Salvador,4,0,Gold Cup,Los Angeles,United States,TRUE
 2019-06-26,Uganda,Zimbabwe,1,1,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-26,Egypt,DR Congo,2,0,African Cup of Nations,Cairo,Egypt,FALSE
 2019-06-26,Nigeria,Guinea,1,0,African Cup of Nations,Alexandria,Egypt,TRUE
-2019-06-26,Trinidad and Tobago,Guyana,1,1,Gold Cup,Kansas City,USA,TRUE
-2019-06-26,USA,Panama,1,0,Gold Cup,Kansas City,USA,FALSE
+2019-06-26,Trinidad and Tobago,Guyana,1,1,Gold Cup,Kansas City,United States,TRUE
+2019-06-26,United States,Panama,1,0,Gold Cup,Kansas City,United States,FALSE
 2019-06-27,Madagascar,Burundi,1,0,African Cup of Nations,Alexandria,Egypt,TRUE
 2019-06-27,Senegal,Algeria,0,1,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-27,Kenya,Tanzania,3,2,African Cup of Nations,Cairo,Egypt,TRUE
@@ -41236,14 +41236,14 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-06-29,Cameroon,Ghana,0,0,African Cup of Nations,Ismaila,Egypt,TRUE
 2019-06-29,Benin,Guinea-Bissau,0,0,African Cup of Nations,Ismaila,Egypt,TRUE
 2019-06-29,Uruguay,Peru,0,0,Copa América,Salvador,Brazil,TRUE
-2019-06-29,Haiti,Canada,3,2,Gold Cup,Houston,USA,TRUE
-2019-06-29,Mexico,Costa Rica,1,1,Gold Cup,Houston,USA,TRUE
+2019-06-29,Haiti,Canada,3,2,Gold Cup,Houston,United States,TRUE
+2019-06-29,Mexico,Costa Rica,1,1,Gold Cup,Houston,United States,TRUE
 2019-06-30,Egypt,Uganda,2,0,African Cup of Nations,Cairo,Egypt,FALSE
 2019-06-30,Zimbabwe,DR Congo,0,4,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-30,Burundi,Guinea,0,2,African Cup of Nations,Cairo,Egypt,TRUE
 2019-06-30,Madagascar,Nigeria,2,0,African Cup of Nations,Alexandria,Egypt,TRUE
-2019-06-30,Jamaica,Panama,1,0,Gold Cup,Philadelphia,USA,TRUE
-2019-06-30,USA,Curaçao,1,0,Gold Cup,Philadelphia,USA,FALSE
+2019-06-30,Jamaica,Panama,1,0,Gold Cup,Philadelphia,United States,TRUE
+2019-06-30,United States,Curaçao,1,0,Gold Cup,Philadelphia,United States,FALSE
 2019-07-01,Kenya,Senegal,0,3,African Cup of Nations,Cairo,Egypt,TRUE
 2019-07-01,Tanzania,Algeria,0,3,African Cup of Nations,Cairo,Egypt,TRUE
 2019-07-01,Namibia,Ivory Coast,1,4,African Cup of Nations,Cairo,Egypt,TRUE
@@ -41253,9 +41253,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-07-02,Benin,Cameroon,0,0,African Cup of Nations,Ismaila,Egypt,TRUE
 2019-07-02,Guinea-Bissau,Ghana,0,2,African Cup of Nations,Suez,Egypt,TRUE
 2019-07-02,Brazil,Argentina,2,0,Copa América,Belo Horizonte,Brazil,FALSE
-2019-07-02,Haiti,Mexico,0,1,Gold Cup,Glendale,USA,TRUE
+2019-07-02,Haiti,Mexico,0,1,Gold Cup,Glendale,United States,TRUE
 2019-07-03,Chile,Peru,0,3,Copa América,Porto Alegre,Brazil,TRUE
-2019-07-03,USA,Jamaica,3,1,Gold Cup,Nashville,USA,FALSE
+2019-07-03,United States,Jamaica,3,1,Gold Cup,Nashville,United States,FALSE
 2019-07-05,Morocco,Benin,1,1,African Cup of Nations,Cairo,Egypt,TRUE
 2019-07-05,Uganda,Senegal,0,1,African Cup of Nations,Cairo,Egypt,TRUE
 2019-07-06,Egypt,South Africa,0,1,African Cup of Nations,Cairo,Egypt,FALSE
@@ -41264,7 +41264,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-07-07,Algeria,Guinea,3,0,African Cup of Nations,Cairo,Egypt,TRUE
 2019-07-07,Madagascar,DR Congo,2,2,African Cup of Nations,Alexandria,Egypt,TRUE
 2019-07-07,Brazil,Peru,3,1,Copa América,Rio de Janeiro,Brazil,FALSE
-2019-07-07,USA,Mexico,0,1,Gold Cup,Chicago,USA,FALSE
+2019-07-07,United States,Mexico,0,1,Gold Cup,Chicago,United States,FALSE
 2019-07-07,India,Tajikistan,2,4,Intercontinental Cup,Ahmedabad,India,FALSE
 2019-07-08,Ghana,Tunisia,1,1,African Cup of Nations,Ismaila,Egypt,TRUE
 2019-07-08,Mali,Ivory Coast,0,1,African Cup of Nations,Suez,Egypt,TRUE
@@ -41354,12 +41354,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-09-04,Mauritius,Mozambique,0,1,FIFA World Cup qualification,Belle Vue Maurel,Mauritius,FALSE
 2019-09-04,São Tomé and Príncipe,Guinea-Bissau,0,1,FIFA World Cup qualification,São Tomé,São Tomé and Príncipe,FALSE
 2019-09-04,South Sudan,Equatorial Guinea,1,1,FIFA World Cup qualification,Omdurman,Sudan,TRUE
-2019-09-05,Argentina,Chile,0,0,Friendly,Los Angeles,USA,TRUE
+2019-09-05,Argentina,Chile,0,0,Friendly,Los Angeles,United States,TRUE
 2019-09-05,Honduras,Puerto Rico,4,0,Friendly,Tegucigalpa,Honduras,FALSE
 2019-09-05,South Korea,Georgia,2,2,Friendly,Istanbul,Turkey,TRUE
 2019-09-05,Montenegro,Hungary,2,1,Friendly,Podgorica,Montenegro,FALSE
 2019-09-05,Northern Ireland,Luxembourg,1,0,Friendly,Belfast,Northern Ireland,FALSE
-2019-09-05,Peru,Ecuador,0,1,Friendly,Harrison,USA,TRUE
+2019-09-05,Peru,Ecuador,0,1,Friendly,Harrison,United States,TRUE
 2019-09-05,Saudi Arabia,Mali,1,1,Friendly,Riyadh,Saudi Arabia,FALSE
 2019-09-05,Republic of Ireland,Switzerland,1,1,UEFA Euro qualification,Dublin,Republic of Ireland,FALSE
 2019-09-05,Gibraltar,Denmark,0,6,UEFA Euro qualification,Gibraltar,Gibraltar,FALSE
@@ -41375,7 +41375,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-09-05,Grenada,Saint Kitts and Nevis,2,1,CONCACAF Nations League,St. George's,Grenada,FALSE
 2019-09-05,French Guiana,Belize,3,0,CONCACAF Nations League,Cayenne,French Guiana,FALSE
 2019-09-05,Dominica,Suriname,1,2,CONCACAF Nations League,Roseau,Dominica,FALSE
-2019-09-05,USA Virgin Islands,Cayman Islands,0,2,CONCACAF Nations League,Saint Croix,USA Virgin Islands,FALSE
+2019-09-05,United States Virgin Islands,Cayman Islands,0,2,CONCACAF Nations League,Saint Croix,United States Virgin Islands,FALSE
 2019-09-05,Barbados,Saint Martin,4,0,CONCACAF Nations League,Bridgetown,Barbados,FALSE
 2019-09-05,Guatemala,Anguilla,10,0,CONCACAF Nations League,Guatemala City,Guatemala,FALSE
 2019-09-05,Guam,Maldives,0,1,FIFA World Cup qualification,Dededo,Guam,FALSE
@@ -41397,12 +41397,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-09-05,Chad,Sudan,1,3,FIFA World Cup qualification,N'Djamena,Chad,FALSE
 2019-09-05,Seychelles,Rwanda,0,3,FIFA World Cup qualification,Victoria,Seychelles,FALSE
 2019-09-05,Somalia,Zimbabwe,1,0,FIFA World Cup qualification,Djibouti,Djibouti,TRUE
-2019-09-06,Brazil,Colombia,2,2,Friendly,Miami Gardens,USA,TRUE
+2019-09-06,Brazil,Colombia,2,2,Friendly,Miami Gardens,United States,TRUE
 2019-09-06,Costa Rica,Uruguay,1,2,Friendly,San José,Costa Rica,FALSE
 2019-09-06,Ivory Coast,Benin,1,2,Friendly,Caen,Egypt,TRUE
 2019-09-06,Morocco,Burkina Faso,1,1,Friendly,Marrakech,Morocco,FALSE
 2019-09-06,Tunisia,Mauritania,1,0,Friendly,Radès,Tunisia,FALSE
-2019-09-06,USA,Mexico,0,3,Friendly,East Rutherford,USA,FALSE
+2019-09-06,United States,Mexico,0,3,Friendly,East Rutherford,United States,FALSE
 2019-09-06,Estonia,Belarus,1,2,UEFA Euro qualification,Tallinn,Estonia,FALSE
 2019-09-06,Germany,Netherlands,2,4,UEFA Euro qualification,Hamburg,Germany,FALSE
 2019-09-06,Wales,Azerbaijan,2,1,UEFA Euro qualification,Cardiff,Wales,FALSE
@@ -41447,7 +41447,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-09-08,Saint Kitts and Nevis,French Guiana,2,2,CONCACAF Nations League,Basseterre,Saint Kitts and Nevis,FALSE
 2019-09-08,Saint Vincent and the Grenadines,Dominica,1,0,CONCACAF Nations League,Arnos Vale,Saint Vincent and the Grenadines,FALSE
 2019-09-08,Suriname,Nicaragua,6,0,CONCACAF Nations League,Paramaribo,Suriname,FALSE
-2019-09-08,Saint Martin,USA Virgin Islands,1,2,CONCACAF Nations League,The Valley,Anguilla,TRUE
+2019-09-08,Saint Martin,United States Virgin Islands,1,2,CONCACAF Nations League,The Valley,Anguilla,TRUE
 2019-09-08,Cayman Islands,Barbados,3,2,CONCACAF Nations League,George Town,Cayman Islands,FALSE
 2019-09-08,Equatorial Guinea,South Sudan,1,0,FIFA World Cup qualification,Malabo,Equatorial Guinea,FALSE
 2019-09-08,Lesotho,Ethiopia,1,1,FIFA World Cup qualification,Maseru,Lesotho,FALSE
@@ -41470,9 +41470,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-09-09,Antigua and Barbuda,Aruba,2,1,CONCACAF Nations League,North Sound,Antigua and Barbuda,FALSE
 2019-09-09,Guyana,Jamaica,0,4,CONCACAF Nations League,Georgetown,Guyana,FALSE
 2019-09-09,Bahamas,Bonaire,2,1,CONCACAF Nations League,Nassau,Bahamas,FALSE
-2019-09-10,Argentina,Mexico,4,0,Friendly,San Antonio,USA,TRUE
-2019-09-10,Brazil,Peru,0,1,Friendly,Los Angeles,USA,TRUE
-2019-09-10,Colombia,Venezuela,0,0,Friendly,Tampa,USA,TRUE
+2019-09-10,Argentina,Mexico,4,0,Friendly,San Antonio,United States,TRUE
+2019-09-10,Brazil,Peru,0,1,Friendly,Los Angeles,United States,TRUE
+2019-09-10,Colombia,Venezuela,0,0,Friendly,Tampa,United States,TRUE
 2019-09-10,Ecuador,Bolivia,3,0,Friendly,Cuenca,Ecuador,FALSE
 2019-09-10,Honduras,Chile,2,1,Friendly,San Pedro Sula,Honduras,FALSE
 2019-09-10,Ivory Coast,Tunisia,2,1,Friendly,Rouen,France,TRUE
@@ -41481,7 +41481,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-09-10,Oman,Lebanon,1,0,Friendly,Muscat,Oman,FALSE
 2019-09-10,Republic of Ireland,Bulgaria,3,1,Friendly,Dublin,Republic of Ireland,FALSE
 2019-09-10,Ukraine,Nigeria,2,2,Friendly,Dnipro,Ukraine,FALSE
-2019-09-10,USA,Uruguay,1,1,Friendly,St. Louis,USA,FALSE
+2019-09-10,United States,Uruguay,1,1,Friendly,St. Louis,United States,FALSE
 2019-09-10,England,Kosovo,5,3,UEFA Euro qualification,London,England,FALSE
 2019-09-10,Montenegro,Czech Republic,0,3,UEFA Euro qualification,Podgorica,Montenegro,FALSE
 2019-09-10,Luxembourg,Serbia,1,3,UEFA Euro qualification,Luxembourg City,Luxembourg,FALSE
@@ -41599,7 +41599,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-10-11,Turkey,Albania,1,0,UEFA Euro qualification,Istanbul,Turkey,FALSE
 2019-10-11,Morocco,Libya,1,1,Friendly,Morocco,Morocco,FALSE
 2019-10-11,Uruguay,Peru,1,0,Friendly,Montevideo,Uruguay,FALSE
-2019-10-11,USA,Cuba,7,0,CONCACAF Nations League,Washington,USA,FALSE
+2019-10-11,United States,Cuba,7,0,CONCACAF Nations League,Washington,United States,FALSE
 2019-10-11,Bermuda,Mexico,1,5,CONCACAF Nations League,Hamilton,Bermuda,FALSE
 2019-10-11,Antigua and Barbuda,Guyana,2,1,CONCACAF Nations League,North Sound,Antigua and Barbuda,FALSE
 2019-10-11,Saint Vincent and the Grenadines,Suriname,2,2,CONCACAF Nations League,Arnos Vale,Saint Vincent and the Grenadines,FALSE
@@ -41619,7 +41619,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-10-12,Dominican Republic,Saint Lucia,3,0,CONCACAF Nations League,Santo Domingo,Dominican Republic,FALSE
 2019-10-12,Montserrat,El Salvador,0,2,CONCACAF Nations League,Lookout,Montserrat,FALSE
 2019-10-12,Jamaica,Aruba,2,0,CONCACAF Nations League,Kingston,Jamaica,FALSE
-2019-10-12,Barbados,USA Virgin Islands,1,0,CONCACAF Nations League,Bridgetown,Barbados,FALSE
+2019-10-12,Barbados,United States Virgin Islands,1,0,CONCACAF Nations League,Bridgetown,Barbados,FALSE
 2019-10-12,Saint Martin,Cayman Islands,3,0,CONCACAF Nations League,The Valley,Anguilla,TRUE
 2019-10-12,Anguilla,Guatemala,0,5,CONCACAF Nations League,The Valley,Anguilla,FALSE
 2019-10-13,Belarus,Netherlands,1,2,UEFA Euro qualification,Minsk,Belarus,FALSE
@@ -41683,13 +41683,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-10-15,Mauritania,Libya,0,0,Friendly,Nouakchott,Mauritania,FALSE
 2019-10-15,Morocco,Gabon,2,3,Friendly,Morocco,Morocco,FALSE
 2019-10-15,Peru,Uruguay,1,1,Friendly,Lima,Peru,FALSE
-2019-10-15,Canada,USA,2,0,CONCACAF Nations League,Toronto,Canada,FALSE
+2019-10-15,Canada,United States,2,0,CONCACAF Nations League,Toronto,Canada,FALSE
 2019-10-15,Mexico,Panama,3,1,CONCACAF Nations League,Mexico City,Mexico,FALSE
 2019-10-15,Dominican Republic,Montserrat,0,0,CONCACAF Nations League,Santo Domingo,Dominican Republic,FALSE
 2019-10-15,Saint Lucia,El Salvador,0,2,CONCACAF Nations League,Gros Islet,Saint Lucia,FALSE
 2019-10-15,Aruba,Jamaica,0,6,CONCACAF Nations League,Willemstad,Curaçao,TRUE
 2019-10-15,Cayman Islands,Saint Martin,1,0,CONCACAF Nations League,George Town,Cayman Islands,FALSE
-2019-10-15,USA Virgin Islands,Barbados,0,4,CONCACAF Nations League,Saint Croix,USA Virgin Islands,FALSE
+2019-10-15,United States Virgin Islands,Barbados,0,4,CONCACAF Nations League,Saint Croix,United States Virgin Islands,FALSE
 2019-10-15,Anguilla,Puerto Rico,2,3,CONCACAF Nations League,The Valley,Anguilla,FALSE
 2019-10-15,Syria,Guam,4,0,FIFA World Cup qualification,Dubai,United Arab Emirates,TRUE
 2019-10-15,Philippines,China PR,0,0,FIFA World Cup qualification,Bacolod,Philippines,FALSE
@@ -41795,13 +41795,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-11-15,Brazil,Argentina,0,1,Superclásico de las Américas,Riyadh,Saudi Arabia,TRUE
 2019-11-15,Bosnia and Herzegovina,Italy,0,3,UEFA Euro qualification,Zenica,Bosnia and Herzegovina,FALSE
 2019-11-15,Armenia,Greece,0,1,UEFA Euro qualification,Yerevan,Armenia,FALSE
-2019-11-15,USA,Canada,4,1,CONCACAF Nations League,Orlando,USA,FALSE
+2019-11-15,United States,Canada,4,1,CONCACAF Nations League,Orlando,United States,FALSE
 2019-11-15,Panama,Mexico,0,3,CONCACAF Nations League,Panama City,Panama,FALSE
 2019-11-15,Antigua and Barbuda,Jamaica,0,2,CONCACAF Nations League,North Sound,Antigua and Barbuda,FALSE
 2019-11-15,Guyana,Aruba,4,2,CONCACAF Nations League,Leonora,Guyana,FALSE
 2019-11-15,Saint Vincent and the Grenadines,Nicaragua,1,0,CONCACAF Nations League,Arnos Vale,Saint Vincent and the Grenadines,FALSE
 2019-11-15,Suriname,Dominica,4,0,CONCACAF Nations League,Paramaribo,Suriname,FALSE
-2019-11-15,Colombia,Peru,1,0,Friendly,Miami Gardens,USA,TRUE
+2019-11-15,Colombia,Peru,1,0,Friendly,Miami Gardens,United States,TRUE
 2019-11-15,Hungary,Uruguay,1,2,Friendly,Budapest,Hungary,FALSE
 2019-11-16,Ivory Coast,Niger,1,0,African Cup of Nations qualification,Abidjan,Ivory Coast,FALSE
 2019-11-16,Madagascar,Ethiopia,1,0,African Cup of Nations qualification,Antananarivo,Madagascar,FALSE
@@ -41818,7 +41818,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-11-16,Saint Lucia,Dominican Republic,1,0,CONCACAF Nations League,Gros Islet,Saint Lucia,FALSE
 2019-11-16,El Salvador,Montserrat,1,0,CONCACAF Nations League,San Salvador,El Salvador,FALSE
 2019-11-16,Saint Martin,Barbados,1,0,CONCACAF Nations League,The Valley,Anguilla,TRUE
-2019-11-16,Cayman Islands,USA Virgin Islands,1,0,CONCACAF Nations League,George Town,Cayman Islands,FALSE
+2019-11-16,Cayman Islands,United States Virgin Islands,1,0,CONCACAF Nations League,George Town,Cayman Islands,FALSE
 2019-11-16,Guatemala,Puerto Rico,5,0,CONCACAF Nations League,Guatemala City,Guatemala,FALSE
 2019-11-17,Chad,Mali,0,2,African Cup of Nations qualification,N'Djamena,Chad,FALSE
 2019-11-17,Guinea,Namibia,2,0,African Cup of Nations qualification,Conakry,Guinea,FALSE
@@ -41882,16 +41882,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-11-19,Scotland,Kazakhstan,3,1,UEFA Euro qualification,Glasgow,Scotland,FALSE
 2019-11-19,Belgium,Cyprus,6,1,UEFA Euro qualification,Brussels,Belgium,FALSE
 2019-11-19,San Marino,Russia,0,5,UEFA Euro qualification,Serravalle,San Marino,FALSE
-2019-11-19,Cuba,USA,0,4,CONCACAF Nations League,George Town,Cayman Islands,TRUE
+2019-11-19,Cuba,United States,0,4,CONCACAF Nations League,George Town,Cayman Islands,TRUE
 2019-11-19,Mexico,Bermuda,2,1,CONCACAF Nations League,Mexico City,Mexico,FALSE
 2019-11-19,El Salvador,Dominican Republic,2,0,CONCACAF Nations League,San Salvador,El Salvador,FALSE
 2019-11-19,Saint Lucia,Montserrat,0,1,CONCACAF Nations League,Gros Islet,Saint Lucia,FALSE
 2019-11-19,Barbados,Cayman Islands,3,0,CONCACAF Nations League,Bridgetown,Barbados,FALSE
-2019-11-19,USA Virgin Islands,Saint Martin,1,2,CONCACAF Nations League,Upper Bethlehem,USA Virgin Islands,FALSE
+2019-11-19,United States Virgin Islands,Saint Martin,1,2,CONCACAF Nations League,Upper Bethlehem,United States Virgin Islands,FALSE
 2019-11-19,Puerto Rico,Anguilla,3,0,CONCACAF Nations League,Bayamón,Puerto Rico,FALSE
 2019-11-19,Brazil,South Korea,3,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
 2019-11-19,Croatia,Georgia,2,1,Friendly,Pula,Croatia,FALSE
-2019-11-19,Ecuador,Colombia,0,1,Friendly,Harrison,USA,TRUE
+2019-11-19,Ecuador,Colombia,0,1,Friendly,Harrison,United States,TRUE
 2019-11-19,Montenegro,Belarus,2,0,Friendly,Podgorica,Montenegro,FALSE
 2019-11-19,Saudi Arabia,Paraguay,0,0,Friendly,Riyadh,Saudi Arabia,FALSE
 2019-11-19,Maldives,Guam,3,1,FIFA World Cup qualification,Malé,Maldives,FALSE
@@ -41932,13 +41932,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2019-12-15,South Korea,China PR,1,0,EAFF Championship,Busan,South Korea,FALSE
 2019-12-18,Hong Kong,China PR,0,2,EAFF Championship,Busan,South Korea,TRUE
 2019-12-18,South Korea,Japan,1,0,EAFF Championship,Busan,South Korea,FALSE
-2020-01-07,Barbados,Canada,1,4,Friendly,Irvine,USA,TRUE
+2020-01-07,Barbados,Canada,1,4,Friendly,Irvine,United States,TRUE
 2020-01-09,Moldova,Sweden,0,1,Friendly,Doha,Qatar,TRUE
-2020-01-10,Barbados,Canada,1,4,Friendly,Irvine,USA,TRUE
+2020-01-10,Barbados,Canada,1,4,Friendly,Irvine,United States,TRUE
 2020-01-12,Kosovo,Sweden,0,1,Friendly,Doha,Qatar,TRUE
-2020-01-15,Canada,Iceland,0,1,Friendly,Irvine,USA,TRUE
-2020-01-19,El Salvador,Iceland,0,1,Friendly,Carson,USA,TRUE
-2020-02-01,USA,Costa Rica,1,0,Friendly,Carson,USA,FALSE
+2020-01-15,Canada,Iceland,0,1,Friendly,Irvine,United States,TRUE
+2020-01-19,El Salvador,Iceland,0,1,Friendly,Carson,United States,TRUE
+2020-02-01,United States,Costa Rica,1,0,Friendly,Carson,United States,FALSE
 2020-09-03,Germany,Spain,1,1,UEFA Nations League,Stuttgart,Germany,FALSE
 2020-09-03,Ukraine,Switzerland,2,1,UEFA Nations League,Lviv,Ukraine,FALSE
 2020-09-03,Russia,Serbia,3,1,UEFA Nations League,Moscow,Russia,FALSE
@@ -42149,7 +42149,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2020-11-12,Moldova,Russia,0,0,Friendly,Chișinău,Moldova,FALSE
 2020-11-12,United Arab Emirates,Tajikistan,3,2,Friendly,Dubai,United Arab Emirates,FALSE
 2020-11-12,Uzbekistan,Syria,0,1,Friendly,Sharjah,United Arab Emirates,TRUE
-2020-11-12,Wales,USA,0,0,Friendly,Cardiff,Wales,FALSE
+2020-11-12,Wales,United States,0,0,Friendly,Cardiff,Wales,FALSE
 2020-11-12,Bolivia,Ecuador,2,3,FIFA World Cup qualification,La Paz,Bolivia,FALSE
 2020-11-12,Argentina,Paraguay,1,1,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
 2020-11-13,Bangladesh,Nepal,2,0,Friendly,Dhaka,Bangladesh,FALSE
@@ -42190,7 +42190,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2020-11-15,Guatemala,Honduras,2,1,Friendly,Guatemala City,Guatemala,FALSE
 2020-11-16,Jordan,Syria,1,0,Friendly,Sharjah,United Arab Emirates,TRUE
 2020-11-16,United Arab Emirates,Bahrain,1,0,Friendly,Dubai,United Arab Emirates,FALSE
-2020-11-16,USA,Panama,6,2,Friendly,Wiener Neustadt,Austria,TRUE
+2020-11-16,United States,Panama,6,2,Friendly,Wiener Neustadt,Austria,TRUE
 2020-11-16,Basque Country,Costa Rica,2,1,Friendly,Eibar,Spain,FALSE
 2020-11-17,Croatia,Portugal,2,3,UEFA Nations League,Split,Croatia,FALSE
 2020-11-17,France,Sweden,4,2,UEFA Nations League,Paris,France,FALSE
@@ -42230,7 +42230,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2020-11-18,Albania,Belarus,3,2,UEFA Nations League,Tirana,Albania,FALSE
 2020-11-18,Kazakhstan,Lithuania,1,2,UEFA Nations League,Almaty,Kazakhstan,FALSE
 2020-12-04,Qatar,Bangladesh,5,0,FIFA World Cup qualification,Doha,Qatar,FALSE
-2020-12-09,USA,El Salvador,6,0,Friendly,Fort Lauderdale,USA,FALSE
+2020-12-09,United States,El Salvador,6,0,Friendly,Fort Lauderdale,United States,FALSE
 2021-01-12,United Arab Emirates,Iraq,0,0,Friendly,Dubai,United Arab Emirates,FALSE
 2021-01-18,Kuwait,Palestine,0,1,Friendly,Kuwait City,Kuwait,FALSE
 2021-01-19,Dominican Republic,Puerto Rico,0,1,Friendly,Santo Domingo,Dominican Republic,FALSE
@@ -42238,7 +42238,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-01-25,Dominican Republic,Serbia,0,0,Friendly,Santo Domingo,Dominican Republic,FALSE
 2021-01-27,Iraq,Kuwait,2,1,Friendly,Basra,Iraq,FALSE
 2021-01-28,Panama,Serbia,0,0,Friendly,Panama City,Panama,FALSE
-2021-01-31,USA,Trinidad and Tobago,7,0,Friendly,Orlando,USA,FALSE
+2021-01-31,United States,Trinidad and Tobago,7,0,Friendly,Orlando,United States,FALSE
 2021-02-01,Jordan,Tajikistan,2,0,Friendly,Dubai,United Arab Emirates,TRUE
 2021-02-05,Jordan,Tajikistan,0,1,Friendly,Dubai,United Arab Emirates,TRUE
 2021-02-15,Jordan,Uzbekistan,0,2,Friendly,Dubai,United Arab Emirates,TRUE
@@ -42279,9 +42279,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-03-25,India,Oman,1,1,Friendly,Dubai,United Arab Emirates,TRUE
 2021-03-25,Japan,South Korea,3,0,Friendly,Yokohama,Japan,FALSE
 2021-03-25,Saudi Arabia,Kuwait,1,0,Friendly,Riyadh,Saudi Arabia,FALSE
-2021-03-25,USA,Jamaica,4,1,Friendly,Wiener Neustadt,Austria,TRUE
+2021-03-25,United States,Jamaica,4,1,Friendly,Wiener Neustadt,Austria,TRUE
 2021-03-25,El Salvador,Grenada,2,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
-2021-03-25,Canada,Bermuda,5,1,FIFA World Cup qualification,Orlando,USA,TRUE
+2021-03-25,Canada,Bermuda,5,1,FIFA World Cup qualification,Orlando,United States,TRUE
 2021-03-25,Curaçao,Saint Vincent and the Grenadines,5,0,FIFA World Cup qualification,Willemstad,Curaçao,FALSE
 2021-03-25,Panama,Barbados,1,0,FIFA World Cup qualification,Santo Domingo,Dominican Republic,TRUE
 2021-03-25,Haiti,Belize,2,0,FIFA World Cup qualification,Port-au-Prince,Haiti,FALSE
@@ -42320,10 +42320,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-03-27,Nepal,Bangladesh,0,0,Friendly,Kathmandu,Nepal,FALSE
 2021-03-27,Qatar,Azerbaijan,2,1,Friendly,Debrecen,Hungary,TRUE
 2021-03-27,Wales,Mexico,1,0,Friendly,Cardiff,Wales,FALSE
-2021-03-27,USA Virgin Islands,Antigua and Barbuda,0,3,FIFA World Cup qualification,Saint Croix,USA Virgin Islands,FALSE
-2021-03-27,Aruba,Suriname,0,6,FIFA World Cup qualification,Bradenton,USA,TRUE
+2021-03-27,United States Virgin Islands,Antigua and Barbuda,0,3,FIFA World Cup qualification,Saint Croix,United States Virgin Islands,FALSE
+2021-03-27,Aruba,Suriname,0,6,FIFA World Cup qualification,Bradenton,United States,TRUE
 2021-03-27,British Virgin Islands,Guatemala,0,3,FIFA World Cup qualification,Willemstad,Curaçao,TRUE
-2021-03-27,Anguilla,Dominican Republic,0,6,FIFA World Cup qualification,Fort Lauderdale,USA,TRUE
+2021-03-27,Anguilla,Dominican Republic,0,6,FIFA World Cup qualification,Fort Lauderdale,United States,TRUE
 2021-03-27,Turks and Caicos Islands,Nicaragua,0,7,FIFA World Cup qualification,San Cristóbal,Dominican Republic,TRUE
 2021-03-27,Bahamas,Saint Kitts and Nevis,0,4,FIFA World Cup qualification,Nassau,Bahamas,FALSE
 2021-03-27,Republic of Ireland,Luxembourg,0,1,FIFA World Cup qualification,Dublin,Republic of Ireland,FALSE
@@ -42339,7 +42339,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-03-27,Lesotho,Sierra Leone,0,0,African Cup of Nations qualification,Maseru,Lesotho,FALSE
 2021-03-27,Benin,Nigeria,0,1,African Cup of Nations qualification,Porto-Novo,Benin,FALSE
 2021-03-28,Greece,Honduras,2,1,Friendly,Thessaloniki,Greece,FALSE
-2021-03-28,Northern Ireland,USA,1,2,Friendly,Belfast,Northern Ireland,FALSE
+2021-03-28,Northern Ireland,United States,1,2,Friendly,Belfast,Northern Ireland,FALSE
 2021-03-28,Montserrat,El Salvador,1,1,FIFA World Cup qualification,Willemstad,Curaçao,TRUE
 2021-03-28,Cuba,Curaçao,1,2,FIFA World Cup qualification,Guatemala City,Guatemala,TRUE
 2021-03-28,Dominica,Panama,1,2,FIFA World Cup qualification,Santo Domingo,Dominican Republic,TRUE
@@ -42369,7 +42369,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-03-29,Kuwait,Lebanon,1,1,Friendly,Dubai,United Arab Emirates,TRUE
 2021-03-29,Nepal,Bangladesh,2,1,Friendly,Kathmandu,Nepal,FALSE
 2021-03-29,Uzbekistan,Iraq,0,1,Friendly,Tashkent,Uzbekistan,FALSE
-2021-03-29,Cayman Islands,Canada,0,11,FIFA World Cup qualification,Bradenton,USA,TRUE
+2021-03-29,Cayman Islands,Canada,0,11,FIFA World Cup qualification,Bradenton,United States,TRUE
 2021-03-29,Burkina Faso,South Sudan,1,0,African Cup of Nations qualification,Ouagadougou,Burkina Faso,FALSE
 2021-03-29,Malawi,Uganda,1,0,African Cup of Nations qualification,Lilongwe,Malawi,FALSE
 2021-03-29,Angola,Gabon,2,0,African Cup of Nations qualification,Luanda,Angola,FALSE
@@ -42383,8 +42383,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-03-30,Costa Rica,Mexico,0,1,Friendly,Wiener Neustadt,Austria,TRUE
 2021-03-30,Iran,Syria,3,0,Friendly,Tehran,Iran,FALSE
 2021-03-30,Republic of Ireland,Qatar,1,1,Friendly,Debrecen,Hungary,TRUE
-2021-03-30,Grenada,USA Virgin Islands,1,0,FIFA World Cup qualification,St. George's,Grenada,FALSE
-2021-03-30,Bermuda,Aruba,5,0,FIFA World Cup qualification,Bradenton,USA,TRUE
+2021-03-30,Grenada,United States Virgin Islands,1,0,FIFA World Cup qualification,St. George's,Grenada,FALSE
+2021-03-30,Bermuda,Aruba,5,0,FIFA World Cup qualification,Bradenton,United States,TRUE
 2021-03-30,Saint Vincent and the Grenadines,British Virgin Islands,3,0,FIFA World Cup qualification,Willemstad,Curaçao,TRUE
 2021-03-30,Barbados,Anguilla,1,0,FIFA World Cup qualification,Santo Domingo,Dominican Republic,TRUE
 2021-03-30,Belize,Turks and Caicos Islands,5,0,FIFA World Cup qualification,San Cristóbal,Dominican Republic,TRUE
@@ -42437,12 +42437,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-05-28,Italy,San Marino,7,0,Friendly,Cagliari,Italy,FALSE
 2021-05-29,Indonesia,Oman,1,3,Friendly,Dubai,United Arab Emirates,TRUE
 2021-05-29,Iraq,Nepal,6,2,Friendly,Basra,Iraq,FALSE
-2021-05-29,Mexico,Iceland,2,1,Friendly,Arlington,USA,TRUE
+2021-05-29,Mexico,Iceland,2,1,Friendly,Arlington,United States,TRUE
 2021-05-29,Singapore,Afghanistan,1,1,Friendly,Dubai,United Arab Emirates,TRUE
 2021-05-29,Sweden,Finland,2,0,Friendly,Stockholm,Sweden,FALSE
 2021-05-29,Thailand,Tajikistan,2,2,Friendly,Sharjah,United Arab Emirates,TRUE
 2021-05-30,Malta,Northern Ireland,0,3,Friendly,Klagenfurt,Austria,TRUE
-2021-05-30,Switzerland,USA,2,1,Friendly,St. Gallen,Switzerland,FALSE
+2021-05-30,Switzerland,United States,2,1,Friendly,St. Gallen,Switzerland,FALSE
 2021-05-31,Jordan,Vietnam,1,1,Friendly,Sharjah,United Arab Emirates,TRUE
 2021-05-31,Turkey,Guinea,0,0,Friendly,Antalya,Turkey,FALSE
 2021-06-01,Croatia,Armenia,1,1,Friendly,Velika Gorica,Croatia,FALSE
@@ -42460,8 +42460,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-02,Netherlands,Scotland,2,2,Friendly,São João da Venda,Portugal,TRUE
 2021-06-02,Norway,Luxembourg,1,0,Friendly,Málaga,Spain,TRUE
 2021-06-02,Romania,Georgia,1,2,Friendly,Ploiești,Romania,FALSE
-2021-06-02,Montserrat,USA Virgin Islands,4,0,FIFA World Cup qualification,San Cristóbal,Dominican Republic,TRUE
-2021-06-02,Cayman Islands,Aruba,1,3,FIFA World Cup qualification,Bradenton,USA,TRUE
+2021-06-02,Montserrat,United States Virgin Islands,4,0,FIFA World Cup qualification,San Cristóbal,Dominican Republic,TRUE
+2021-06-02,Cayman Islands,Aruba,1,3,FIFA World Cup qualification,Bradenton,United States,TRUE
 2021-06-02,Cuba,British Virgin Islands,5,0,FIFA World Cup qualification,Guatemala City,Guatemala,TRUE
 2021-06-02,Dominica,Anguilla,3,0,FIFA World Cup qualification,Santo Domingo,Dominican Republic,TRUE
 2021-06-02,Puerto Rico,Bahamas,7,0,FIFA World Cup qualification,Mayagüez,Puerto Rico,FALSE
@@ -42471,8 +42471,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-03,Switzerland,Liechtenstein,7,0,Friendly,St. Gallen,Switzerland,FALSE
 2021-06-03,Turkey,Moldova,2,0,Friendly,Paderborn,Germany,TRUE
 2021-06-03,Ukraine,Northern Ireland,1,0,Friendly,Dnipro,Ukraine,FALSE
-2021-06-03,Mexico,Costa Rica,0,0,CONCACAF Nations League,Denver,USA,TRUE
-2021-06-03,USA,Honduras,1,0,CONCACAF Nations League,Denver,USA,FALSE
+2021-06-03,Mexico,Costa Rica,0,0,CONCACAF Nations League,Denver,United States,TRUE
+2021-06-03,United States,Honduras,1,0,CONCACAF Nations League,Denver,United States,FALSE
 2021-06-03,Nepal,Taiwan,2,0,FIFA World Cup qualification,Kuwait City,Kuwait,TRUE
 2021-06-03,Iran,Hong Kong,3,1,FIFA World Cup qualification,Arad,Iran,FALSE
 2021-06-03,Bahrain,Cambodia,8,0,FIFA World Cup qualification,Riffa,Bahrain,FALSE
@@ -42517,8 +42517,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-05,Saudi Arabia,Yemen,3,0,FIFA World Cup qualification,Riyadh,Saudi Arabia,FALSE
 2021-06-05,Lebanon,Sri Lanka,3,2,FIFA World Cup qualification,Goyang,South Korea,TRUE
 2021-06-05,South Korea,Turkmenistan,5,0,FIFA World Cup qualification,Goyang,South Korea,FALSE
-2021-06-05,USA Virgin Islands,El Salvador,0,7,FIFA World Cup qualification,Saint Croix,USA Virgin Islands,FALSE
-2021-06-05,Aruba,Canada,0,7,FIFA World Cup qualification,Bradenton,USA,TRUE
+2021-06-05,United States Virgin Islands,El Salvador,0,7,FIFA World Cup qualification,Saint Croix,United States Virgin Islands,FALSE
+2021-06-05,Aruba,Canada,0,7,FIFA World Cup qualification,Bradenton,United States,TRUE
 2021-06-05,British Virgin Islands,Curaçao,0,8,FIFA World Cup qualification,Guatemala City,Guatemala,TRUE
 2021-06-05,Panama,Anguilla,13,0,FIFA World Cup qualification,Panama City,Panama,FALSE
 2021-06-05,Turks and Caicos Islands,Haiti,0,10,FIFA World Cup qualification,Providenciales,Turks and Caicos Islands,FALSE
@@ -42532,8 +42532,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-06,Moldova,Azerbaijan,1,0,Friendly,Chișinău,Moldova,FALSE
 2021-06-06,Netherlands,Georgia,3,0,Friendly,Enschede,Netherlands,FALSE
 2021-06-06,Norway,Greece,1,2,Friendly,Málaga,Spain,TRUE
-2021-06-06,Honduras,Costa Rica,2,2,CONCACAF Nations League,Denver,USA,TRUE
-2021-06-06,USA,Mexico,3,2,CONCACAF Nations League,Denver,USA,FALSE
+2021-06-06,Honduras,Costa Rica,2,2,CONCACAF Nations League,Denver,United States,TRUE
+2021-06-06,United States,Mexico,3,2,CONCACAF Nations League,Denver,United States,FALSE
 2021-06-07,Andorra,Gibraltar,0,0,Friendly,Andorra la Vella,Andorra,FALSE
 2021-06-07,Faroe Islands,Liechtenstein,5,1,Friendly,Tórshavn,Faroe Islands,FALSE
 2021-06-07,Germany,Latvia,7,1,Friendly,Düsseldorf,Germany,FALSE
@@ -42567,8 +42567,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-08,Spain,Lithuania,4,0,Friendly,Leganés,Spain,FALSE
 2021-06-08,Grenada,Montserrat,1,2,FIFA World Cup qualification,St. George's,Grenada,FALSE
 2021-06-08,El Salvador,Antigua and Barbuda,3,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
-2021-06-08,Canada,Suriname,4,0,FIFA World Cup qualification,Bridgeview,USA,TRUE
-2021-06-08,Bermuda,Cayman Islands,1,1,FIFA World Cup qualification,Bradenton,USA,TRUE
+2021-06-08,Canada,Suriname,4,0,FIFA World Cup qualification,Bridgeview,United States,TRUE
+2021-06-08,Bermuda,Cayman Islands,1,1,FIFA World Cup qualification,Bradenton,United States,TRUE
 2021-06-08,Saint Vincent and the Grenadines,Cuba,0,1,FIFA World Cup qualification,St. George's,Grenada,TRUE
 2021-06-08,Curaçao,Guatemala,0,0,FIFA World Cup qualification,Willemstad,Curaçao,FALSE
 2021-06-08,Barbados,Dominica,1,1,FIFA World Cup qualification,Santo Domingo,Dominican Republic,TRUE
@@ -42584,7 +42584,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-09,Turkmenistan,Lebanon,3,2,FIFA World Cup qualification,Goyang,South Korea,TRUE
 2021-06-09,Niger,Congo,0,1,Friendly,Antalya,Turkey,TRUE
 2021-06-09,Portugal,Israel,4,0,Friendly,Lisbon,Portugal,FALSE
-2021-06-09,USA,Costa Rica,4,0,Friendly,Sandy,USA,FALSE
+2021-06-09,United States,Costa Rica,4,0,Friendly,Sandy,United States,FALSE
 2021-06-09,South Korea,Sri Lanka,5,0,FIFA World Cup qualification,Goyang,South Korea,FALSE
 2021-06-10,Estonia,Latvia,2,1,Baltic Cup,Tallinn,Estonia,FALSE
 2021-06-10,South Africa,Uganda,3,2,Friendly,Johannesburg,South Africa,FALSE
@@ -42611,7 +42611,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-12,Panama,Curaçao,2,1,FIFA World Cup qualification,Panama City,Panama,FALSE
 2021-06-12,Saint Kitts and Nevis,El Salvador,0,4,FIFA World Cup qualification,Basseterre,Saint Kitts and Nevis,FALSE
 2021-06-12,Ghana,Ivory Coast,0,0,Friendly,Cape Coast,Ghana,FALSE
-2021-06-12,Mexico,Honduras,0,0,Friendly,Atlanta,USA,TRUE
+2021-06-12,Mexico,Honduras,0,0,Friendly,Atlanta,United States,TRUE
 2021-06-12,Morocco,Burkina Faso,1,0,Friendly,Rabat,Morocco,FALSE
 2021-06-12,Wales,Switzerland,1,1,UEFA Euro,Cardiff,Wales,FALSE
 2021-06-12,Denmark,Finland,0,1,UEFA Euro,Copenhagen,Denmark,FALSE
@@ -42643,7 +42643,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-15,Japan,Kyrgyzstan,5,1,FIFA World Cup qualification,Suita,Japan,FALSE
 2021-06-15,Thailand,Malaysia,0,1,FIFA World Cup qualification,Dubai,United Arab Emirates,TRUE
 2021-06-15,United Arab Emirates,Vietnam,3,2,FIFA World Cup qualification,Dubai,United Arab Emirates,FALSE
-2021-06-15,Canada,Haiti,3,0,FIFA World Cup qualification,Bridgeview,USA,TRUE
+2021-06-15,Canada,Haiti,3,0,FIFA World Cup qualification,Bridgeview,United States,TRUE
 2021-06-15,Curaçao,Panama,0,0,FIFA World Cup qualification,Willemstad,Curaçao,FALSE
 2021-06-15,El Salvador,Saint Kitts and Nevis,2,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2021-06-15,Tunisia,Mali,1,0,Friendly,Radès,Tunisia,FALSE
@@ -42700,36 +42700,36 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-06-27,Belgium,Portugal,1,0,UEFA Euro,Seville,Spain,TRUE
 2021-06-27,Brazil,Ecuador,1,1,Copa América,Goiânia,Brazil,FALSE
 2021-06-27,Venezuela,Peru,0,1,Copa América,Brasília,Brazil,TRUE
-2021-06-27,El Salvador,Guatemala,0,0,Friendly,Los Angeles,USA,TRUE
+2021-06-27,El Salvador,Guatemala,0,0,Friendly,Los Angeles,United States,TRUE
 2021-06-28,Croatia,Spain,3,5,UEFA Euro,Copenhagen,Denmark,TRUE
 2021-06-28,France,Switzerland,3,3,UEFA Euro,Bucharest,Romania,TRUE
 2021-06-28,Argentina,Bolivia,4,1,Copa América,Cuiabá,Brazil,TRUE
 2021-06-28,Uruguay,Paraguay,1,0,Copa América,Rio de Janeiro,Brazil,TRUE
 2021-06-29,England,Germany,2,0,UEFA Euro,London,England,FALSE
 2021-06-29,Sweden,Ukraine,1,2,UEFA Euro,Glasgow,Scotland,TRUE
-2021-06-30,Mexico,Panama,3,0,Friendly,Nashville,USA,TRUE
+2021-06-30,Mexico,Panama,3,0,Friendly,Nashville,United States,TRUE
 2021-07-02,Switzerland,Spain,1,1,UEFA Euro,Saint Petersburg,Russia,TRUE
 2021-07-02,Belgium,Italy,1,2,UEFA Euro,Munich,Germany,TRUE
 2021-07-02,Peru,Paraguay,3,3,Copa América,Goiânia,Brazil,TRUE
 2021-07-02,Brazil,Chile,1,0,Copa América,Rio de Janeiro,Brazil,FALSE
-2021-07-02,Haiti,Saint Vincent and the Grenadines,6,1,Gold Cup qualification,Fort Lauderdale,USA,TRUE
-2021-07-02,Trinidad and Tobago,Montserrat,6,1,Gold Cup qualification,Fort Lauderdale,USA,TRUE
-2021-07-02,Bermuda,Barbados,8,1,Gold Cup qualification,Fort Lauderdale,USA,TRUE
+2021-07-02,Haiti,Saint Vincent and the Grenadines,6,1,Gold Cup qualification,Fort Lauderdale,United States,TRUE
+2021-07-02,Trinidad and Tobago,Montserrat,6,1,Gold Cup qualification,Fort Lauderdale,United States,TRUE
+2021-07-02,Bermuda,Barbados,8,1,Gold Cup qualification,Fort Lauderdale,United States,TRUE
 2021-07-03,Czech Republic,Denmark,1,2,UEFA Euro,Baku,Azerbaijan,TRUE
 2021-07-03,Ukraine,England,0,4,UEFA Euro,Rome,Italy,TRUE
-2021-07-03,Mexico,Nigeria,4,0,Friendly,Nashville,USA,TRUE
+2021-07-03,Mexico,Nigeria,4,0,Friendly,Nashville,United States,TRUE
 2021-07-03,Uruguay,Colombia,0,0,Copa América,Brasília,Brazil,TRUE
 2021-07-03,Argentina,Ecuador,3,0,Copa América,Goiânia,Brazil,TRUE
-2021-07-03,Guatemala,Guyana,4,0,Gold Cup qualification,Fort Lauderdale,USA,TRUE
-2021-07-03,Cuba,French Guiana,0,3,Gold Cup qualification,Fort Lauderdale,USA,TRUE
-2021-07-03,Guadeloupe,Bahamas,2,0,Gold Cup qualification,Fort Lauderdale,USA,TRUE
+2021-07-03,Guatemala,Guyana,4,0,Gold Cup qualification,Fort Lauderdale,United States,TRUE
+2021-07-03,Cuba,French Guiana,0,3,Gold Cup qualification,Fort Lauderdale,United States,TRUE
+2021-07-03,Guadeloupe,Bahamas,2,0,Gold Cup qualification,Fort Lauderdale,United States,TRUE
 2021-07-04,Qatar,El Salvador,1,0,Friendly,Pula,Croatia,TRUE
 2021-07-05,Brazil,Peru,1,0,Copa América,Rio de Janeiro,Brazil,FALSE
 2021-07-06,Argentina,Colombia,1,1,Copa América,Brasília,Brazil,TRUE
 2021-07-06,Italy,Spain,1,1,UEFA Euro,London,England,TRUE
-2021-07-06,Haiti,Bermuda,4,1,Gold Cup qualification,Fort Lauderdale,USA,TRUE
-2021-07-06,Guatemala,Guadeloupe,1,1,Gold Cup qualification,Fort Lauderdale,USA,TRUE
-2021-07-06,Trinidad and Tobago,French Guiana,1,1,Gold Cup qualification,Fort Lauderdale,USA,TRUE
+2021-07-06,Haiti,Bermuda,4,1,Gold Cup qualification,Fort Lauderdale,United States,TRUE
+2021-07-06,Guatemala,Guadeloupe,1,1,Gold Cup qualification,Fort Lauderdale,United States,TRUE
+2021-07-06,Trinidad and Tobago,French Guiana,1,1,Gold Cup qualification,Fort Lauderdale,United States,TRUE
 2021-07-06,Eswatini,Lesotho,3,1,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-06,South Africa,Botswana,1,0,COSAFA Cup,Port Elizabeth,South Africa,FALSE
 2021-07-07,England,Denmark,2,1,UEFA Euro,London,England,FALSE
@@ -42743,53 +42743,53 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-07-10,Brazil,Argentina,0,1,Copa América,Rio de Janeiro,Brazil,FALSE
 2021-07-10,Lesotho,Botswana,0,4,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-10,Zambia,Eswatini,0,1,COSAFA Cup,Port Elizabeth,South Africa,TRUE
-2021-07-10,Mexico,Trinidad and Tobago,0,0,Gold Cup,Arlington,USA,TRUE
+2021-07-10,Mexico,Trinidad and Tobago,0,0,Gold Cup,Arlington,United States,TRUE
 2021-07-11,England,Italy,1,1,UEFA Euro,London,England,FALSE
 2021-07-11,Namibia,Zimbabwe,2,0,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-11,Mozambique,Malawi,2,0,COSAFA Cup,Port Elizabeth,South Africa,TRUE
-2021-07-11,El Salvador,Guatemala,2,0,Gold Cup,Frisco,USA,TRUE
-2021-07-11,Canada,Martinique,4,1,Gold Cup,Kansas City,USA,TRUE
-2021-07-11,USA,Haiti,1,0,Gold Cup,Kansas City,USA,FALSE
-2021-07-12,Jamaica,Suriname,2,0,Gold Cup,Orlando,USA,TRUE
-2021-07-12,Costa Rica,Guadeloupe,3,1,Gold Cup,Orlando,USA,TRUE
+2021-07-11,El Salvador,Guatemala,2,0,Gold Cup,Frisco,United States,TRUE
+2021-07-11,Canada,Martinique,4,1,Gold Cup,Kansas City,United States,TRUE
+2021-07-11,United States,Haiti,1,0,Gold Cup,Kansas City,United States,FALSE
+2021-07-12,Jamaica,Suriname,2,0,Gold Cup,Orlando,United States,TRUE
+2021-07-12,Costa Rica,Guadeloupe,3,1,Gold Cup,Orlando,United States,TRUE
 2021-07-13,Botswana,Zambia,1,2,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-13,South Africa,Lesotho,4,0,COSAFA Cup,Port Elizabeth,South Africa,FALSE
 2021-07-13,Senegal,Zimbabwe,2,1,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-13,Malawi,Namibia,1,1,COSAFA Cup,Port Elizabeth,South Africa,TRUE
-2021-07-13,Qatar,Panama,3,3,Gold Cup,Houston,USA,TRUE
-2021-07-13,Honduras,Grenada,4,0,Gold Cup,Houston,USA,TRUE
+2021-07-13,Qatar,Panama,3,3,Gold Cup,Houston,United States,TRUE
+2021-07-13,Honduras,Grenada,4,0,Gold Cup,Houston,United States,TRUE
 2021-07-14,South Africa,Zambia,0,0,COSAFA Cup,Port Elizabeth,South Africa,FALSE
 2021-07-14,Eswatini,Botswana,1,1,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-14,Mozambique,Namibia,1,0,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-14,Senegal,Malawi,2,1,COSAFA Cup,Port Elizabeth,South Africa,TRUE
-2021-07-14,Trinidad and Tobago,El Salvador,0,2,Gold Cup,Frisco,USA,TRUE
-2021-07-14,Guatemala,Mexico,0,3,Gold Cup,Dallas,USA,TRUE
-2021-07-15,Haiti,Canada,1,4,Gold Cup,Kansas City,USA,TRUE
-2021-07-15,USA,Martinique,6,1,Gold Cup,Kansas City,USA,FALSE
+2021-07-14,Trinidad and Tobago,El Salvador,0,2,Gold Cup,Frisco,United States,TRUE
+2021-07-14,Guatemala,Mexico,0,3,Gold Cup,Dallas,United States,TRUE
+2021-07-15,Haiti,Canada,1,4,Gold Cup,Kansas City,United States,TRUE
+2021-07-15,United States,Martinique,6,1,Gold Cup,Kansas City,United States,FALSE
 2021-07-16,Senegal,Eswatini,2,2,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-16,South Africa,Mozambique,3,0,COSAFA Cup,Port Elizabeth,South Africa,FALSE
-2021-07-16,Guadeloupe,Jamaica,1,2,Gold Cup,Orlando,USA,TRUE
-2021-07-16,Suriname,Costa Rica,1,2,Gold Cup,Orlando,USA,TRUE
-2021-07-17,Grenada,Qatar,0,4,Gold Cup,Houston,USA,TRUE
-2021-07-17,Panama,Honduras,2,3,Gold Cup,Houston,USA,TRUE
+2021-07-16,Guadeloupe,Jamaica,1,2,Gold Cup,Orlando,United States,TRUE
+2021-07-16,Suriname,Costa Rica,1,2,Gold Cup,Orlando,United States,TRUE
+2021-07-17,Grenada,Qatar,0,4,Gold Cup,Houston,United States,TRUE
+2021-07-17,Panama,Honduras,2,3,Gold Cup,Houston,United States,TRUE
 2021-07-18,Eswatini,Mozambique,1,1,COSAFA Cup,Port Elizabeth,South Africa,TRUE
 2021-07-18,South Africa,Senegal,0,0,COSAFA Cup,Port Elizabeth,South Africa,FALSE
-2021-07-18,Guatemala,Trinidad and Tobago,1,1,Gold Cup,Frisco,USA,TRUE
-2021-07-18,Mexico,El Salvador,1,0,Gold Cup,Dallas,USA,TRUE
-2021-07-18,Martinique,Haiti,1,2,Gold Cup,Frisco,USA,TRUE
-2021-07-18,USA,Canada,1,0,Gold Cup,Kansas City,USA,FALSE
-2021-07-20,Suriname,Guadeloupe,2,1,Gold Cup,Houston,USA,TRUE
-2021-07-20,Costa Rica,Jamaica,1,0,Gold Cup,Orlando,USA,TRUE
-2021-07-20,Panama,Grenada,3,1,Gold Cup,Orlando,USA,TRUE
-2021-07-20,Honduras,Qatar,0,2,Gold Cup,Houston,USA,TRUE
-2021-07-24,Mexico,Honduras,3,0,Gold Cup,Glendale,USA,TRUE
-2021-07-24,Qatar,El Salvador,3,2,Gold Cup,Glendale,USA,TRUE
-2021-07-25,Costa Rica,Canada,0,2,Gold Cup,Arlington,USA,TRUE
-2021-07-25,USA,Jamaica,1,0,Gold Cup,Arlington,USA,FALSE
-2021-07-29,Mexico,Canada,2,1,Gold Cup,Houston,USA,TRUE
-2021-07-29,USA,Qatar,1,0,Gold Cup,Austin,USA,FALSE
-2021-08-01,USA,Mexico,1,0,Gold Cup,Las Vegas,USA,FALSE
-2021-08-21,El Salvador,Costa Rica,0,0,Friendly,Carson,USA,TRUE
+2021-07-18,Guatemala,Trinidad and Tobago,1,1,Gold Cup,Frisco,United States,TRUE
+2021-07-18,Mexico,El Salvador,1,0,Gold Cup,Dallas,United States,TRUE
+2021-07-18,Martinique,Haiti,1,2,Gold Cup,Frisco,United States,TRUE
+2021-07-18,United States,Canada,1,0,Gold Cup,Kansas City,United States,FALSE
+2021-07-20,Suriname,Guadeloupe,2,1,Gold Cup,Houston,United States,TRUE
+2021-07-20,Costa Rica,Jamaica,1,0,Gold Cup,Orlando,United States,TRUE
+2021-07-20,Panama,Grenada,3,1,Gold Cup,Orlando,United States,TRUE
+2021-07-20,Honduras,Qatar,0,2,Gold Cup,Houston,United States,TRUE
+2021-07-24,Mexico,Honduras,3,0,Gold Cup,Glendale,United States,TRUE
+2021-07-24,Qatar,El Salvador,3,2,Gold Cup,Glendale,United States,TRUE
+2021-07-25,Costa Rica,Canada,0,2,Gold Cup,Arlington,United States,TRUE
+2021-07-25,United States,Jamaica,1,0,Gold Cup,Arlington,United States,FALSE
+2021-07-29,Mexico,Canada,2,1,Gold Cup,Houston,United States,TRUE
+2021-07-29,United States,Qatar,1,0,Gold Cup,Austin,United States,FALSE
+2021-08-01,United States,Mexico,1,0,Gold Cup,Las Vegas,United States,FALSE
+2021-08-21,El Salvador,Costa Rica,0,0,Friendly,Carson,United States,TRUE
 2021-08-22,Niger,Sudan,2,1,Friendly,Dubai,United Arab Emirates,TRUE
 2021-08-26,Sudan,Niger,3,0,Friendly,Dubai,United Arab Emirates,TRUE
 2021-08-26,Ethiopia,Sierra Leone,0,0,Friendly,Addis Ababa,Ethiopia,FALSE
@@ -42851,7 +42851,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-09-02,Venezuela,Argentina,1,3,FIFA World Cup qualification,Caracas,Venezuela,FALSE
 2021-09-02,Chile,Brazil,0,1,FIFA World Cup qualification,Santiago,Chile,FALSE
 2021-09-02,Canada,Honduras,1,1,FIFA World Cup qualification,Toronto,Canada,FALSE
-2021-09-02,El Salvador,USA,0,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
+2021-09-02,El Salvador,United States,0,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2021-09-02,Panama,Costa Rica,0,0,FIFA World Cup qualification,Panama City,Panama,FALSE
 2021-09-02,Mexico,Jamaica,2,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2021-09-03,Mauritania,Zambia,1,2,FIFA World Cup qualification,Nouakchott,Mauritania,FALSE
@@ -42904,7 +42904,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-09-05,Costa Rica,Mexico,0,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2021-09-05,El Salvador,Honduras,0,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2021-09-05,Jamaica,Panama,0,3,FIFA World Cup qualification,Kingston,Jamaica,FALSE
-2021-09-05,USA,Canada,1,1,FIFA World Cup qualification,Nashville,USA,FALSE
+2021-09-05,United States,Canada,1,1,FIFA World Cup qualification,Nashville,United States,FALSE
 2021-09-06,Djibouti,Niger,2,4,FIFA World Cup qualification,Rabat,Morocco,TRUE
 2021-09-06,Liberia,Central African Republic,1,0,FIFA World Cup qualification,Douala,Cameroon,TRUE
 2021-09-06,Ivory Coast,Cameroon,2,1,FIFA World Cup qualification,Abidjan,Ivory Coast,FALSE
@@ -42962,13 +42962,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-09-08,Costa Rica,Jamaica,1,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2021-09-08,Panama,Mexico,1,1,FIFA World Cup qualification,Panama City,Panama,FALSE
 2021-09-08,Canada,El Salvador,3,0,FIFA World Cup qualification,Toronto,Canada,FALSE
-2021-09-08,Honduras,USA,1,4,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
+2021-09-08,Honduras,United States,1,4,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2021-09-09,Colombia,Chile,3,1,FIFA World Cup qualification,Barranquilla,Colombia,FALSE
 2021-09-09,Paraguay,Venezuela,2,1,FIFA World Cup qualification,Asunción,Paraguay,FALSE
 2021-09-09,Uruguay,Ecuador,1,0,FIFA World Cup qualification,Montevideo,Uruguay,FALSE
 2021-09-09,Argentina,Bolivia,3,0,FIFA World Cup qualification,Buenos Aires,Argentina,FALSE
 2021-09-09,Brazil,Peru,2,0,FIFA World Cup qualification,Recife,Brazil,FALSE
-2021-09-24,El Salvador,Guatemala,0,2,Friendly,Washington,USA,TRUE
+2021-09-24,El Salvador,Guatemala,0,2,Friendly,Washington,United States,TRUE
 2021-09-30,Egypt,Liberia,2,0,Friendly,Alexandria,Egypt,FALSE
 2021-10-01,Sri Lanka,Bangladesh,0,1,SAFF Cup,Malé,Maldives,TRUE
 2021-10-01,Maldives,Nepal,0,1,SAFF Cup,Malé,Maldives,FALSE
@@ -42987,7 +42987,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-10-07,China PR,Vietnam,3,2,FIFA World Cup qualification,Sharjah,United Arab Emirates,TRUE
 2021-10-07,Australia,Oman,3,1,FIFA World Cup qualification,Doha,Qatar,TRUE
 2021-10-07,Honduras,Costa Rica,0,0,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
-2021-10-07,USA,Jamaica,2,0,FIFA World Cup qualification,Austin,USA,FALSE
+2021-10-07,United States,Jamaica,2,0,FIFA World Cup qualification,Austin,United States,FALSE
 2021-10-07,El Salvador,Panama,1,0,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2021-10-07,Mexico,Canada,1,1,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2021-10-07,Equatorial Guinea,Zambia,2,0,FIFA World Cup qualification,Malabo,Equatorial Guinea,FALSE
@@ -43051,7 +43051,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-10-09,Morocco,Guinea-Bissau,3,0,FIFA World Cup qualification,Casablanca,Morocco,FALSE
 2021-10-10,Costa Rica,El Salvador,2,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2021-10-10,Jamaica,Canada,0,0,FIFA World Cup qualification,Kingston,Jamaica,FALSE
-2021-10-10,Panama,USA,1,0,FIFA World Cup qualification,Panama City,Panama,FALSE
+2021-10-10,Panama,United States,1,0,FIFA World Cup qualification,Panama City,Panama,FALSE
 2021-10-10,Mexico,Honduras,3,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2021-10-10,Zambia,Equatorial Guinea,1,1,FIFA World Cup qualification,Lusaka,Zambia,FALSE
 2021-10-10,Mauritania,Tunisia,0,0,FIFA World Cup qualification,Nouakchott,Mauritania,FALSE
@@ -43119,7 +43119,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-10-12,Cambodia,Guam,2,1,AFC Asian Cup qualification,Isa Town,Bahrain,TRUE
 2021-10-12,Morocco,Guinea,4,1,FIFA World Cup qualification,Agadir,Morocco,FALSE
 2021-10-13,Honduras,Jamaica,0,2,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
-2021-10-13,USA,Costa Rica,2,1,FIFA World Cup qualification,Columbus,USA,FALSE
+2021-10-13,United States,Costa Rica,2,1,FIFA World Cup qualification,Columbus,United States,FALSE
 2021-10-13,Canada,Panama,4,1,FIFA World Cup qualification,Toronto,Canada,FALSE
 2021-10-13,El Salvador,Mexico,0,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2021-10-13,Bangladesh,Nepal,1,1,SAFF Cup,Malé,Maldives,TRUE
@@ -43130,8 +43130,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-10-14,Brazil,Uruguay,4,1,FIFA World Cup qualification,Manaus,Brazil,FALSE
 2021-10-14,Chile,Venezuela,3,0,FIFA World Cup qualification,Santiago,Chile,FALSE
 2021-10-16,India,Nepal,3,0,SAFF Cup,Malé,Maldives,TRUE
-2021-10-27,Mexico,Ecuador,2,3,Friendly,Charlotte,USA,TRUE
-2021-11-05,El Salvador,Bolivia,0,1,Friendly,Washington,USA,TRUE
+2021-10-27,Mexico,Ecuador,2,3,Friendly,Charlotte,United States,TRUE
+2021-11-05,El Salvador,Bolivia,0,1,Friendly,Washington,United States,TRUE
 2021-11-09,Sri Lanka,Maldives,4,4,Mahinda Rajapaksa Cup,Colombo,Sri Lanka,FALSE
 2021-11-10,Kosovo,Jordan,0,2,Friendly,Pristina,Kosovo,FALSE
 2021-11-10,Nicaragua,Cuba,0,3,Friendly,Managua,Nicaragua,FALSE
@@ -43177,7 +43177,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-11-12,Canada,Costa Rica,1,0,FIFA World Cup qualification,Edmonton,Canada,FALSE
 2021-11-12,Honduras,Panama,2,3,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2021-11-12,El Salvador,Jamaica,1,1,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
-2021-11-12,USA,Mexico,2,0,FIFA World Cup qualification,Cincinnati,USA,FALSE
+2021-11-12,United States,Mexico,2,0,FIFA World Cup qualification,Cincinnati,United States,FALSE
 2021-11-12,Northern Ireland,Lithuania,1,0,FIFA World Cup qualification,Belfast,Northern Ireland,FALSE
 2021-11-12,Italy,Switzerland,1,1,FIFA World Cup qualification,Rome,Italy,FALSE
 2021-11-12,Moldova,Scotland,0,2,FIFA World Cup qualification,Chișinău,Moldova,FALSE
@@ -43260,7 +43260,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-11-16,China PR,Australia,1,1,FIFA World Cup qualification,Sharjah,United Arab Emirates,TRUE
 2021-11-16,Vietnam,Saudi Arabia,0,1,FIFA World Cup qualification,Hanoi,Vietnam,FALSE
 2021-11-16,Oman,Japan,0,1,FIFA World Cup qualification,Muscat,Oman,FALSE
-2021-11-16,Jamaica,USA,1,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
+2021-11-16,Jamaica,United States,1,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2021-11-16,Canada,Mexico,2,1,FIFA World Cup qualification,Edmonton,Canada,FALSE
 2021-11-16,Costa Rica,Honduras,2,1,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2021-11-16,Panama,El Salvador,2,1,FIFA World Cup qualification,Panama City,Panama,FALSE
@@ -43290,7 +43290,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-12-03,Qatar,Oman,2,1,Arab Cup,Al Rayyan,Qatar,FALSE
 2021-12-03,Mauritania,United Arab Emirates,0,1,Arab Cup,Doha,Qatar,TRUE
 2021-12-03,Syria,Tunisia,2,0,Arab Cup,Al Khor,Qatar,TRUE
-2021-12-04,El Salvador,Ecuador,1,1,Friendly,Houston,USA,TRUE
+2021-12-04,El Salvador,Ecuador,1,1,Friendly,Houston,United States,TRUE
 2021-12-04,Jordan,Morocco,0,4,Arab Cup,Al Rayyan,Qatar,TRUE
 2021-12-04,Palestine,Saudi Arabia,1,1,Arab Cup,Al Rayyan,Qatar,TRUE
 2021-12-04,Lebanon,Algeria,0,2,Arab Cup,Al Wakrah,Qatar,TRUE
@@ -43303,18 +43303,18 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2021-12-07,Morocco,Saudi Arabia,1,0,Arab Cup,Doha,Qatar,TRUE
 2021-12-07,Algeria,Egypt,1,1,Arab Cup,Al Wakrah,Qatar,TRUE
 2021-12-07,Lebanon,Sudan,1,0,Arab Cup,Al Rayyan,Qatar,TRUE
-2021-12-08,Mexico,Chile,2,2,Friendly,Austin,USA,TRUE
+2021-12-08,Mexico,Chile,2,2,Friendly,Austin,United States,TRUE
 2021-12-09,Tanzania,Uganda,0,2,Friendly,Dar es Salaam,Tanzania,FALSE
 2021-12-10,Tunisia,Oman,2,1,Arab Cup,Al Rayyan,Qatar,TRUE
 2021-12-10,Qatar,United Arab Emirates,5,0,Arab Cup,Al Khor,Qatar,FALSE
 2021-12-11,Egypt,Jordan,3,1,Arab Cup,Al Wakrah,Qatar,TRUE
 2021-12-11,Morocco,Algeria,2,2,Arab Cup,Doha,Qatar,TRUE
-2021-12-11,El Salvador,Chile,0,1,Friendly,Los Angeles,USA,TRUE
+2021-12-11,El Salvador,Chile,0,1,Friendly,Los Angeles,United States,TRUE
 2021-12-15,Tunisia,Egypt,1,0,Arab Cup,Doha,Qatar,TRUE
 2021-12-15,Qatar,Algeria,1,2,Arab Cup,Doha,Qatar,FALSE
 2021-12-18,Qatar,Egypt,0,0,Arab Cup,Doha,Qatar,FALSE
 2021-12-18,Tunisia,Algeria,0,2,Arab Cup,Al Khor,Qatar,TRUE
-2021-12-18,USA,Bosnia and Herzegovina,1,0,Friendly,Los Angeles,USA,FALSE
+2021-12-18,United States,Bosnia and Herzegovina,1,0,Friendly,Los Angeles,United States,FALSE
 2021-12-30,Mauritania,Burkina Faso,0,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
 2021-12-30,Sudan,Ethiopia,2,3,Friendly,Limbé,Cameroon,TRUE
 2021-12-31,Malawi,Comoros,2,1,Friendly,Jeddah,Saudi Arabia,TRUE
@@ -43346,7 +43346,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-01-15,South Korea,Iceland,5,1,Friendly,Antalya,Turkey,TRUE
 2022-01-15,Nigeria,Sudan,3,1,African Cup of Nations,Garoua,Cameroon,TRUE
 2022-01-15,Guinea-Bissau,Egypt,0,1,African Cup of Nations,Garoua,Cameroon,TRUE
-2022-01-16,Colombia,Honduras,2,1,Friendly,Fort Lauderdale,USA,TRUE
+2022-01-16,Colombia,Honduras,2,1,Friendly,Fort Lauderdale,United States,TRUE
 2022-01-16,Peru,Panama,1,1,Friendly,Lima,Peru,FALSE
 2022-01-16,Ivory Coast,Sierra Leone,2,2,African Cup of Nations,Douala,Cameroon,TRUE
 2022-01-16,Algeria,Equatorial Guinea,0,1,African Cup of Nations,Douala,Cameroon,TRUE
@@ -43381,7 +43381,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-01-27,Indonesia,Timor-Leste,4,1,Friendly,Gianyar,Indonesia,FALSE
 2022-01-27,Uzbekistan,South Sudan,3,0,Friendly,Dubai,United Arab Emirates,TRUE
 2022-01-27,Jamaica,Mexico,1,2,FIFA World Cup qualification,Kingston,Jamaica,FALSE
-2022-01-27,USA,El Salvador,1,0,FIFA World Cup qualification,Columbus,USA,FALSE
+2022-01-27,United States,El Salvador,1,0,FIFA World Cup qualification,Columbus,United States,FALSE
 2022-01-27,Honduras,Canada,0,2,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
 2022-01-27,Costa Rica,Panama,1,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2022-01-27,Lebanon,South Korea,0,1,FIFA World Cup qualification,Sidon,Lebanon,FALSE
@@ -43405,7 +43405,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-01-30,Indonesia,Timor-Leste,3,0,Friendly,Gianyar,Indonesia,FALSE
 2022-01-30,Egypt,Morocco,2,1,African Cup of Nations,Yaoundé,Cameroon,TRUE
 2022-01-30,Senegal,Equatorial Guinea,3,1,African Cup of Nations,Yaoundé,Cameroon,TRUE
-2022-01-30,Canada,USA,2,0,FIFA World Cup qualification,Hamilton,Canada,FALSE
+2022-01-30,Canada,United States,2,0,FIFA World Cup qualification,Hamilton,Canada,FALSE
 2022-01-30,Mexico,Costa Rica,0,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2022-01-30,Panama,Jamaica,3,2,FIFA World Cup qualification,Panama City,Panama,FALSE
 2022-01-30,Honduras,El Salvador,0,2,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
@@ -43426,7 +43426,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-02-01,Peru,Ecuador,1,1,FIFA World Cup qualification,Lima,Peru,FALSE
 2022-02-01,Brazil,Paraguay,4,0,FIFA World Cup qualification,Belo Horizonte,Brazil,FALSE
 2022-02-02,Burkina Faso,Senegal,1,3,African Cup of Nations,Yaoundé,Cameroon,TRUE
-2022-02-02,USA,Honduras,3,0,FIFA World Cup qualification,Saint Paul,USA,FALSE
+2022-02-02,United States,Honduras,3,0,FIFA World Cup qualification,Saint Paul,United States,FALSE
 2022-02-02,Jamaica,Costa Rica,0,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2022-02-02,El Salvador,Canada,0,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2022-02-02,Mexico,Panama,1,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
@@ -43453,7 +43453,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-03-23,Seychelles,Lesotho,0,0,African Cup of Nations qualification,Saint Pierre,Mauritius,TRUE
 2022-03-23,Somalia,Eswatini,0,3,African Cup of Nations qualification,Dar es Salaam,Tanzania,TRUE
 2022-03-24,Jamaica,El Salvador,1,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
-2022-03-24,Mexico,USA,0,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
+2022-03-24,Mexico,United States,0,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
 2022-03-24,Panama,Honduras,1,1,FIFA World Cup qualification,Panama City,Panama,FALSE
 2022-03-24,Costa Rica,Canada,1,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2022-03-24,Lebanon,Syria,0,3,FIFA World Cup qualification,Sidon,Lebanon,FALSE
@@ -43526,13 +43526,13 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-03-27,El Salvador,Costa Rica,1,2,FIFA World Cup qualification,San Salvador,El Salvador,FALSE
 2022-03-27,Canada,Jamaica,4,0,FIFA World Cup qualification,Toronto,Canada,FALSE
 2022-03-27,Honduras,Mexico,0,1,FIFA World Cup qualification,San Pedro Sula,Honduras,FALSE
-2022-03-27,USA,Panama,5,1,FIFA World Cup qualification,Orlando,USA,FALSE
+2022-03-27,United States,Panama,5,1,FIFA World Cup qualification,Orlando,United States,FALSE
 2022-03-27,New Zealand,Tahiti,1,0,FIFA World Cup qualification,Doha,Qatar,TRUE
 2022-03-27,Solomon Islands,Papua New Guinea,3,2,FIFA World Cup qualification,Doha,Qatar,TRUE
 2022-03-27,Barbados,Guyana,0,5,Friendly,Port of Spain,Trinidad and Tobago,TRUE
 2022-03-27,Belize,Cuba,0,3,Friendly,Belmopan,Belize,FALSE
 2022-03-27,Benin,Zambia,2,1,Friendly,Antalya,Turkey,TRUE
-2022-03-27,Guatemala,Haiti,2,1,Friendly,Fort Lauderdale,USA,TRUE
+2022-03-27,Guatemala,Haiti,2,1,Friendly,Fort Lauderdale,United States,TRUE
 2022-03-27,Laos,Brunei,3,2,Friendly,Vientiane,Laos,FALSE
 2022-03-27,Liberia,Sierra Leone,0,1,Friendly,Antalya,Turkey,TRUE
 2022-03-27,Thailand,Suriname,1,0,Friendly,Pathum Thani,Thailand,FALSE
@@ -43600,12 +43600,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-03-29,Kazakhstan,Moldova,0,1,UEFA Nations League,Nur-Sultan,Kazakhstan,FALSE
 2022-03-29,Gambia,Chad,2,2,African Cup of Nations qualification,Agadir,Morocco,TRUE
 2022-03-30,Mexico,El Salvador,2,0,FIFA World Cup qualification,Mexico City,Mexico,FALSE
-2022-03-30,Costa Rica,USA,2,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
+2022-03-30,Costa Rica,United States,2,0,FIFA World Cup qualification,San José,Costa Rica,FALSE
 2022-03-30,Panama,Canada,1,0,FIFA World Cup qualification,Panama City,Panama,FALSE
 2022-03-30,Jamaica,Honduras,2,1,FIFA World Cup qualification,Kingston,Jamaica,FALSE
 2022-03-30,Solomon Islands,New Zealand,0,5,FIFA World Cup qualification,Doha,Qatar,TRUE
-2022-04-24,El Salvador,Guatemala,0,4,Friendly,San Jose,USA,TRUE
-2022-04-27,Mexico,Guatemala,0,0,Friendly,Orlando,USA,TRUE
+2022-04-24,El Salvador,Guatemala,0,4,Friendly,San Jose,United States,TRUE
+2022-04-27,Mexico,Guatemala,0,0,Friendly,Orlando,United States,TRUE
 2022-05-12,Bahamas,Turks and Caicos Islands,4,2,Friendly,Nassau,Bahamas,FALSE
 2022-05-12,Dominica,Saint Vincent and the Grenadines,2,1,Friendly,Roseau,Dominica,FALSE
 2022-05-14,Bahamas,Turks and Caicos Islands,1,2,Friendly,Nassau,Bahamas,FALSE
@@ -43621,7 +43621,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-05-27,Thailand,Turkmenistan,1,0,Friendly,Sisaket,Thailand,FALSE
 2022-05-28,Ethiopia,Lesotho,1,1,Friendly,Adama,Ethiopia,FALSE
 2022-05-28,India,Jordan,0,2,Friendly,Doha,Qatar,TRUE
-2022-05-28,Mexico,Nigeria,2,1,Friendly,Arlington,USA,TRUE
+2022-05-28,Mexico,Nigeria,2,1,Friendly,Arlington,United States,TRUE
 2022-05-29,United Arab Emirates,Gambia,1,1,Friendly,Dubai,United Arab Emirates,FALSE
 2022-05-30,Ethiopia,Lesotho,1,1,Friendly,Adama,Ethiopia,FALSE
 2022-05-30,Trinidad and Tobago,Saint Lucia,1,0,Friendly,San Fernando,Trinidad and Tobago,FALSE
@@ -43638,7 +43638,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-01,Kuwait,Singapore,0,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
 2022-06-01,Malaysia,Hong Kong,2,0,Friendly,Kuala Lumpur,Malaysia,FALSE
 2022-06-01,Syria,Tajikistan,1,0,Friendly,Dubai,United Arab Emirates,TRUE
-2022-06-01,USA,Morocco,3,0,Friendly,Cincinnati,USA,FALSE
+2022-06-01,United States,Morocco,3,0,Friendly,Cincinnati,United States,FALSE
 2022-06-01,Vietnam,Afghanistan,2,0,Friendly,Ho Chi Minh City,Vietnam,FALSE
 2022-06-02,Tunisia,Equatorial Guinea,4,0,African Cup of Nations qualification,Radès,Tunisia,FALSE
 2022-06-02,Mozambique,Rwanda,1,1,African Cup of Nations qualification,Johannesburg,South Africa,TRUE
@@ -43659,10 +43659,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-02,Bulgaria,North Macedonia,1,1,UEFA Nations League,Razgrad,Bulgaria,FALSE
 2022-06-02,Estonia,San Marino,2,0,UEFA Nations League,Tallinn,Estonia,FALSE
 2022-06-02,Cambodia,Timor-Leste,2,1,Friendly,Phnom Penh,Cambodia,FALSE
-2022-06-02,Ecuador,Nigeria,1,0,Friendly,Harrison,USA,TRUE
+2022-06-02,Ecuador,Nigeria,1,0,Friendly,Harrison,United States,TRUE
 2022-06-02,Japan,Paraguay,4,1,Friendly,Sapporo,Japan,FALSE
 2022-06-02,South Korea,Brazil,1,5,Friendly,Seoul,South Korea,FALSE
-2022-06-02,Mexico,Uruguay,0,3,Friendly,Glendale,USA,TRUE
+2022-06-02,Mexico,Uruguay,0,3,Friendly,Glendale,United States,TRUE
 2022-06-03,Togo,Eswatini,2,2,African Cup of Nations qualification,Lomé,Togo,FALSE
 2022-06-03,Burkina Faso,Cape Verde,2,0,African Cup of Nations qualification,Marrakech,Morocco,TRUE
 2022-06-03,Comoros,Lesotho,2,0,African Cup of Nations qualification,Moroni,Comoros,FALSE
@@ -43670,7 +43670,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-03,Curaçao,Honduras,0,1,CONCACAF Nations League,Willemstad,Curaçao,FALSE
 2022-06-03,Bahamas,Saint Vincent and the Grenadines,1,0,CONCACAF Nations League,Nassau,Bahamas,FALSE
 2022-06-03,Nicaragua,Trinidad and Tobago,2,1,CONCACAF Nations League,Managua,Nicaragua,FALSE
-2022-06-03,Sint Maarten,USA Virgin Islands,1,1,CONCACAF Nations League,Willemstad,Curaçao,TRUE
+2022-06-03,Sint Maarten,United States Virgin Islands,1,1,CONCACAF Nations League,Willemstad,Curaçao,TRUE
 2022-06-03,Turks and Caicos Islands,Bonaire,1,4,CONCACAF Nations League,Providenciales,Turks and Caicos Islands,FALSE
 2022-06-03,Saint Martin,Aruba,0,0,CONCACAF Nations League,The Valley,Anguilla,TRUE
 2022-06-03,British Virgin Islands,Cayman Islands,1,1,CONCACAF Nations League,Tortola,British Virgin Islands,FALSE
@@ -43723,16 +43723,16 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-05,Bulgaria,Georgia,2,5,UEFA Nations League,Razgrad,Bulgaria,FALSE
 2022-06-05,San Marino,Malta,0,2,UEFA Nations League,Serravalle,San Marino,FALSE
 2022-06-05,Argentina,Estonia,5,0,Friendly,Pamplona,Spain,TRUE
-2022-06-05,Mexico,Ecuador,0,0,Friendly,Chicago,USA,TRUE
+2022-06-05,Mexico,Ecuador,0,0,Friendly,Chicago,United States,TRUE
 2022-06-05,Peru,New Zealand,1,0,Friendly,Barcelona,Spain,TRUE
 2022-06-05,Saudi Arabia,Colombia,0,1,Friendly,Murcia,Spain,TRUE
-2022-06-05,USA,Uruguay,0,0,Friendly,Kansas City,USA,FALSE
+2022-06-05,United States,Uruguay,0,0,Friendly,Kansas City,United States,FALSE
 2022-06-06,Equatorial Guinea,Libya,2,0,African Cup of Nations qualification,Malabo,Equatorial Guinea,FALSE
 2022-06-06,Honduras,Curaçao,1,2,CONCACAF Nations League,San Pedro Sula,Honduras,FALSE
 2022-06-06,Saint Vincent and the Grenadines,Nicaragua,2,2,CONCACAF Nations League,Kingstown,Saint Vincent and the Grenadines,FALSE
 2022-06-06,Trinidad and Tobago,Bahamas,1,0,CONCACAF Nations League,Port of Spain,Trinidad and Tobago,FALSE
 2022-06-06,Bonaire,Sint Maarten,2,2,CONCACAF Nations League,Willemstad,Curaçao,TRUE
-2022-06-06,USA Virgin Islands,Turks and Caicos Islands,3,2,CONCACAF Nations League,Saint Croix,USA Virgin Islands,FALSE
+2022-06-06,United States Virgin Islands,Turks and Caicos Islands,3,2,CONCACAF Nations League,Saint Croix,United States Virgin Islands,FALSE
 2022-06-06,Aruba,Saint Martin,3,0,CONCACAF Nations League,Willemstad,Curaçao,TRUE
 2022-06-06,Cayman Islands,British Virgin Islands,1,1,CONCACAF Nations League,George Town,Cayman Islands,FALSE
 2022-06-06,Austria,Denmark,1,2,UEFA Nations League,Vienna,Austria,FALSE
@@ -43808,7 +43808,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-09,New Zealand,Oman,0,0,Friendly,Al Rayyan,Qatar,TRUE
 2022-06-09,San Marino,Iceland,0,1,Friendly,Serravalle,San Marino,FALSE
 2022-06-09,Saudi Arabia,Venezuela,0,1,Friendly,Murcia,Spain,TRUE
-2022-06-10,USA,Grenada,5,0,CONCACAF Nations League,Austin,USA,FALSE
+2022-06-10,United States,Grenada,5,0,CONCACAF Nations League,Austin,United States,FALSE
 2022-06-10,Saint Vincent and the Grenadines,Trinidad and Tobago,0,2,CONCACAF Nations League,Kingstown,Saint Vincent and the Grenadines,FALSE
 2022-06-10,Bahamas,Nicaragua,0,2,CONCACAF Nations League,Nassau,Bahamas,FALSE
 2022-06-10,Dominican Republic,Guatemala,1,1,CONCACAF Nations League,Santo Domingo,Dominican Republic,FALSE
@@ -43837,7 +43837,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-11,Mexico,Suriname,3,0,CONCACAF Nations League,Torreón,Mexico,FALSE
 2022-06-11,Guyana,Haiti,2,6,CONCACAF Nations League,Leonora,Guyana,FALSE
 2022-06-11,Montserrat,Bermuda,3,2,CONCACAF Nations League,Santo Domingo,Dominican Republic,TRUE
-2022-06-11,USA Virgin Islands,Bonaire,0,2,CONCACAF Nations League,Saint Croix,USA Virgin Islands,FALSE
+2022-06-11,United States Virgin Islands,Bonaire,0,2,CONCACAF Nations League,Saint Croix,United States Virgin Islands,FALSE
 2022-06-11,Sint Maarten,Turks and Caicos Islands,8,2,CONCACAF Nations League,Willemstad,Curaçao,TRUE
 2022-06-11,England,Italy,0,0,UEFA Nations League,Wolverhampton,England,FALSE
 2022-06-11,Hungary,Germany,1,1,UEFA Nations League,Budapest,Hungary,FALSE
@@ -43849,7 +43849,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-11,Romania,Finland,1,0,UEFA Nations League,Bucharest,Romania,FALSE
 2022-06-11,Faroe Islands,Lithuania,2,1,UEFA Nations League,Tórshavn,Faroe Islands,FALSE
 2022-06-11,Luxembourg,Turkey,0,2,UEFA Nations League,Luxembourg,Luxembourg,FALSE
-2022-06-11,Ecuador,Cape Verde,1,0,Friendly,Fort Lauderdale,USA,TRUE
+2022-06-11,Ecuador,Cape Verde,1,0,Friendly,Fort Lauderdale,United States,TRUE
 2022-06-11,Uruguay,Panama,5,0,Friendly,Montevideo,Uruguay,FALSE
 2022-06-12,Martinique,Panama,0,0,CONCACAF Nations League,Fort de France,Martinique,FALSE
 2022-06-12,Cuba,Antigua and Barbuda,3,1,CONCACAF Nations League,Santiago,Cuba,FALSE
@@ -43895,10 +43895,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-14,Myanmar,Singapore,2,6,AFC Asian Cup qualification,Bishkek,Kyrgyzstan,TRUE
 2022-06-14,Kyrgyzstan,Tajikistan,0,0,AFC Asian Cup qualification,Bishkek,Kyrgyzstan,FALSE
 2022-06-14,Jamaica,Mexico,1,1,CONCACAF Nations League,Kingston,Jamaica,FALSE
-2022-06-14,El Salvador,USA,1,1,CONCACAF Nations League,San Salvador,El Salvador,FALSE
+2022-06-14,El Salvador,United States,1,1,CONCACAF Nations League,San Salvador,El Salvador,FALSE
 2022-06-14,Haiti,Guyana,6,0,CONCACAF Nations League,Santo Domingo,Dominican Republic,TRUE
 2022-06-14,French Guiana,Belize,1,0,CONCACAF Nations League,Cayenne,French Guiana,FALSE
-2022-06-14,Bonaire,USA Virgin Islands,2,0,CONCACAF Nations League,Willemstad,Curaçao,TRUE
+2022-06-14,Bonaire,United States Virgin Islands,2,0,CONCACAF Nations League,Willemstad,Curaçao,TRUE
 2022-06-14,Turks and Caicos Islands,Sint Maarten,2,0,CONCACAF Nations League,Providenciales,Turks and Caicos Islands,FALSE
 2022-06-14,England,Hungary,0,4,UEFA Nations League,Wolverhampton,England,FALSE
 2022-06-14,Germany,Italy,5,2,UEFA Nations League,Mönchengladbach,Germany,FALSE
@@ -43918,7 +43918,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-06-17,Mapuche,Maule Sur,0,1,CONIFA South America Football Cup,Linares,Chile,TRUE
 2022-06-18,Mapuche,Aymara,3,1,CONIFA South America Football Cup,Linares,Chile,TRUE
 2022-06-19,Aymara,Maule Sur,0,1,CONIFA South America Football Cup,Linares,Chile,TRUE
-2022-08-31,Mexico,Paraguay,0,1,Friendly,Atlanta,USA,TRUE
+2022-08-31,Mexico,Paraguay,0,1,Friendly,Atlanta,United States,TRUE
 2022-09-17,Fiji,New Caledonia,1,0,MSG Prime Minister's Cup,Luganville,Vanuatu,TRUE
 2022-09-17,Solomon Islands,New Caledonia,1,0,MSG Prime Minister's Cup,Luganville,Vanuatu,TRUE
 2022-09-21,Brunei Darussalam,Maldives,0,3,Friendly,Bandar Seri Begawan,Brunei,TRUE
@@ -43944,9 +43944,9 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-22,Slovakia,Azerbaijan,1,2,UEFA Nations League,Trnava,Slovakia,FALSE
 2022-09-22,Latvia,Moldova,1,2,UEFA Nations League,Riga,Latvia,FALSE
 2022-09-22,Liechtenstein,Andorra,0,2,UEFA Nations League,Vaduz,Liechtenstein,FALSE
-2022-09-23,Japan,USA,2,0,Kirin Challenge Cup,Düsseldorf,Germany,TRUE
+2022-09-23,Japan,United States,2,0,Kirin Challenge Cup,Düsseldorf,Germany,TRUE
 2022-09-23,Algeria,Guinea,1,0,Friendly,Oran,Algeria,FALSE
-2022-09-23,Argentina,Honduras,3,0,Friendly,Miami Gardens,USA,TRUE
+2022-09-23,Argentina,Honduras,3,0,Friendly,Miami Gardens,United States,TRUE
 2022-09-23,Bahrain,Cape Verde,1,2,Friendly,Riffa,Bahrain,FALSE
 2022-09-23,Brazil,Ghana,3,0,Friendly,Le Havre,France,TRUE
 2022-09-23,Cameroon,Uzbekistan,0,2,Friendly,Goyang,South Korea,TRUE
@@ -43954,8 +43954,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-23,DR Congo,Burkina Faso,0,1,Friendly,Casablanca,Morocco,TRUE
 2022-09-23,Egypt,Niger,3,0,Friendly,Alexandria,Egypt,FALSE
 2022-09-23,Iran,Uruguay,1,0,Friendly,St Polten,Austria,TRUE
-2022-09-23,Iraq,Oman,1,1,Friendly,Amman,Jordan,TRUE
-2022-09-23,Jordan,Syria,2,0,Friendly,Amman,Jordan,FALSE
+2022-09-23,Iraq,Oman,1,1,Jordan International Tournament,Amman,Jordan,TRUE
+2022-09-23,Jordan,Syria,2,0,Jordan International Tournament,Amman,Jordan,FALSE
 2022-09-23,South Korea,Costa Rica,2,2,Friendly,Goyang,South Korea,FALSE
 2022-09-23,Mali,Zambia,1,0,Friendly,Bamako,Mali,FALSE
 2022-09-23,Morocco,Chile,2,0,Friendly,Barcelona,Spain,TRUE
@@ -43970,7 +43970,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-23,Bulgaria,Gibraltar,5,1,UEFA Nations League,Razgrad,Bulgaria,FALSE
 2022-09-23,Estonia,Malta,2,1,UEFA Nations League,Tallinn,Estonia,FALSE
 2022-09-24,Bolivia,Senegal,0,2,Friendly,Orléans,France,TRUE
-2022-09-24,Colombia,Guatemala,4,1,Friendly,Harrison,USA,TRUE
+2022-09-24,Colombia,Guatemala,4,1,Friendly,Harrison,United States,TRUE
 2022-09-24,Fiji,Solomon Islands,2,2,MSG Prime Minister's Cup,Luganville,Vanuatu,TRUE
 2022-09-24,Grenada,Saint Vincent and the Grenadines,1,3,Friendly,Carriacou,Grenada,FALSE
 2022-09-24,Hong Kong,Myanmar,0,0,Friendly,Hong Kong,Hong Kong,FALSE
@@ -43980,7 +43980,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-24,Laos,Maldives,1,3,Friendly,Bandar Seri Begawan,Brunei,TRUE
 2022-09-24,Madagascar,Congo,3,3,Friendly,Mohammedia,Morocco,TRUE
 2022-09-24,Mauritania,Benin,1,0,Friendly,Mohammedia,Morocco,TRUE
-2022-09-24,Mexico,Peru,1,0,Friendly,Pasadena,USA,TRUE
+2022-09-24,Mexico,Peru,1,0,Friendly,Pasadena,United States,TRUE
 2022-09-24,South Africa,Sierra Leone,4,0,Friendly,Johannesburg,South Africa,FALSE
 2022-09-24,Tanzania,Uganda,1,0,Friendly,Benghazi,Libya,TRUE
 2022-09-24,Vanuatu,Papua New Guinea,0,1,MSG Prime Minister's Cup,Port Vila,Vanuatu,FALSE
@@ -44008,8 +44008,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-25,Andorra,Latvia,1,1,UEFA Nations League,Andorra la Vella,Andorra,FALSE
 2022-09-25,Moldova,Liechtenstein,2,0,UEFA Nations League,Chișinău,Moldova,FALSE
 2022-09-26,Ethiopia,Sudan,2,2,Friendly,Addis Ababa,Ethiopia,FALSE
-2022-09-26,Iraq,Syria,1,0,Friendly,Amman,Jordan,TRUE
-2022-09-26,Jordan,Oman,1,0,Friendly,Amman,Jordan,FALSE
+2022-09-26,Iraq,Syria,1,0,Jordan International Tournament,Amman,Jordan,TRUE
+2022-09-26,Jordan,Oman,1,0,Jordan International Tournament,Amman,Jordan,FALSE
 2022-09-26,England,Germany,3,3,UEFA Nations League,London,England,FALSE
 2022-09-26,Hungary,Italy,0,2,UEFA Nations League,Budapest,Hungary,FALSE
 2022-09-26,Montenegro,Finland,0,2,UEFA Nations League,Podgorica,Montenegro,FALSE
@@ -44019,7 +44019,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-26,San Marino,Estonia,0,4,UEFA Nations League,Serravalle,San Marino,FALSE
 2022-09-27,Fiji,Papua New Guinea,0,1,MSG Prime Minister's Cup,Luganville,Vanuatu,TRUE
 2022-09-27,Algeria,Nigeria,2,1,Friendly,Oran,Algeria,FALSE
-2022-09-27,Argentina,Jamaica,3,0,Friendly,Harrison,USA,TRUE
+2022-09-27,Argentina,Jamaica,3,0,Friendly,Harrison,United States,TRUE
 2022-09-27,Bahrain,Panama,0,2,Friendly,Riffa,Bahrain,FALSE
 2022-09-27,Brazil,Tunisia,5,1,Friendly,Paris,France,TRUE
 2022-09-27,Brunei Darussalam,Laos,1,0,Friendly,Bandar Seri Begawan,Brunei,TRUE
@@ -44031,7 +44031,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-27,Egypt,Liberia,3,0,Friendly,Alexandria,Egypt,FALSE
 2022-09-27,Equatorial Guinea,Togo,2,2,Friendly,Casablanca,Morocco,TRUE
 2022-09-27,Ghana,Nicaragua,1,0,Friendly,Lorca,Spain,TRUE
-2022-09-27,Honduras,Guatemala,2,1,Friendly,Houston,USA,TRUE
+2022-09-27,Honduras,Guatemala,2,1,Friendly,Houston,United States,TRUE
 2022-09-27,Indonesia,Curaçao,2,1,Friendly,Cibinong,Indonesia,FALSE
 2022-09-27,Iran,Senegal,1,1,Friendly,Maria Enzersdorf,Austria,TRUE
 2022-09-27,Ivory Coast,Guinea,3,1,Friendly,Amiens,France,TRUE
@@ -44040,12 +44040,12 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-27,Madagascar,Benin,3,1,Friendly,Mohammedia,Morocco,TRUE
 2022-09-27,Malta,Israel,2,1,Friendly,Ta' Qali,Malta,FALSE
 2022-09-27,Mauritania,Congo,2,0,Friendly,Mohammedia,Morocco,TRUE
-2022-09-27,Mexico,Colombia,2,3,Friendly,Santa Clara,USA,TRUE
+2022-09-27,Mexico,Colombia,2,3,Friendly,Santa Clara,United States,TRUE
 2022-09-27,Nepal,Bangladesh,3,1,Friendly,Kathmandu,Nepal,FALSE
 2022-09-27,Paraguay,Morocco,0,0,Friendly,Sevilla,Spain,TRUE
-2022-09-27,Peru,El Salvador,4,1,Friendly,Washington,USA,TRUE
+2022-09-27,Peru,El Salvador,4,1,Friendly,Washington,United States,TRUE
 2022-09-27,Qatar,Chile,2,2,Friendly,Vienna,Austria,TRUE
-2022-09-27,Saudi Arabia,USA,0,0,Friendly,Murcia,Spain,TRUE
+2022-09-27,Saudi Arabia,United States,0,0,Friendly,Murcia,Spain,TRUE
 2022-09-27,South Africa,Botswana,1,0,Friendly,Johannesburg,South Africa,FALSE
 2022-09-27,United Arab Emirates,Venezuela,0,4,Friendly,Wiener Neustadt,Austria,TRUE
 2022-09-27,Vietnam,India,3,0,Friendly,Ho Chi Minh City,Vietnam,FALSE
@@ -44058,4 +44058,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2022-09-27,Sweden,Slovenia,1,1,UEFA Nations League,Stockholm,Sweden,FALSE
 2022-09-27,Kosovo,Cyprus,5,1,UEFA Nations League,Pristina,Kosovo,FALSE
 2022-09-27,Greece,Northern Ireland,3,1,UEFA Nations League,Athens,Greece,FALSE
-2022-09-30,Fiji,Solomon Islands,0,0,MSG Prime Minister's Cup,Luganville,Vanuatu,TRUE
+2022-09-30,Fiji,Solomon Islands,1,0,MSG Prime Minister's Cup,Luganville,Vanuatu,TRUE
+2022-10-01,Saint Vincent and the Grenadines,Grenada,1,5,Friendly,Kingstown,Saint Vincent and the Grenadines,FALSE
+2022-10-22,Saudi Arabia,North Macedonia,1,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE
+2022-10-23,Qatar,Guatemala,2,0,Friendly,Málaga,Spain,TRUE
+2022-10-26,Saudi Arabia,Albania,1,1,Friendly,Abu Dhabi,United Arab Emirates,TRUE
+2022-10-27,Qatar,Honduras,1,0,Friendly,Marbella,Spain,TRUE
+2022-10-30,Saudi Arabia,Honduras,0,0,Friendly,Abu Dhabi,United Arab Emirates,TRUE

--- a/wcpredictor/data/wcresults_2014.csv
+++ b/wcpredictor/data/wcresults_2014.csv
@@ -1,0 +1,33 @@
+Team,Stage
+Brazil,SF
+Mexico,R16
+Croatia,G
+Cameroon,G
+Spain,G
+Netherlands,SF
+Chile,R16
+Australia,G
+Colombia,QF
+Greece,R16
+Japan,G
+Ivory Coast,G
+Uruguay,R16
+England,G
+Costa Rica,QF
+Italy,G
+Switzerland,R16
+France,QF
+Honduras,G
+Ecuador,G
+Argentina,RU
+Bosnia and Herzegovina,G
+Nigeria,R16
+Iran,G
+Germany,W
+Portugal,G
+Ghana,G
+USA,R16
+Belgium,QF
+Algeria,R16
+Russia,G
+South Korea,G

--- a/wcpredictor/data/wcresults_2018.csv
+++ b/wcpredictor/data/wcresults_2018.csv
@@ -1,0 +1,33 @@
+Team,Stage
+Russia,QF
+Saudi Arabia,G
+Egypt,G
+Uruguay,QF
+Morocco,G
+Iran,G
+Portugal,R16
+Spain,R16
+France,W
+Australia,G
+Peru,G
+Denmark,R16
+Argentina,R16
+Iceland,G
+Croatia,RU
+Nigeria,G
+Costa Rica,G
+Serbia,G
+Brazil,QF
+Switzerland,R16
+Germany,G
+Mexico,R16
+Sweden,QF
+South Korea,G
+Belgium,SF
+Panama,G
+England,SF
+Tunisia,G
+Colombia,R16
+Japan,R16
+Poland,G
+Senegal,G

--- a/wcpredictor/scripts/run_simulations.py
+++ b/wcpredictor/scripts/run_simulations.py
@@ -37,18 +37,33 @@ def get_cmd_line_args():
     parser.add_argument("--only_wc_teams",
                         help="If set, only fits model to teams playing in the World Cup",
                         action="store_true")
-    parser.add_argument("--use_ratings",
-                        help="If set, model is fitted using the Fifa rankings of each team",
+    parser.add_argument("--dont_use_ratings",
+                        help="If set, model is fitted without using the Fifa rankings of each team",
                         action="store_true")
+    parser.add_argument("--include_competitions",
+                        help="comma-separated list of competitions to include in training data",
+                        default="W,C1,WQ,CQ,C2,F")
+    parser.add_argument("--exclude_competitions",
+                        help="comma-separated list of competitions to exclude from training data")
+
     args = parser.parse_args()
     return args
 
 def main():
     args = get_cmd_line_args()
+    # use the fifa ratings as priors?
+    use_ratings = False if args.dont_use_ratings else True
+    # list of competitions to include
+    comps = args.include_competitions.split(",")
+    if args.exclude_competitions:
+        exclude_comps = args.exclude_competitions.split(",")
+        for comp in exclude_comps:
+            comps.remove(comp)
     model = get_and_train_model(only_wc_teams = args.only_wc_teams,
-                                use_ratings = args.use_ratings,
+                                use_ratings = use_ratings,
                                 start_date = args.training_data_start,
-                                end_date = args.training_data_end)
+                                end_date = args.training_data_end,
+                                competitions = comps)
     teams_df = get_teams_data(args.tournament_year)
     teams = list(teams_df.Team.values)
     team_results = {

--- a/wcpredictor/scripts/run_simulations.py
+++ b/wcpredictor/scripts/run_simulations.py
@@ -4,12 +4,16 @@ from re import U
 import pandas as pd
 import argparse
 
-from wcpredictor  import get_teams_data
-from wcpredictor  import Tournament
-from wcpredictor  import get_and_train_model
+from wcpredictor  import (
+    get_teams_data,
+    get_wcresults_data,
+    Tournament,
+    get_and_train_model,
+    get_difference_in_stages
+)
 
 
-def main():
+def get_cmd_line_args():
     parser = argparse.ArgumentParser("Simulate multiple World Cups")
     parser.add_argument("--num_simulations",
                         help="How many simulations to run",
@@ -27,6 +31,9 @@ def main():
     parser.add_argument("--output_csv",
                         help="Path to output CSV file",
                         default="sim_results.csv")
+    parser.add_argument("--output_loss_txt",
+                        help="Path to output txt file of loss function vals",
+                        default="sim_results_loss.txt")
     parser.add_argument("--only_wc_teams",
                         help="If set, only fits model to teams playing in the World Cup",
                         action="store_true")
@@ -34,6 +41,10 @@ def main():
                         help="If set, model is fitted using the Fifa rankings of each team",
                         action="store_true")
     args = parser.parse_args()
+    return args
+
+def main():
+    args = get_cmd_line_args()
     model = get_and_train_model(only_wc_teams = args.only_wc_teams,
                                 use_ratings = args.use_ratings,
                                 start_date = args.training_data_start,
@@ -50,16 +61,32 @@ def main():
             "W": 0
         } for team in teams
     }
+    wcresults_df = None
+    loss_values = []
+    if args.tournament_year != "2022":
+        wcresults_df = get_wcresults_data(args.tournament_year)
     for _ in range(args.num_simulations):
         t = Tournament(args.tournament_year)
         t.play_group_stage(model)
         t.play_knockout_stages(model)
+        total_loss = 0
         for team in teams:
             result = t.get_furthest_position_for_team(team)
             team_results[team][result] += 1
+            if args.tournament_year != "2022":
+                actual_result = wcresults_df.loc[
+                    wcresults_df.Team == team].Stage.values[0]
+                loss = get_difference_in_stages(result, actual_result)
+                total_loss += loss
+        loss_values.append(total_loss)
     team_records = [{"team": k, **v} for k,v in team_results.items()]
     df = pd.DataFrame(team_records)
     df.to_csv(args.output_csv)
+    # output txt file containing loss function values
+    if args.tournament_year != "2022":
+        with open(args.output_loss_txt, "w") as outfile:
+            for val in loss_values:
+                outfile.write(f"{val}\n")
 
 
 if __name__ == "__main__":

--- a/wcpredictor/src/data_loader.py
+++ b/wcpredictor/src/data_loader.py
@@ -1,5 +1,7 @@
 import os
+import json
 import pandas as pd
+from typing import Optional, Union, List, Tuple, Dict
 
 def get_teams_data(year: str = "2022") -> pd.DataFrame:
     if year not in ["2014","2018","2022"]:
@@ -34,21 +36,47 @@ def get_fifa_rankings_data() -> pd.DataFrame:
 
 def get_results_data(
         start_date: str = "2018-06-01",
-        end_date: str = "2022-11-20") -> pd.DataFrame:
+        end_date: str = "2022-11-20",
+        competitions:List[str] = ["W","C1","WQ","CQ","C2","F"]
+) -> pd.DataFrame:
+    """
+    filter the results dataframe by date and competition.
+    Key for competitions:
+    "W": world cup finals,
+    "C1": top-level continental cup,
+    "WQ": world cup qualifiers",
+    "CQ": continental cup qualifiers"
+    "C2": 2nd-tier continental, e.g. UEFA Nations League,
+    "F": friendly/other.
+    """
     current_dir = os.path.dirname(__file__)
     csv_path = os.path.join(
         current_dir, "..","data",
         "results.csv"
     )
     results_df = pd.read_csv(csv_path,parse_dates=['date'])
+    # get an index of what competition is in what category
+    json_path = os.path.join(
+        current_dir, "..","data",
+        "competition_index.json"
+    )
+    competitions_index = json.load(open(json_path))
     # filter by date
     results_df = results_df[(results_df.date > start_date) &
                             (results_df.date < end_date)]
+    # replace any names that we have written differently elsewhere
+    results_df.replace("United States", "USA", inplace=True)
     # filter matches with non-fifa recognised teams
     rankings_df = get_fifa_rankings_data()
     fifa_teams = (rankings_df.Team.values)
     results_df = results_df[(results_df.home_team.isin(fifa_teams)) &
                             (results_df.away_team.isin(fifa_teams))]
+    # filter by competition
+    comp_filter = [competitions_index[comp] for comp in competitions]
+    # flatten this nested list
+    comp_filter = [comp for complist in comp_filter for comp in complist]
+    results_df = results_df[results_df.tournament.isin(comp_filter)]
+
     results_df.reset_index(drop=True)
     return results_df
 

--- a/wcpredictor/src/data_loader.py
+++ b/wcpredictor/src/data_loader.py
@@ -51,3 +51,13 @@ def get_results_data(
                             (results_df.away_team.isin(fifa_teams))]
     results_df.reset_index(drop=True)
     return results_df
+
+
+def get_wcresults_data(year: str) -> pd.DataFrame:
+    current_dir = os.path.dirname(__file__)
+    csv_path = os.path.join(
+        current_dir, "..","data",
+        f"wcresults_{year}.csv"
+    )
+    wcresults_df = pd.read_csv(csv_path)
+    return wcresults_df

--- a/wcpredictor/src/utils.py
+++ b/wcpredictor/src/utils.py
@@ -122,3 +122,24 @@ def predict_group_match(wc_pred: WCPred,
         fixture_teams = [(team_1, team_2)],
         seed = seed
     )[1][0]
+
+
+def get_difference_in_stages(stage_1:str, stage_2:str) -> int:
+    """
+    Give an integer value to the differences between two
+    'stages' i.e. how far a team got in the tournament.
+    This can be used to calculate a loss function, i.e. difference
+    between predicted and actual results for past tournaments.
+
+    Parameters
+    ==========
+    stage_1, stage_2: both str, can be "G","R16","QF","SF","RU","W"
+
+    Returns
+    =======
+    diff: int, how far apart the two stages are.
+    """
+    stages = ["G","R16","QF","SF","RU","W"]
+    if not stage_1 in stages and stage_2 in stages:
+        raise RuntimeError(f"Unknown value for stage - must be in {stages}")
+    return abs(stages.index(stage_1) - stages.index(stage_2))

--- a/wcpredictor/src/utils.py
+++ b/wcpredictor/src/utils.py
@@ -14,9 +14,21 @@ from .bpl_interface import WCPred
 def get_and_train_model(only_wc_teams: bool = True,
                         use_ratings: bool = True,
                         start_date: str = "2018-06-01",
-                        end_date: str = "2022-11-20"
+                        end_date: str = "2022-11-20",
+                        competitions: List[str] = ["W","C1","WQ","CQ","C2","F"]
                         ) -> WCPred:
-    results = get_results_data(start_date, end_date)
+    """
+    Use 'competitions' argument to specify which rows to include in training data.
+    Key for competitions:
+    "W": world cup finals,
+    "C1": top-level continental cup,
+    "WQ": world cup qualifiers",
+    "CQ": continental cup qualifiers"
+    "C2": 2nd-tier continental, e.g. UEFA Nations League,
+    "F": friendly/other.
+    """
+    results = get_results_data(start_date, end_date, competitions=competitions)
+    print(f"Using {len(results)} rows in training data")
     # if we are getting results up to 2018, maybe we are simulating
     # the 2018 world cup?
     if "2018" in end_date:


### PR DESCRIPTION
* Add "loss-function" calculation so we can see how well we did in predicting 2014 and 2018 world cups.
* Add filter on competitions - default is to include all, but can specify in `wcpred_run_simulations` either an `--include_competitions` or a `--exclude_competitions` to determine which of "W" (world cup), "WQ" (world cup qualifier), "C1" (top-level continental cup, e.g. Euros), "CQ" (qualification for e.g. Euros), "C2" (2nd tier European cup, e.g. Nations League), "F" (friendly, or anything else),  get included in training data
* Updated `results.csv` to include recent world cup qualifiers (also involves renaming "USA" -> "United States" - this is rectified in `get_results_data` in `data_loader.py`).