### PR TITLE
Feature/fifa game rankings

### DIFF
--- a/wcpredictor/__init__.py
+++ b/wcpredictor/__init__.py
@@ -4,7 +4,8 @@ from .src.data_loader import (
     get_fixture_data,
     get_results_data,
     get_fifa_rankings_data,
-    get_wcresults_data
+    get_wcresults_data,
+    get_confederations_data
 )
 from .src.tournament import Tournament, Group
 from .src.utils import (

--- a/wcpredictor/data/confederations.csv
+++ b/wcpredictor/data/confederations.csv
@@ -99,7 +99,7 @@ Sudan,CAF
 Togo,CAF
 Mozambique,CAF
 Zambia,CAF
-Morocco,CAV
+Morocco,CAF
 Bahamas,CONCACAF
 Belize,CONCACAF
 Aruba,CONCACAF

--- a/wcpredictor/data/fifa_game_rankings.csv
+++ b/wcpredictor/data/fifa_game_rankings.csv
@@ -45,4 +45,4 @@ Finland,70,72,67,70
 Iceland,68,69,67,69
 Northern Ireland,66,70,72,69
 New Zealand,70,67,68,68
-China,68,68,67,68
+China PR,68,68,67,68

--- a/wcpredictor/scripts/run_simulations.py
+++ b/wcpredictor/scripts/run_simulations.py
@@ -34,12 +34,13 @@ def get_cmd_line_args():
     parser.add_argument("--output_loss_txt",
                         help="Path to output txt file of loss function vals",
                         default="sim_results_loss.txt")
-    parser.add_argument("--only_wc_teams",
-                        help="If set, only fits model to teams playing in the World Cup",
-                        action="store_true")
     parser.add_argument("--dont_use_ratings",
                         help="If set, model is fitted without using the Fifa rankings of each team",
                         action="store_true")
+    parser.add_argument("--ratings_source",
+                        choices=["game","org"],
+                        default="game",
+                        help="if 'game' use FIFA video game ratings for prior, if 'org', use FIFA organization ratings")
     parser.add_argument("--include_competitions",
                         help="comma-separated list of competitions to include in training data",
                         default="W,C1,WQ,CQ,C2,F")
@@ -52,18 +53,17 @@ def get_cmd_line_args():
 def main():
     args = get_cmd_line_args()
     # use the fifa ratings as priors?
-    use_ratings = False if args.dont_use_ratings else True
+    ratings_src = None if args.dont_use_ratings else args.ratings_source
     # list of competitions to include
     comps = args.include_competitions.split(",")
     if args.exclude_competitions:
         exclude_comps = args.exclude_competitions.split(",")
         for comp in exclude_comps:
             comps.remove(comp)
-    model = get_and_train_model(only_wc_teams = args.only_wc_teams,
-                                use_ratings = use_ratings,
-                                start_date = args.training_data_start,
+    model = get_and_train_model(start_date = args.training_data_start,
                                 end_date = args.training_data_end,
-                                competitions = comps)
+                                competitions = comps,
+                                rankings_source=ratings_src)
     teams_df = get_teams_data(args.tournament_year)
     teams = list(teams_df.Team.values)
     team_results = {

--- a/wcpredictor/scripts/run_simulations.py
+++ b/wcpredictor/scripts/run_simulations.py
@@ -23,11 +23,14 @@ def get_cmd_line_args():
                         choices={"2014","2018","2022"},
                         default="2022")
     parser.add_argument("--training_data_start",
-                        help="earliest date for training data",
-                        default="2018-06-30")
+                        help="earliest date for training data")
     parser.add_argument("--training_data_end",
-                        help="latest date for training data",
-                        default="2022-11-20")
+                        help="latest date for training data")
+    parser.add_argument("--years_training_data",
+                        help="how many years of training data, before tournament start",
+                        type=int,
+                        default=6
+                        )
     parser.add_argument("--output_csv",
                         help="Path to output CSV file",
                         default="sim_results.csv")
@@ -50,6 +53,29 @@ def get_cmd_line_args():
     args = parser.parse_args()
     return args
 
+
+def get_start_end_dates(args):
+    """
+    Based on the command line args, define what period of training data to use.
+    """
+    if args.training_data_start:
+        start_date = args.training_data_start
+    else:
+        start_year = int(args.tournament_year) - args.years_training_data
+        # always start at 1st June, to capture the summer tournament
+        start_date = f"{start_year}-06-01"
+    if args.training_data_end:
+        end_date = args.training_data_end
+    else:
+        end_year = int(args.tournament_year)
+        # end at 1st June if tournament year is 2014 or 2018, or 1st Nov for 2022
+        if args.tournament_year == "2022":
+            end_date = "2022-11-01"
+        else:
+            end_date = f"{args.tournament_year}-06-01"
+    print(f"Start/End dates for training data are {start_date}, {end_date}")
+    return start_date, end_date
+
 def main():
     args = get_cmd_line_args()
     # use the fifa ratings as priors?
@@ -60,8 +86,9 @@ def main():
         exclude_comps = args.exclude_competitions.split(",")
         for comp in exclude_comps:
             comps.remove(comp)
-    model = get_and_train_model(start_date = args.training_data_start,
-                                end_date = args.training_data_end,
+    start_date, end_date = get_start_end_dates(args)
+    model = get_and_train_model(start_date = start_date,
+                                end_date = end_date,
                                 competitions = comps,
                                 rankings_source=ratings_src)
     teams_df = get_teams_data(args.tournament_year)

--- a/wcpredictor/src/data_loader.py
+++ b/wcpredictor/src/data_loader.py
@@ -25,13 +25,59 @@ def get_fixture_data(year: str = "2022") -> pd.DataFrame:
     return pd.read_csv(csv_path)
 
 
-def get_fifa_rankings_data() -> pd.DataFrame:
+def get_confederations_data() -> pd.DataFrame:
+    """
+    Which teams belong to which federations
+    """
     current_dir = os.path.dirname(__file__)
+    filename = "confederations.csv"
     csv_path = os.path.join(
         current_dir, "..","data",
-        "fifa_rankings.csv"
+        filename
     )
-    return pd.read_csv(csv_path)
+    df =  pd.read_csv(csv_path)
+    return df
+
+
+def get_fifa_rankings_data(source: str = "game") -> pd.DataFrame:
+    """
+    Get the FIFA rankings, either from FIFA (the organisation), if source != 'game'
+    or from the FIFA video game (with default values for teams not in the game)
+    if source == 'game'
+    """
+    # should we use the videogame rankings over the official FIFA (organisation) ones?
+    game_rankings = source == "game"
+    current_dir = os.path.dirname(__file__)
+    filename = "fifa_game_rankings.csv" if game_rankings else "fifa_rankings.csv"
+    csv_path = os.path.join(
+        current_dir, "..","data",
+        filename
+    )
+    df =  pd.read_csv(csv_path)
+    if game_rankings:
+        print("Using FIFA videogame rankings")
+        # assign default values to teams not otherwise covered, use the same as Qatar
+        default_row = df.loc[df.Team=="Qatar"]
+        all_teams = get_confederations_data().Team.unique()
+        current_teams = df.Team.unique()
+        new_teams = list(set(all_teams) - set(current_teams))
+        attacks = len(new_teams)*[default_row.Attack.values[0]]
+        midfields = len(new_teams)*[default_row.Midfield.values[0]]
+        defences = len(new_teams)*[default_row.Defence.values[0]]
+        overalls = len(new_teams)*[default_row.Overall.values[0]]
+        new_df = pd.DataFrame(
+            {"Team":new_teams,
+             "Attack": attacks,
+             "Midfield": midfields,
+             "Defence": defences,
+             "Overall": overalls}
+        )
+        df = pd.concat([df, new_df])
+        df = df.reset_index(drop=True)
+    else:
+        print("Using FIFA organisation rankings")
+    return df
+
 
 
 def get_results_data(
@@ -67,7 +113,7 @@ def get_results_data(
     # replace any names that we have written differently elsewhere
     results_df.replace("United States", "USA", inplace=True)
     # filter matches with non-fifa recognised teams
-    rankings_df = get_fifa_rankings_data()
+    rankings_df = get_fifa_rankings_data("org")
     fifa_teams = (rankings_df.Team.values)
     results_df = results_df[(results_df.home_team.isin(fifa_teams)) &
                             (results_df.away_team.isin(fifa_teams))]
@@ -77,7 +123,7 @@ def get_results_data(
     comp_filter = [comp for complist in comp_filter for comp in complist]
     results_df = results_df[results_df.tournament.isin(comp_filter)]
 
-    results_df.reset_index(drop=True)
+    results_df = results_df.reset_index(drop=True)
     return results_df
 
 

--- a/wcpredictor/src/utils.py
+++ b/wcpredictor/src/utils.py
@@ -11,11 +11,10 @@ from .data_loader import (
 from .bpl_interface import WCPred
 
 
-def get_and_train_model(only_wc_teams: bool = True,
-                        use_ratings: bool = True,
-                        start_date: str = "2018-06-01",
+def get_and_train_model(start_date: str = "2018-06-01",
                         end_date: str = "2022-11-20",
-                        competitions: List[str] = ["W","C1","WQ","CQ","C2","F"]
+                        competitions: List[str] = ["W","C1","WQ","CQ","C2","F"],
+                        rankings_source: str = "game",
                         ) -> WCPred:
     """
     Use 'competitions' argument to specify which rows to include in training data.
@@ -26,7 +25,11 @@ def get_and_train_model(only_wc_teams: bool = True,
     "CQ": continental cup qualifiers"
     "C2": 2nd-tier continental, e.g. UEFA Nations League,
     "F": friendly/other.
+
+    rankings_source determines whether we use the FIFA video game rankings for prior values
+    for the covariates ("game"), or use the FIFA organisation ones ("org"), or neither (None).
     """
+    print("in get_and_train_model")
     results = get_results_data(start_date, end_date, competitions=competitions)
     print(f"Using {len(results)} rows in training data")
     # if we are getting results up to 2018, maybe we are simulating
@@ -39,14 +42,11 @@ def get_and_train_model(only_wc_teams: bool = True,
     else:
         tournament_year = "2022"
     teams = list(get_teams_data(tournament_year).Team)
-    ratings = get_fifa_rankings_data()
-    if (only_wc_teams and use_ratings):
+
+    if rankings_source:
+        ratings = get_fifa_rankings_data(rankings_source)
         wc_pred = WCPred(results=results,
-                        teams=teams,
                         ratings=ratings)
-    elif only_wc_teams and not use_ratings:
-        wc_pred = WCPred(results=results,
-                        teams=teams)
     else:
         wc_pred = WCPred(results=results)
     wc_pred.set_training_data()


### PR DESCRIPTION
Make the default option to use the FIFA video game rankings as input to priors, with teams not included in the game given the same ratings as Qatar (the lowest ranked team in the WC).  This is now configurable via `rankings_source` argument in `get_and_train_model`, which can be either "game", "org", or None.
* Also fixed typo in confederation for Morocco in `confederations.csv`
* Fixed name of China in `fifa_game_rankings.csv
* Added `get_confederations_data` function to `data_loader.py`
* Removed `wc_teams_only` option from command-line and from `get_and_train_model`.